### PR TITLE
Fix select() example

### DIFF
--- a/sotodlib/hardware/config.py
+++ b/sotodlib/hardware/config.py
@@ -151,10 +151,10 @@ class Hardware(object):
             26 which have "A" polarization and are located in pixels 20-29
             (recall the "." matches a single character)::
 
-                new = hw.select({"wafer": ["25", "26"],
-                                 "band": "MF.1",
-                                 "pol": "A",
-                                 "pixel": "02."})
+                new = hw.select(match={"wafer": ["25", "26"],
+                                "band": "MF.1",
+                                "pol": "A",
+                                "pixel": "02."})
 
         Args:
             telescopes (str): A regex string to apply to telescope names or a


### PR DESCRIPTION
This pull request adds a necessary keyword to the select() method example. It also formats config.py with black.