### PR TITLE
Invert phi to get azimuth in export

### DIFF
--- a/sotodlib/data/toast_frame_utils.py
+++ b/sotodlib/data/toast_frame_utils.py
@@ -723,7 +723,9 @@ def tod_to_frames(
         for f in range(n_frames):
             fdata[f]["boresight"] = core3g.G3TimestreamMap()
         ang_theta, ang_phi, ang_psi = qa.to_angles(bore)
-        ang_az = ang_phi
+        # Astronomical convention for azimuth is opposite to spherical
+        # coordinate phi.
+        ang_az = -ang_phi
         ang_el = (np.pi / 2.0) - ang_theta
         ang_roll = ang_psi
         split_field(ang_az, core3g.G3Timestream, "boresight", "az", None,


### PR DESCRIPTION
@mhasself noticed that the exported so3g files have the wrong Azimuth convention (#44). Initially I thought there was an error in the TOAST internal convention but it turns out we just need to invert the `phi` angle when translating the horizontal quaternions into Az/El. The TOAST internal conventions are fine.