### PR TITLE
Automatically select the models with small scales if we are simulating high nside

### DIFF
--- a/sotodlib/pipeline_tools/pysm.py
+++ b/sotodlib/pipeline_tools/pysm.py
@@ -116,6 +116,8 @@ def simulate_sky_signal(args, comm, data, focalplanes, subnpix, localsm, signaln
                     )
                 )
             else:
+                if not model_tag.endswith("s") and args.nside > 512:
+                    model_tag += "s"
                 pysm_component_objects.append(
                     so_pysm_models.get_so_models(
                         model_tag, args.nside, map_dist=map_dist


### PR DESCRIPTION
`so_pysm_models` has 2 versions for each model,
e.g. `SO_d0` is the same as PySM 2, `SO_d0s` has small scales signal added.

We want to automatically select the models with small scales if we are running at high nside