### PR TITLE
Per wafer datadump

### DIFF
--- a/pipelines/toast_so_example.py
+++ b/pipelines/toast_so_example.py
@@ -4,6 +4,7 @@
 # Full license can be found in the top level "LICENSE" file.
 
 import os
+import sys
 
 import numpy as np
 
@@ -138,13 +139,21 @@ hw.data["detectors"] = dets
 
 if comm.world_rank == 0:
     print("Selecting detectors...", flush=True)
-# Dowselect to just 10 pixels on one wafer
-small_hw = hw.select(match={"wafer": "41", "pixel": "00."})
+# Downselect to just 10 pixels on one wafer
+#small_hw = hw.select(match={"wafer": "41", "pixel": "00."})
+#small_hw = hw.select(match={"wafer": "41"})
+small_hw = hw.select(match={"wafer": "40"})
+#small_hw = hw.select(match={"band": "LF1"})
 if comm.world_rank == 0:
     small_hw.dump("selected.toml", overwrite=True)
 
 # The data directory (this is a single band)
-dir = "/project/projectdirs/sobs/sims/pipe-s0001/datadump_LAT_LF1"
+# dir = "/project/projectdirs/sobs/sims/pipe-s0001/datadump_LAT_LF1"
+if len(sys.argv) > 1:
+    dir = sys.argv[1]
+    print("Loading data from {}".format(dir), flush=True)
+else:
+    dir = "datadump_LAT_LF1"
 # dir = "/home/kisner/scratch/sobs/pipe/datadump_LAT_LF1"
 
 # Here we divide the data for each observation into a process grid.

--- a/pipelines/toast_so_sim.py
+++ b/pipelines/toast_so_sim.py
@@ -678,6 +678,13 @@ def parse_arguments(comm):
         "--export_key", required=False, default=None,
         help="Group exported TOD by a detector trait: wafer, card, crate or tube",
     )
+    parser.add_argument(
+        "--export_compress",
+        required=False,
+        default=False,
+        action="store_true",
+        help="Re-digitize and compress the exported signal.",
+    )
 
     #try:
     args = parser.parse_args()
@@ -2088,6 +2095,7 @@ def export_TOD(args, comm, data, totalname, focalplanes, other=None):
         filesize=2**30,
         units=core3g.G3TimestreamUnits.Tcmb,
         detgroups=detgroups,
+        compress=args.export_compress,
     )
     export.exec(data)
     if comm.comm_world is not None:

--- a/pipelines/toast_so_sim.py
+++ b/pipelines/toast_so_sim.py
@@ -674,6 +674,10 @@ def parse_arguments(comm):
     parser.add_argument(
         "--export", required=False, default=None, help="Output TOD export path"
     )
+    parser.add_argument(
+        "--export_key", required=False, default=None,
+        help="Group exported TOD by a detector trait: wafer, card, crate or tube",
+    )
 
     #try:
     args = parser.parse_args()
@@ -697,8 +701,8 @@ def parse_arguments(comm):
 
     if comm.world_rank == 0:
         print("\nAll parameters:")
-        print(args, flush=args.flush)
-        print("")
+        print(args)
+        print("", flush=True)
 
     if args.groupsize:
         comm = toast.Comm(groupsize=args.groupsize)
@@ -1031,14 +1035,14 @@ def load_focalplanes(args, comm, schedules):
                     # Only accept a fraction of the detectors for
                     # testing and development
                     continue
-                focalplane[detname] = {
+                focalplane[detname] = detdata.copy()
+                focalplane[detname].update({
                     "NET": net,
                     "fknee": fknee,
                     "fmin": fmin,
                     "alpha": alpha,
                     "A": A,
                     "C": C,
-                    "quat": detdata["quat"],
                     "FWHM": detdata["fwhm"],
                     "freq": center,
                     "bandcenter_ghz": center,
@@ -1046,9 +1050,8 @@ def load_focalplanes(args, comm, schedules):
                     "index": index,
                     "telescope": telescope,
                     "tube": tube,
-                    "wafer": wafer,
                     "band": band,
-                }
+                })
             focalplanes.append(focalplane)
             timer1.stop()
             timer1.report(
@@ -1081,7 +1084,7 @@ def load_focalplanes(args, comm, schedules):
     timer.stop()
     if comm.world_rank == 0:
         timer.report("Loading focalplane(s)")
-    return detweights
+    return detweights, focalplanes
 
 
 @function_timer
@@ -2045,7 +2048,7 @@ def output_tidas(args, comm, data, totalname):
 
 
 @function_timer
-def export_TOD(args, comm, data, totalname, other=None):
+def export_TOD(args, comm, data, totalname, focalplanes, other=None):
     if args.export is None:
         return
 
@@ -2058,18 +2061,33 @@ def export_TOD(args, comm, data, totalname, other=None):
 
     path = os.path.abspath(args.export)
 
+    key = args.export_key
+    if key is not None:
+        prefix = "{}_{}".format(args.bands, key)
+        detgroups = {}
+        for fp in focalplanes:
+            for det, detdata in fp.items():
+                value = detdata[key]
+                if value not in detgroups:
+                    detgroups[value] = []
+                detgroups[value].append(det)
+    else:
+        prefix = args.bands
+        detgroups = None
+
     if comm.world_rank == 0:
         log.info("Exporting data to directory tree at {}".format(path))
     timer.start()
     export = ToastExport(
         path,
-        prefix=args.bands,
+        prefix=prefix,
         use_intervals=True,
         cache_name=totalname,
         cache_copy=other,
         mask_flag_common=data.obs[0]['tod'].TURNAROUND,
         filesize=2**30,
         units=core3g.G3TimestreamUnits.Tcmb,
+        detgroups=detgroups,
     )
     export.exec(data)
     if comm.comm_world is not None:
@@ -2289,9 +2307,9 @@ def main():
 
     load_weather(args, comm, schedules)
 
-    # load or simulate the focalplane
+    # load or simulate the focalplane and pair it with each schedule
 
-    detweights = load_focalplanes(args, comm, schedules)
+    detweights, focalplanes = load_focalplanes(args, comm, schedules)
 
     # Create the TOAST data object to match the schedule.  This will
     # include simulating the boresight pointing.
@@ -2386,7 +2404,7 @@ def main():
             # export the timestream data.
             output_tidas(args, comm, data, totalname)
             #export_TOD(args, comm, data, totalname, other=[signalname])
-            export_TOD(args, comm, data, totalname)
+            export_TOD(args, comm, data, totalname, focalplanes)
 
             memreport(comm.comm_world, "after export")
 

--- a/sotodlib/data/toast_export.py
+++ b/sotodlib/data/toast_export.py
@@ -58,8 +58,9 @@ class ToastExport(toast.Operator):
         detgroups (dict):  Dictionary of groups to arrange the detectors into.
             Each key is a name of the group and each value is a list of
             detector names
-        compress (bool):  Store the timestreams as FLAC-compressed, 24-bit
-            integers instead of uncompressed doubles.
+        compress (bool or dict):  If True or a dictionary of compression parameters,
+            store the timestreams as FLAC-compressed, 24-bit integers instead of
+            uncompressed doubles.
         verbose (bool):  Verbose reporting
 
     """

--- a/sotodlib/data/toast_export.py
+++ b/sotodlib/data/toast_export.py
@@ -60,6 +60,7 @@ class ToastExport(toast.Operator):
             detector names
         compress (bool):  Store the timestreams as FLAC-compressed, 24-bit
             integers instead of uncompressed doubles.
+        verbose (bool):  Verbose reporting
 
     """
     def __init__(self, outdir, prefix="so", use_todchunks=False,
@@ -67,7 +68,7 @@ class ToastExport(toast.Operator):
                  cache_flag_name=None, cache_copy=None, mask_flag_common=255,
                  mask_flag=255, filesize=500000000, units=None,
                  detgroups=None,
-                 compress=False,
+                 compress=False, verbose=True,
     ):
         self._outdir = outdir
         self._prefix = prefix
@@ -85,6 +86,7 @@ class ToastExport(toast.Operator):
         self._units = units
         self._detgroups = detgroups
         self._compress = compress
+        self._verbose = verbose
         # We call the parent class constructor
         super().__init__()
 
@@ -238,7 +240,7 @@ class ToastExport(toast.Operator):
                     copy_flavors.append(
                         (flv, flavor_type[flv], flavor_maptype[flv],
                          "signal_{}".format(flv)))
-            if grouprank == 0 and len(copy_flavors) > 0:
+            if grouprank == 0 and len(copy_flavors) > 0 and self._verbose:
                 print("Found {} extra TOD flavors: {}".format(
                     len(copy_flavors), copy_flavors), flush=True)
 
@@ -376,7 +378,7 @@ class ToastExport(toast.Operator):
                            for f in range(nframes)]
             frm_sizes = [framesizes[foff + f] for f in range(nframes)]
 
-            if grouprank == 0:
+            if grouprank == 0 and self._verbose:
                 print("  {} file {} detector group {}".format(
                     obsdir, ifile, detgroup), flush=True)
                 print("    start frame = {}, nframes = {}"

--- a/sotodlib/data/toast_export.py
+++ b/sotodlib/data/toast_export.py
@@ -58,10 +58,8 @@ class ToastExport(toast.Operator):
         detgroups (dict):  Dictionary of groups to arrange the detectors into.
             Each key is a name of the group and each value is a list of
             detector names
-        gain_compressor (float):  Extra gain to apply to the signal before
-            encoding in 24-bit integers.  Only applied when compress=True.
         compress (bool):  Store the timestreams as FLAC-compressed, 24-bit
-            integers instead of uncompressed doubles.  See `gain_compressor`.
+            integers instead of uncompressed doubles.
 
     """
     def __init__(self, outdir, prefix="so", use_todchunks=False,
@@ -69,7 +67,6 @@ class ToastExport(toast.Operator):
                  cache_flag_name=None, cache_copy=None, mask_flag_common=255,
                  mask_flag=255, filesize=500000000, units=None,
                  detgroups=None,
-                 gain_compressor=30000,
                  compress=False,
     ):
         self._outdir = outdir
@@ -87,7 +84,6 @@ class ToastExport(toast.Operator):
         self._target_framefile = filesize
         self._units = units
         self._detgroups = detgroups
-        self._gain_compressor = gain_compressor
         self._compress = compress
         # We call the parent class constructor
         super().__init__()
@@ -227,9 +223,9 @@ class ToastExport(toast.Operator):
                             flavor_maptype[pref] = so3g.MapIntervalsInt
         # If the main signals and flags are coming from the cache, remove
         # them from consideration here.
-        if self._cache_name is None:  # FIXME: isn't this test inverted?
+        if self._cache_name is not None:
             flavors.discard(self._cache_name)
-        if self._cache_flag_name is None:  # FIXME: isn't this test inverted?
+        if self._cache_flag_name is not None:
             flavors.discard(self._cache_flag_name)
 
         # Restrict this list of available flavors to just those that
@@ -363,7 +359,7 @@ class ToastExport(toast.Operator):
                 nframes = len(framesizes) - foff
             else:
                 # get number of frames in this file
-                nframes = file_frame_offs[ifile+1] - foff
+                nframes = file_frame_offs[ifile + 1] - foff
 
             writer = None
             if grouprank == 0:
@@ -376,9 +372,9 @@ class ToastExport(toast.Operator):
 
             # Collect data for all frames in the file in one go.
 
-            frm_offsets = [frame_sample_offs[foff+f]
+            frm_offsets = [frame_sample_offs[foff + f]
                            for f in range(nframes)]
-            frm_sizes = [framesizes[foff+f] for f in range(nframes)]
+            frm_sizes = [framesizes[foff + f] for f in range(nframes)]
 
             if grouprank == 0:
                 print("  {} file {} detector group {}".format(
@@ -399,7 +395,6 @@ class ToastExport(toast.Operator):
                 dets=detnames,
                 mask_flag_common=self._mask_flag_common,
                 mask_flag=self._mask_flag,
-                gain_compressor=self._gain_compressor,
                 compress=self._compress,
             )
 
@@ -451,7 +446,8 @@ class ToastExport(toast.Operator):
             else:
                 keep_offsets = False
                 for detgroup, detectors in self._detgroups.items():
-                    self._export_observation(obs, cgroup, detgroup, detectors, keep_offsets)
+                    self._export_observation(obs, cgroup, detgroup, detectors,
+                                             keep_offsets)
                     keep_offsets = True
 
         return

--- a/sotodlib/data/toast_export.py
+++ b/sotodlib/data/toast_export.py
@@ -389,6 +389,8 @@ class ToastExport(toast.Operator):
                 copy_detector=copy_flavors,
                 units=self._units,
                 dets=detnames,
+                mask_flag_common=self._mask_flag_common,
+                mask_flag=self._mask_flag,
             )
 
             if grouprank == 0:

--- a/sotodlib/data/toast_export.py
+++ b/sotodlib/data/toast_export.py
@@ -55,12 +55,17 @@ class ToastExport(toast.Operator):
         filesize (int):  The approximate file size of each frame file in
             bytes.
         units (G3TimestreamUnits):  The units of the detector data.
+        detgroups (dict):  Dictionary of groups to arrange the detectors into.
+            Each key is a name of the group and each value is a list of
+            detector names
 
     """
     def __init__(self, outdir, prefix="so", use_todchunks=False,
                  use_intervals=False, cache_name=None, cache_common=None,
                  cache_flag_name=None, cache_copy=None, mask_flag_common=255,
-                 mask_flag=255, filesize=500000000, units=None):
+                 mask_flag=255, filesize=500000000, units=None,
+                 detgroups=None,
+    ):
         self._outdir = outdir
         self._prefix = prefix
         self._cache_common = cache_common
@@ -75,6 +80,7 @@ class ToastExport(toast.Operator):
         self._useintervals = use_intervals
         self._target_framefile = filesize
         self._units = units
+        self._detgroups = detgroups
         # We call the parent class constructor
         super().__init__()
 
@@ -163,6 +169,207 @@ class ToastExport(toast.Operator):
         persample = 8 + 1 + 32 + 48 + 24 + 24 + 8 * ndet * nflavor
         return persample
 
+    def _export_observation(self, obs, cgroup,
+                            detgroup=None, detectors=None):
+        """ Export observation in one or more frame files
+        """
+
+        grouprank = 0
+        if cgroup is not None:
+            grouprank = cgroup.rank
+
+        # Observation information.  Anything here that is a simple data
+        # type will get written to the observation frame.
+        props = dict()
+        for k, v in obs.items():
+            if isinstance(v, (int, str, bool, float)):
+                props[k] = v
+
+        # Every observation must have a name...
+        obsname = obs["name"]
+
+        # The TOD
+        tod = obs["tod"]
+        nsamp = tod.total_samples
+        if detectors is None:
+            detquat = tod.detoffset()
+            detindx = tod.detindx
+            detnames = tod.detectors
+        else:
+            detquat_temp = tod.detoffset()
+            detindx_temp = tod.detindx
+            detquat = {}
+            detindx = {}
+            detnames = []
+            toddets = set(tod.detectors)
+            for det in detectors:
+                if det not in toddets:
+                    continue
+                detnames.append(det)
+                detquat[det] = detquat_temp[det]
+                detindx[det] = detindx_temp[det]
+        ndets = len(detquat)
+
+        # Get any other metadata from the TOD
+        props.update(tod.meta)
+
+        # First process in the group makes the output directory
+        obsdir = os.path.join(self._outdir, obsname)
+        if cgroup.rank == 0:
+            if not os.path.isdir(obsdir):
+                os.makedirs(obsdir)
+        cgroup.barrier()
+
+        detranks, sampranks = tod.grid_size
+
+        # Determine frame sizes based on the data distribution
+        framesizes = None
+        if self._usechunks:
+            framesizes = tod.total_chunks
+        elif self._useintervals:
+            if "intervals" not in obs:
+                raise RuntimeError(
+                    "Observation does not contain intervals, cannot \
+                    distribute using them")
+            framesizes = intervals_to_chunklist(obs["intervals"], nsamp)
+        if framesizes is None:
+            framesizes = [nsamp]
+
+        # Examine all the cache objects and find the set of prefixes
+        flavors = set()
+        flavor_type = dict()
+        flavor_maptype = dict()
+        pat = re.compile(r"^(.*?)_(.*)")
+        for nm in list(tod.cache.keys()):
+            mat = pat.match(nm)
+            if mat is not None:
+                pref = mat.group(1)
+                md = mat.group(2)
+                if md in detnames:
+                    # This cache field has the form <prefix>_<det>
+                    if pref not in flavor_type:
+                        ref = tod.cache.reference(nm)
+                        if ref.dtype == np.dtype(np.float64):
+                            flavors.add(pref)
+                            flavor_type[pref] = core3g.G3Timestream
+                            flavor_maptype[pref] = core3g.G3TimestreamMap
+                        elif ref.dtype == np.dtype(np.int32):
+                            flavors.add(pref)
+                            flavor_type[pref] = core3g.G3VectorInt
+                            flavor_maptype[pref] = core3g.G3MapVectorInt
+                        elif ref.dtype == np.dtype(np.uint8):
+                            flavors.add(pref)
+                            flavor_type[pref] = so3g.IntervalsInt
+                            flavor_maptype[pref] = so3g.MapIntervalsInt
+        # If the main signals and flags are coming from the cache, remove
+        # them from consideration here.
+        if self._cache_name is None:  # FIXME: isn't this test inverted?
+            flavors.discard(self._cache_name)
+        if self._cache_flag_name is None:  # FIXME: isn't this test inverted?
+            flavors.discard(self._cache_flag_name)
+
+        # Restrict this list of available flavors to just those that
+        # we want to export.
+        copy_flavors = []
+        if self._cache_copy is not None:
+            copy_flavors = list()
+            for flv in flavors:
+                if flv in self._cache_copy:
+                    copy_flavors.append(
+                        (flv, flavor_type[flv], flavor_maptype[flv],
+                         "signal_{}".format(flv)))
+            if grouprank == 0 and len(copy_flavors) > 0:
+                print("Found {} extra TOD flavors: {}".format(
+                    len(copy_flavors), copy_flavors), flush=True)
+
+        # Given the dimensions of this observation, compute the frame
+        # file sizes and all relevant offsets.
+
+        frame_sample_offs = None
+        file_sample_offs = None
+        file_frame_offs = None
+        if grouprank == 0:
+            # Compute the frame file breaks.  We ignore the observation
+            # and calibration frames since they are small.
+            sampbytes = self._bytes_per_sample(len(detquat),
+                                               len(copy_flavors) + 1)
+
+            file_sample_offs, file_frame_offs, frame_sample_offs = \
+                s3utils.compute_file_frames(
+                    sampbytes, framesizes,
+                    file_size=self._target_framefile)
+
+        if cgroup is not None:
+            file_sample_offs = cgroup.bcast(file_sample_offs, root=0)
+            file_frame_offs = cgroup.bcast(file_frame_offs, root=0)
+            frame_sample_offs = cgroup.bcast(frame_sample_offs, root=0)
+
+        if detgroup is None:
+            prefix = self._prefix
+        else:
+            prefix = "{}_{}".format(self._prefix, detgroup)
+        ex_files = [os.path.join(obsdir,
+                    "{}_{:08d}.g3".format(prefix, x))
+                    for x in file_sample_offs]
+
+        # Loop over each frame file.  Write the header frames and then
+        # gather the data from all processes before writing the scan
+        # frames.
+
+        for ifile, (ffile, foff) in enumerate(zip(ex_files,
+                                              file_frame_offs)):
+            nframes = None
+            # print("  ifile = {}, ffile = {}, foff = {}"
+            #       .format(ifile, ffile, foff), flush=True)
+            if ifile == len(ex_files) - 1:
+                # we are at the last file
+                nframes = len(framesizes) - foff
+            else:
+                # get number of frames in this file
+                nframes = file_frame_offs[ifile+1] - foff
+
+            writer = None
+            if grouprank == 0:
+                writer = core3g.G3Writer(ffile)
+                self._write_obs(writer, props, detindx)
+                if "noise" in obs:
+                    self._write_precal(writer, detquat, obs["noise"])
+                else:
+                    self._write_precal(writer, detquat, None)
+
+            # Collect data for all frames in the file in one go.
+
+            frm_offsets = [frame_sample_offs[foff+f]
+                           for f in range(nframes)]
+            frm_sizes = [framesizes[foff+f] for f in range(nframes)]
+
+            if grouprank == 0:
+                print("  {} file {} detector group {}".format(
+                    obsdir, ifile, detgroup), flush=True)
+                print("    start frame = {}, nframes = {}"
+                      .format(foff, nframes), flush=True)
+                print("    frame offs = ", frm_offsets, flush=True)
+                print("    frame sizes = ", frm_sizes, flush=True)
+
+            fdata = tod_to_frames(
+                tod, foff, nframes, frm_offsets, frm_sizes,
+                cache_signal=self._cache_name,
+                cache_flags=self._cache_flag_name,
+                cache_common_flags=self._cache_common,
+                copy_common=None,
+                copy_detector=copy_flavors,
+                units=self._units,
+                dets=detnames,
+            )
+
+            if grouprank == 0:
+                for fdt in fdata:
+                    writer(fdt)
+                del writer
+            del fdata
+
+        return
+
     def exec(self, data):
         """Export data to a directory tree of so3g frames.
 
@@ -189,10 +396,6 @@ class ToastExport(toast.Operator):
         if cworld is not None:
             worldrank = cworld.rank
 
-        grouprank = 0
-        if cgroup is not None:
-            grouprank = cgroup.rank
-
         # One process checks the path
         if worldrank == 0:
             if not os.path.isdir(self._outdir):
@@ -200,173 +403,12 @@ class ToastExport(toast.Operator):
         cworld.barrier()
 
         for obs in data.obs:
-            # Observation information.  Anything here that is a simple data
-            # type will get written to the observation frame.
-            props = dict()
-            for k, v in obs.items():
-                if isinstance(v, (int, str, bool, float)):
-                    props[k] = v
-
-            # Every observation must have a name...
-            obsname = obs["name"]
-
-            # The TOD
-            tod = obs["tod"]
-            nsamp = tod.total_samples
-            detquat = tod.detoffset()
-            detindx = tod.detindx
-            ndets = len(detquat)
-            detnames = tod.detectors
-
-            # Get any other metadata from the TOD
-            props.update(tod.meta)
-
-            # First process in the group makes the output directory
-            obsdir = os.path.join(self._outdir, obsname)
-            if cgroup.rank == 0:
-                if not os.path.isdir(obsdir):
-                    os.makedirs(obsdir)
-            cgroup.barrier()
-
-            detranks, sampranks = tod.grid_size
-
-            # Determine frame sizes based on the data distribution
-            framesizes = None
-            if self._usechunks:
-                framesizes = tod.total_chunks
-            elif self._useintervals:
-                if "intervals" not in obs:
-                    raise RuntimeError(
-                        "Observation does not contain intervals, cannot \
-                        distribute using them")
-                framesizes = intervals_to_chunklist(obs["intervals"], nsamp)
-            if framesizes is None:
-                framesizes = [nsamp]
-
-            # Examine all the cache objects and find the set of prefixes
-            flavors = set()
-            flavor_type = dict()
-            flavor_maptype = dict()
-            pat = re.compile(r"^(.*?)_(.*)")
-            for nm in list(tod.cache.keys()):
-                mat = pat.match(nm)
-                if mat is not None:
-                    pref = mat.group(1)
-                    md = mat.group(2)
-                    if md in detnames:
-                        # This cache field has the form <prefix>_<det>
-                        if pref not in flavor_type:
-                            ref = tod.cache.reference(nm)
-                            if ref.dtype == np.dtype(np.float64):
-                                flavors.add(pref)
-                                flavor_type[pref] = core3g.G3Timestream
-                                flavor_maptype[pref] = core3g.G3TimestreamMap
-                            elif ref.dtype == np.dtype(np.int32):
-                                flavors.add(pref)
-                                flavor_type[pref] = core3g.G3VectorInt
-                                flavor_maptype[pref] = core3g.G3MapVectorInt
-                            elif ref.dtype == np.dtype(np.uint8):
-                                flavors.add(pref)
-                                flavor_type[pref] = so3g.IntervalsInt
-                                flavor_maptype[pref] = so3g.MapIntervalsInt
-            # If the main signals and flags are coming from the cache, remove
-            # them from consideration here.
-            if self._cache_name is None:
-                flavors.discard(self._cache_name)
-            if self._cache_flag_name is None:
-                flavors.discard(self._cache_flag_name)
-
-            # Restrict this list of available flavors to just those that
-            # we want to export.
-            copy_flavors = []
-            if self._cache_copy is not None:
-                copy_flavors = list()
-                for flv in flavors:
-                    if flv in self._cache_copy:
-                        copy_flavors.append(
-                            (flv, flavor_type[flv], flavor_maptype[flv],
-                             "signal_{}".format(flv)))
-                if grouprank == 0 and len(copy_flavors) > 0:
-                    print("Found {} extra TOD flavors: {}".format(
-                        len(copy_flavors), copy_flavors), flush=True)
-
-            # Given the dimensions of this observation, compute the frame
-            # file sizes and all relevant offsets.
-
-            frame_sample_offs = None
-            file_sample_offs = None
-            file_frame_offs = None
-            if grouprank == 0:
-                # Compute the frame file breaks.  We ignore the observation
-                # and calibration frames since they are small.
-                sampbytes = self._bytes_per_sample(len(detquat),
-                                                   len(copy_flavors) + 1)
-
-                file_sample_offs, file_frame_offs, frame_sample_offs = \
-                    s3utils.compute_file_frames(
-                        sampbytes, framesizes,
-                        file_size=self._target_framefile)
-
-            if cgroup is not None:
-                file_sample_offs = cgroup.bcast(file_sample_offs, root=0)
-                file_frame_offs = cgroup.bcast(file_frame_offs, root=0)
-                frame_sample_offs = cgroup.bcast(frame_sample_offs, root=0)
-
-            ex_files = [os.path.join(obsdir,
-                        "{}_{:08d}.g3".format(self._prefix, x))
-                        for x in file_sample_offs]
-
-            # Loop over each frame file.  Write the header frames and then
-            # gather the data from all processes before writing the scan
-            # frames.
-
-            for ifile, (ffile, foff) in enumerate(zip(ex_files,
-                                                  file_frame_offs)):
-                nframes = None
-                # print("  ifile = {}, ffile = {}, foff = {}"
-                #       .format(ifile, ffile, foff), flush=True)
-                if ifile == len(ex_files) - 1:
-                    # we are at the last file
-                    nframes = len(framesizes) - foff
-                else:
-                    # get number of frames in this file
-                    nframes = file_frame_offs[ifile+1] - foff
-
-                writer = None
-                if grouprank == 0:
-                    writer = core3g.G3Writer(ffile)
-                    self._write_obs(writer, props, detindx)
-                    if "noise" in obs:
-                        self._write_precal(writer, detquat, obs["noise"])
-                    else:
-                        self._write_precal(writer, detquat, None)
-
-                # Collect data for all frames in the file in one go.
-
-                frm_offsets = [frame_sample_offs[foff+f]
-                               for f in range(nframes)]
-                frm_sizes = [framesizes[foff+f] for f in range(nframes)]
-
-                if grouprank == 0:
-                    print("  {} file {}".format(obsdir, ifile), flush=True)
-                    print("    start frame = {}, nframes = {}"
-                          .format(foff, nframes), flush=True)
-                    print("    frame offs = ", frm_offsets, flush=True)
-                    print("    frame sizes = ", frm_sizes, flush=True)
-
-                fdata = tod_to_frames(
-                    tod, foff, nframes, frm_offsets, frm_sizes,
-                    cache_signal=self._cache_name,
-                    cache_flags=self._cache_flag_name,
-                    cache_common_flags=self._cache_common,
-                    copy_common=None,
-                    copy_detector=copy_flavors,
-                    units=self._units)
-
-                if grouprank == 0:
-                    for fdt in fdata:
-                        writer(fdt)
-                    del writer
-                del fdata
+            if self._detgroups is None:
+                detgroup = None
+                detectors = obs["tod"].detectors
+                self._export_observation(obs, cgroup)
+            else:
+                for detgroup, detectors in self._detgroups.items():
+                    self._export_observation(obs, cgroup, detgroup, detectors)
 
         return

--- a/sotodlib/data/toast_export.py
+++ b/sotodlib/data/toast_export.py
@@ -58,6 +58,10 @@ class ToastExport(toast.Operator):
         detgroups (dict):  Dictionary of groups to arrange the detectors into.
             Each key is a name of the group and each value is a list of
             detector names
+        gain_compressor (float):  Extra gain to apply to the signal before
+            encoding in 24-bit integers.  Only applied when compress=True.
+        compress (bool):  Store the timestreams as FLAC-compressed, 24-bit
+            integers instead of uncompressed doubles.  See `gain_compressor`.
 
     """
     def __init__(self, outdir, prefix="so", use_todchunks=False,
@@ -65,6 +69,8 @@ class ToastExport(toast.Operator):
                  cache_flag_name=None, cache_copy=None, mask_flag_common=255,
                  mask_flag=255, filesize=500000000, units=None,
                  detgroups=None,
+                 gain_compressor=30000,
+                 compress=False,
     ):
         self._outdir = outdir
         self._prefix = prefix
@@ -81,6 +87,8 @@ class ToastExport(toast.Operator):
         self._target_framefile = filesize
         self._units = units
         self._detgroups = detgroups
+        self._gain_compressor = gain_compressor
+        self._compress = compress
         # We call the parent class constructor
         super().__init__()
 
@@ -391,6 +399,8 @@ class ToastExport(toast.Operator):
                 dets=detnames,
                 mask_flag_common=self._mask_flag_common,
                 mask_flag=self._mask_flag,
+                gain_compressor=self._gain_compressor,
+                compress=self._compress,
             )
 
             if grouprank == 0:

--- a/sotodlib/data/toast_frame_utils.py
+++ b/sotodlib/data/toast_frame_utils.py
@@ -225,7 +225,9 @@ def tod_to_frames(
         copy_detector=None,
         mask_flag_common=255,
         mask_flag=255,
-        units=None):
+        units=None,
+        dets=None,
+):
     """Gather all data from the distributed TOD cache for a set of frames.
 
     Args:
@@ -248,6 +250,8 @@ def tod_to_frames(
         mask_flag_common (int):  Bitmask to apply to common flags.
         mask_flag (int):  Bitmask to apply to per-detector flags.
         units: G3 units of the detector data.
+        dets (list):  List of detectors to include in the frame.  If None,
+            use all of the detectors in the TOD object.
 
     Returns:
         (list): List of frames on rank zero.  Other processes have a list of
@@ -261,7 +265,14 @@ def tod_to_frames(
     comm_row = tod.grid_comm_row
 
     # Detector names
-    detnames = tod.detectors
+    if dets is None:
+        detnames = tod.detectors
+    else:
+        detnames = []
+        use_dets = set(dets)
+        for det in tod.detectors:
+            if det in use_dets:
+                detnames.append(det)
 
     # Local sample range
     local_first = tod.local_samples[0]

--- a/sotodlib/data/toast_frame_utils.py
+++ b/sotodlib/data/toast_frame_utils.py
@@ -34,7 +34,7 @@ FIELD_TO_CACHE= {
 }
 
 
-def recode_timestream(ts, rmstarget=2 ** 14):
+def recode_timestream(ts, rmstarget=2 ** 10):
     """ts is a G3Timestream.  Returns a new
     G3Timestream for same samples as ts, but with data
     scaled and translated with gain and offset,
@@ -55,7 +55,7 @@ def recode_timestream(ts, rmstarget=2 ** 14):
 
     """
     v = np.array(ts)
-    rms = np.std(v)
+    rms = np.std(np.diff(v)) / np.sqrt(2)
     if rms == 0:
         gain = 1
         offset = v[0]

--- a/sotodlib/data/toast_frame_utils.py
+++ b/sotodlib/data/toast_frame_utils.py
@@ -42,7 +42,7 @@ def recode_timestream(ts, params, rmstarget=2 ** 10, rmsmode="white"):
 
     Args:
         ts (G3Timestream) :  Input signal
-        compresspar (bool or dict) :  if True, compress with default
+        params (bool or dict) :  if True, compress with default
             parameters.  If dict with 'rmstarget' member, override
             default `rmstarget`.  If dict with `gain` and `offset`
             members, use those instead.
@@ -97,10 +97,10 @@ def recode_timestream(ts, params, rmstarget=2 ** 10, rmsmode="white"):
             gain = 1
         else:
             gain = rmstarget / rms
-            # If the data have extreme outliers, we have to reduce the gain
-            # to fit the 24-bit signed integer range
-            while amp * gain >= 2 ** 23:
-                gain *= 0.5
+        # If the data have extreme outliers, we have to reduce the gain
+        # to fit the 24-bit signed integer range
+        while amp * gain >= 2 ** 23:
+            gain *= 0.5
     elif amp * gain >= 2 ** 23:
         raise RuntimeError("The specified gain and offset saturate the band.")
     v = np.round((v - offset) * gain)

--- a/sotodlib/data/toast_load.py
+++ b/sotodlib/data/toast_load.py
@@ -29,7 +29,7 @@ from toast.tod import spt3g_utils as s3utils
 
 from ..hardware import Hardware
 
-from .toast_frame_utils import frames_to_tod
+from .toast_frame_utils import frame_to_tod
 
 
 # FIXME:  This CamelCase name is ridiculous in all caps...
@@ -45,8 +45,8 @@ class SOTOD(TOD):
         file_names:
         file_nframes:
         file_sample_offs:
-        file_frame_offs:
         frame_sizes:
+        frame_sizes_by_offset:
         frame_sample_offs:
         detquats:
         mpicomm (mpi4py.MPI.Comm): the MPI communicator over which this
@@ -57,7 +57,8 @@ class SOTOD(TOD):
 
     """
     def __init__(self, path, file_names, file_nframes, file_sample_offs,
-                 file_frame_offs, frame_sizes, frame_sample_offs, detquats,
+                 frame_sizes, frame_sizes_by_offset,
+                 frame_sample_offs, detquats,
                  mpicomm, detranks=1):
         self._path = path
         self._units = None
@@ -67,15 +68,21 @@ class SOTOD(TOD):
         self._file_names = file_names
         self._file_nframes = file_nframes
         self._file_sample_offs = file_sample_offs
-        self._file_frame_offs = file_frame_offs
 
-        nsamp = np.sum(self._frame_sizes)
+        sampsizes = []
+        nsamp = 0
+        for sz in frame_sizes_by_offset.values():
+            sampsizes.append(sz)
+            nsamp += sz
 
         # We need to assign a unique integer index to each detector.  This
         # is used when seeding the streamed RNG in order to simulate
         # timestreams.  For simplicity, and assuming that detector names
         # are not too long, we can convert the detector name to bytes and
         # then to an integer.
+        # FIXME: these numbers will not agree with the ones synthesized
+        # FIXME:     in toast_so_sim.py.  Instead, they should be made
+        # FIXME:     part of the hardware model.
 
         self._detindx = {}
         for det in detquats.keys():
@@ -94,7 +101,7 @@ class SOTOD(TOD):
         super().__init__(
             mpicomm, list(sorted(detquats.keys())), nsamp,
             detindx=self._detindx, detranks=detranks,
-            sampsizes=self._frame_sizes, meta=dict())
+            sampsizes=sampsizes, meta=dict())
 
         # Now that the data distribution is set, read frames into memory.
         self.load_frames()
@@ -106,7 +113,8 @@ class SOTOD(TOD):
             rank = self.mpicomm.rank
 
         # Timestamps
-        self.cache.create("timestamps", np.int64, (self.local_samples[1],))
+        self.cache.create(self.TIMESTAMP_NAME, np.float64,
+                          (self.local_samples[1],))
 
         # Boresight pointing
         self.cache.create("qboresight_radec", np.float64,
@@ -115,33 +123,37 @@ class SOTOD(TOD):
                           (self.local_samples[1], 4))
 
         # Common flags
-        self.cache.create("flags_common", np.uint8, (self.local_samples[1],))
+        self.cache.create(self.COMMON_FLAG_NAME, np.uint8,
+                          (self.local_samples[1],))
 
         # Telescope position and velocity
-        self.cache.create("site_position", np.float64,
+        self.cache.create(self.POSITION_NAME, np.float64,
                           (self.local_samples[1], 3))
-        self.cache.create("site_velocity", np.float64,
+        self.cache.create(self.VELOCITY_NAME, np.float64,
                           (self.local_samples[1], 3))
 
         # Detector data and flags
         for det in self.local_dets:
-            name = "{}_{}".format("signal", det)
+            name = "{}_{}".format(self.SIGNAL_NAME, det)
             self.cache.create(name, np.float64, (self.local_samples[1],))
-            name = "{}_{}".format("flags", det)
+            name = "{}_{}".format(self.FLAG_NAME, det)
             self.cache.create(name, np.uint8, (self.local_samples[1],))
 
-        for ifile, (ffile, fnf, foff) in enumerate(
-                zip(self._file_names, self._file_nframes,
-                    self._file_frame_offs)):
+        for (ffile, fnf, frame_offsets, frame_sizes) in zip(
+                self._file_names, self._file_nframes,
+                self._frame_sample_offs, self._frame_sizes):
+
+            print("{} : Loading {}".format(rank, ffile), flush=True)  # DEBUG
 
             # Loop over all frames- only the root process will actually
             # read data from disk.
-            gfile = [None for x in range(fnf)]
             if rank == 0:
                 gfile = core3g.G3File(ffile)
+            else:
+                gfile = [None] * fnf
 
-            scanframe = 0
-            for fileframe, fdata in enumerate(gfile):
+            for fdata, frame_offset, frame_size in zip(
+                    gfile, frame_offsets, frame_sizes):
                 is_scan = True
                 if rank == 0:
                     if fdata.type != core3g.G3FrameType.Scan:
@@ -150,20 +162,15 @@ class SOTOD(TOD):
                     is_scan = self.mpicomm.bcast(is_scan, root=0)
                 if not is_scan:
                     continue
-                frame = foff + scanframe
-                frame_offset = self._frame_sample_offs[frame]
-                frame_size = self._frame_sizes[frame]
 
-                frames_to_tod(
+                frame_to_tod(
                     self,
-                    frame,
                     frame_offset,
                     frame_size,
                     frame_data=fdata,
                     detector_map="signal",
                     flag_map="flags")
 
-                scanframe += 1
                 if self.mpicomm is not None:
                     self.mpicomm.barrier()
             del gfile
@@ -271,7 +278,7 @@ class SOTOD(TOD):
         return
 
 
-def parse_cal_frame(frm, dets):
+def parse_cal_frames(calframes, dets):
     detlist = None
     if isinstance(dets, Hardware):
         detlist = list(sorted(dets.data["detectors"].keys()))
@@ -279,35 +286,38 @@ def parse_cal_frame(frm, dets):
         detlist = dets
     qname = "detector_offset"
     detoffset = dict()
-    if detlist is None:
-        for d, q in frm[qname].iteritems():
-            detoffset[d] = np.array(q)
-    else:
-        for d, q in frm[qname].iteritems():
-            if d in detlist:
-                detoffset[d] = np.array(q)
     kfreq = "noise_stream_freq"
     kpsd = "noise_stream_psd"
     kindx = "noise_stream_index"
     dstr = "noise_detector_streams"
     dwt = "noise_detector_weights"
-    detnames = list(sorted(detoffset.keys()))
     noise_freq = dict()
-    for k, v in frm[kfreq].iteritems():
-        noise_freq[k] = np.array(v)
-    noise_psds = dict()
-    for k, v in frm[kpsd].iteritems():
-        noise_psds[k] = np.array(v)
     noise_index = dict()
-    for k, v in frm[kindx].iteritems():
-        noise_index[k] = int(v)
+    noise_psds = dict()
+    mixing = dict()
     detstrms = dict()
     detwghts = dict()
-    for k, v in frm[dstr].iteritems():
-        detstrms[k] = np.array(v)
-    for k, v in frm[dwt].iteritems():
-        detwghts[k] = np.array(v)
-    mixing = dict()
+    detnames = []
+    for calframe in calframes:
+        if detlist is None:
+            for d, q in calframe[qname].iteritems():
+                detoffset[d] = np.array(q)
+        else:
+            for d, q in calframe[qname].iteritems():
+                if d in detlist:
+                    detoffset[d] = np.array(q)
+        detnames += list(detoffset.keys())
+        for k, v in calframe[kfreq].iteritems():
+            noise_freq[k] = np.array(v)
+        for k, v in calframe[kpsd].iteritems():
+            noise_psds[k] = np.array(v)
+        for k, v in calframe[kindx].iteritems():
+            noise_index[k] = int(v)
+        for k, v in calframe[dstr].iteritems():
+            detstrms[k] = np.array(v)
+        for k, v in calframe[dwt].iteritems():
+            detwghts[k] = np.array(v)
+    detnames = sorted(detnames)
     for det in detnames:
         mixing[det] = dict()
         for st, wt in zip(detstrms[det], detwghts[det]):
@@ -345,16 +355,17 @@ def load_observation(path, dets=None, mpicomm=None, prefix=None, **kwargs):
     if mpicomm is not None:
         rank = mpicomm.rank
     frame_sizes = list()
+    frame_sizes_by_offset = {}
     frame_sample_offs = list()
     file_names = list()
     file_sample_offs = list()
-    file_frame_offs = list()
     nframes = list()
 
     obs = dict()
 
     latest_obs = None
-    latest_cal = None
+    latest_cal_frames = []
+    first_offset = None
 
     if rank == 0:
         pat = None
@@ -362,39 +373,49 @@ def load_observation(path, dets=None, mpicomm=None, prefix=None, **kwargs):
             pat = re.compile(r".*_(\d{8}).g3")
         else:
             pat = re.compile(r"{}_(\d{{8}}).g3".format(prefix))
-        frameoff = 0
-        checkoff = 0
         for root, dirs, files in os.walk(path, topdown=True):
             for f in sorted(files):
                 fmat = pat.match(f)
                 if fmat is not None:
                     ffile = os.path.join(path, f)
                     fsampoff = int(fmat.group(1))
-                    if fsampoff != checkoff:
-                        raise RuntimeError("frame file {} is at \
-                            sample offset {}, are some files\
-                            missing?".format(ffile, checkoff))
+                    if first_offset is None:
+                        first_offset = fsampoff
                     file_names.append(ffile)
                     allframes = 0
                     file_sample_offs.append(fsampoff)
-                    file_frame_offs.append(frameoff)
+                    frame_sizes.append([])
+                    frame_sample_offs.append([])
                     for frame in core3g.G3File(ffile):
                         allframes += 1
-                        if frame.type == core3g.G3FrameType.Observation:
-                            latest_obs = frame
-                        elif frame.type == core3g.G3FrameType.Calibration:
-                            latest_cal = frame
-                        elif frame.type == core3g.G3FrameType.Scan:
+                        if frame.type == core3g.G3FrameType.Scan:
                             # This is a scan frame, process it.
                             fsz = len(frame["boresight"]["az"])
-                            frame_sample_offs.append(fsampoff)
+                            if fsampoff not in frame_sizes_by_offset:
+                                frame_sizes_by_offset[fsampoff] = fsz
+                            else:
+                                if frame_sizes_by_offset[fsampoff] != fsz:
+                                    raise RuntimeError(
+                                        "Frame size at {} changes. {} != {}"
+                                        "".format(
+                                            fsampoff,
+                                            frame_sizes_by_offset[fsampoff],
+                                            fsz))
+                            frame_sample_offs[-1].append(fsampoff)
+                            frame_sizes[-1].append(fsz)
                             fsampoff += fsz
-                            frame_sizes.append(fsz)
-                            frameoff += 1
-                            checkoff += fsz
                         else:
-                            # Unknown frame type- skip it.
-                            pass
+                            frame_sample_offs[-1].append(0)
+                            frame_sizes[-1].append(0)
+                            if frame.type == core3g.G3FrameType.Observation:
+                                latest_obs = frame
+                            elif frame.type == core3g.G3FrameType.Calibration:
+                                if fsampoff == first_offset:
+                                    latest_cal_frames.append(frame)
+                            else:
+                                # Unknown frame type- skip it.
+                                pass
+                    frame_sample_offs[-1] = np.array(frame_sample_offs[-1], dtype=np.int64)
                     nframes.append(allframes)
             break
         if len(file_names) == 0:
@@ -402,17 +423,15 @@ def load_observation(path, dets=None, mpicomm=None, prefix=None, **kwargs):
                 "No frames found at '{}' with prefix '{}'"
                 .format(path, prefix))
         file_sample_offs = np.array(file_sample_offs, dtype=np.int64)
-        file_frame_offs = np.array(file_frame_offs, dtype=np.int64)
-        frame_sample_offs = np.array(frame_sample_offs, dtype=np.int64)
 
     if mpicomm is not None:
         latest_obs = mpicomm.bcast(latest_obs, root=0)
-        latest_cal = mpicomm.bcast(latest_cal, root=0)
+        latest_cal_frames = mpicomm.bcast(latest_cal_frames, root=0)
         nframes = mpicomm.bcast(nframes, root=0)
         file_names = mpicomm.bcast(file_names, root=0)
         file_sample_offs = mpicomm.bcast(file_sample_offs, root=0)
-        file_frame_offs = mpicomm.bcast(file_frame_offs, root=0)
         frame_sizes = mpicomm.bcast(frame_sizes, root=0)
+        frame_sizes_by_offset = mpicomm.bcast(frame_sizes_by_offset, root=0)
         frame_sample_offs = mpicomm.bcast(frame_sample_offs, root=0)
 
     if latest_obs is None:
@@ -420,15 +439,15 @@ def load_observation(path, dets=None, mpicomm=None, prefix=None, **kwargs):
     for k, v in latest_obs.iteritems():
         obs[k] = s3utils.from_g3_type(v)
 
-    if latest_cal is None:
+    if len(latest_cal_frames) == 0:
         raise RuntimeError("No calibration frame with detector offsets!")
-    detoffset, noise = parse_cal_frame(latest_cal, dets)
+    detoffset, noise = parse_cal_frames(latest_cal_frames, dets)
 
     obs["noise"] = noise
 
     obs["tod"] = SOTOD(path, file_names, nframes, file_sample_offs,
-                       file_frame_offs, frame_sizes, frame_sample_offs,
-                       detquats=detoffset,
+                       frame_sizes, frame_sizes_by_offset,
+                       frame_sample_offs, detquats=detoffset,
                        mpicomm=mpicomm, **kwargs)
     return obs
 
@@ -532,7 +551,9 @@ def load_data(dir, obs=None, comm=None, prefix=None, **kwargs):
         # In case something goes wrong on one process, make sure the job
         # is killed.
         try:
-            data.obs.append(load_observation(opath, mpicomm=cgroup, **kwargs))
+            data.obs.append(
+                load_observation(opath, mpicomm=cgroup, prefix=prefix, **kwargs)
+            )
         except:
             exc_type, exc_value, exc_traceback = sys.exc_info()
             lines = traceback.format_exception(exc_type, exc_value,

--- a/sotodlib/data/toast_load.py
+++ b/sotodlib/data/toast_load.py
@@ -145,7 +145,7 @@ class SOTOD(TOD):
                 self._file_names, self._file_nframes,
                 self._frame_sample_offs, self._frame_sizes):
 
-            print("{} : Loading {}".format(rank, ffile), flush=True)  # DEBUG
+            # print("{} : Loading {}".format(rank, ffile), flush=True)
 
             # Loop over all frames- only the root process will actually
             # read data from disk.

--- a/sotodlib/data/toast_load.py
+++ b/sotodlib/data/toast_load.py
@@ -54,12 +54,13 @@ class SOTOD(TOD):
         detranks (int):  The dimension of the process grid in the detector
             direction.  The MPI communicator size must be evenly divisible
             by this number.
+        all_flavors (bool):  Return all signal flavors
 
     """
     def __init__(self, path, file_names, file_nframes, file_sample_offs,
                  frame_sizes, frame_sizes_by_offset,
                  frame_sample_offs, detquats,
-                 mpicomm, detranks=1):
+                 mpicomm, detranks=1, all_flavors=False):
         self._path = path
         self._units = None
         self._detquats = detquats
@@ -68,6 +69,7 @@ class SOTOD(TOD):
         self._file_names = file_names
         self._file_nframes = file_nframes
         self._file_sample_offs = file_sample_offs
+        self._all_flavors = all_flavors
 
         sampsizes = []
         nsamp = 0
@@ -168,8 +170,8 @@ class SOTOD(TOD):
                     frame_offset,
                     frame_size,
                     frame_data=fdata,
-                    detector_map="signal",
-                    flag_map="flags")
+                    all_flavors=self._all_flavors,
+                )
 
                 if self.mpicomm is not None:
                     self.mpicomm.barrier()


### PR DESCRIPTION
This PR modifies the TOAST/so3g facilities to
* support breaking the so3g files by wafer, card or other detector characteristic listed in the hardware configuration
* support FLAC compression of the G3TimeStreams. The compression requires casting the floating point-valued TOD into integers. The `recode` method determines the optimal gain and offset to meet the desired number of significant bits within the TOD RMS. The applied gain and offset are recorded in the so3g file and used when decompressing the TOD.
* support loading all flavors of the TOD recorded in the so3g file
* fix a bug in recording the time stamps in the so3g files and add missing method to expand them into the TOAST cache upon load
* Fix a bug in not propagating the common flag mask from `ToastExport` all the way to `tod_to_frames`
* Fix an off-by-one error in reading and writing the flags
* significantly expand the toast_load unit tests to verify the signal, timestamps and flags in the output files
* ensure that the cache names of the TOD objects agree between exported and imported data
* fixes a bug in loading so3g files that only recovered the first frame in each file