### PR TITLE
Reduce size of simulated hardware test.

### DIFF
--- a/.github/workflows/run_tests.sh
+++ b/.github/workflows/run_tests.sh
@@ -8,6 +8,8 @@ cp -a /home/sotodlib .
 
 pushd sotodlib >/dev/null 2>&1
 
+export SOTODLIB_TEST_DISABLE_PLOTS=1
+
 python3 setup.py test
 
 popd >/dev/null 2>&1


### PR DESCRIPTION
Running the tests in this branch locally takes about 20s on my laptop:
```
python setup.py test
<snip>
Ran 39 tests in 20.255s

OK
```
If I disable plotting, I get:
```
SOTODLIB_TEST_DISABLE_PLOTS=1 python setup.py test
<snip>
Ran 39 tests in 10.738s

OK
```
Is this acceptable?  If so, then this closes #62 
