### PR TITLE
intro.rst: use pip instead of setup.py directly

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -69,15 +69,14 @@ Installing sotodlib
 You can either install directly to your conda environment / virtualenv::
 
     %> cd sotodlib
-    %> python setup.py clean
-    %> python setup.py install
+    %> pip install .
 
 Or (if you are frequently hacking on this code) you can install the package in
 "develop" mode, which installs symlinks from your conda environment /
 virtualenv that point back to your source checkout::
 
     %> cd sotodlib
-    %> python setup.py develop
+    %> pip install -e .
 
 
 Running Tests


### PR DESCRIPTION
Uses pip to manage the package directly. Useful when in the future there are other dependencies. See e.g. <https://stackoverflow.com/questions/30306099/pip-install-editable-vs-python-setup-py-develop/30306403>