### PR TITLE
Refactoring of Projection Matrix

### DIFF
--- a/docs/coords.rst
+++ b/docs/coords.rst
@@ -36,8 +36,6 @@ conventions:
 - ``tod['timestamps']``: timestamps (as unix timestamps).
 - ``tod['boresight']``: child AxisManager with boresight pointing in
   horizon coordinates.
-- ``tod['sight']``: G3VectorQuat, of length samps, representing the
-  rotation from focal plane coordinates to equatorial coordinates.
 - ``tod['focal_plane']``: child AxisManager, with shape (dets) and
   fields ``xi``, ``eta``, ``gamma`` representing detector position and
   orientation in the focal plane.  See ``coord_sys`` documentation for
@@ -46,10 +44,17 @@ conventions:
   - ``'xi'``: position of the detector, measured "to the right" of the
     boresight, i.e. parallel to increasing azimuth.
   - ``'eta'``: position of the detector, measured "up" from the
-    boresight, i.e. parallel to increasing elevationn.
+    boresight, i.e. parallel to increasing elevation.
   - ``'gamma'``: orientation of the detector, measured clockwise from
     North, i.e. 0 degrees is parall to the eta axis, and 90 degrees is
     parallel to the xi axis.
+
+The following item is supported, as an alternative to
+``tod['boresight']`` and ``tod['timestamps']``:
+
+- ``tod['boresight_equ']``: child AxisManager giving the boresight
+  pointing in equatorial coordinates (``'ra'``, ``'dec'``, ``'psi'``,
+  forming a lonlat triple, with ``'psi'`` optional but recommended).
 
 Many functions require an AxisManager ``tod`` as the main
 argument, and extract the above fields from that object by default.
@@ -67,7 +72,7 @@ To compute the RA and dec of all detectors at all times, use
 
   # Plot RA and dec for detector at index 10.
   det_idx = 10
-  ra, dec = coords[det_idx,:,0], coords[det_idx,:,1]
+  ra, dec = radec[det_idx,:,0], radec[det_idx,:,1]
   plt.plot(ra, dec)
 
 If want the horizon coordinates, use :func:`get_horizon`.
@@ -111,6 +116,27 @@ call :func:`get_supergeom` on the set of footprints.
 
 Projection Matrix
 =================
+
+Usage
+-----
+
+Assuming that you have an AxisManager "tod" with "signal",
+"timestamps", "boresight", and "focal_plane" elements, then this
+should work::
+
+  from sotodlib import coords
+
+  wcsk = coords.get_wcs_kernel('car', 0., 0., 0.01*coords.DEG)
+  P = coords.P.for_tod(tod, wcs_kernel=wcsk)
+
+  map1 = P.remove_weights(tod)
+  map1.write('output_car.fits')
+
+
+For more advice, see :class:`P` in the module reference.  See also the
+`pwg-tutorials`_ repository (this may be private to SO members),
+especially so_pipeline_pt2_20200623.ipynb.
+
 
 Background
 ----------
@@ -212,13 +238,6 @@ In fact, .remove_weights can perform steps (1), (2), and (3).  But it
 is worth mentioning the full series, because although step (2) is the
 most expensive it does not depend on the input data and so its output
 map can be re-used for different filters or input signals.
-
-Usage
------
-
-See :class:`P` in the module reference.  See also the `pwg-tutorials`_
-repository (this may be private to SO members), especially
-so_pipeline_pt2_20200623.ipynb.
 
 .. _`pwg-tutorials`: https://github.com/simonsobs/pwg-tutorials/
 

--- a/sotodlib/coords/helpers.py
+++ b/sotodlib/coords/helpers.py
@@ -66,10 +66,12 @@ def _valid_arg(*args, src=None):
             return a
     return None
 
-def _find_field(axisman, default, provided):
-    """Temporary wrapper for _valid_arg..."""
-    return _valid_arg(provided, default, src=axisman)
-
+def _not_both(a, b, name='{item}'):
+    if a is not None:
+        if b is not None:
+            raise ValueError('self.%s and kwarg %s both not None!' % (name, name))
+        return a
+    return b
 
 def get_radec(tod, wrap=False, dets=None, timestamps=None, focal_plane=None,
               boresight=None, sight=None):

--- a/sotodlib/coords/helpers.py
+++ b/sotodlib/coords/helpers.py
@@ -219,7 +219,9 @@ def get_footprint(tod, wcs_kernel, dets=None, timestamps=None, boresight=None,
     asm = so3g.proj.Assembly.attach(sight, fp1)
     output = np.zeros((len(fake_dets), n_samp, 4))
     proj = so3g.proj.Projectionist.for_geom((1,1), wcs_kernel)
-    if rot: proj.q_celestial_to_native *= rot
+    if rot:
+        # Works whether rot is a quat or a vector of them.
+        asm.Q = rot * asm.Q
     proj.get_planar(asm, output=output)
 
     output2 = output*0

--- a/sotodlib/coords/helpers.py
+++ b/sotodlib/coords/helpers.py
@@ -299,3 +299,67 @@ def get_supergeom(*geoms, tol=1e-3):
         w0.wcs.crpix -= corner_a[::-1]
         s0 = corner_b - corner_a
     return tuple(map(int, s0)), w0
+
+def _invert_weights_map(weights, eigentol=1e-6, UPLO='U'):
+    """Compute an inverse weights matrix, using eigendecomposition methods
+    that are safe against singular matrices.  This is similar to
+    scipy.linalg.pinvh, but applied to each pixel in a map in an
+    efficient way.
+
+    Args:
+      weights: an array with at least 2 dimensions, where the leading
+        two dimensions are the same.  For example, shape (3, 3, 200,
+        100) or (3, 3, 10231230).
+      eigentol: sets the threshold for keeping eigenvectors.  In each
+        matrix inversion, any eigenvectors whose absolute values are
+        less than eigentol times the largest absolute eigenvalue are
+        set to zero (and thus excluded from inclusion in the inverse).
+      UPLO (str): this can be 'U' or 'L' signifying that only the
+        upper diagonal or lower diagonal (respectively) elements of
+        each weights sub-matrix should be considered.  (This argument
+        is passed through to np.linalg.eigh.)
+
+    Returns:
+      The inverse of weights, computed for the square submatrices
+      defined by the first two axes.  In cases where the inverse does
+      not formally exist, the non-trivial eigenmodes of the matrix
+      will be exactly inverted, and singular or near-singular modes
+      form the null space.
+
+    """
+    # Collapse and reindex weights map so it is (npix, n, n).
+    w = weights.reshape(weights.shape[:2] + (-1,)).transpose(2, 0, 1)
+
+    # Get eigendecomposition of each (n, n) sub-matrix
+    v, U = np.linalg.eigh(w, UPLO)
+
+    # Identify acceptable eigenvalues -- reject ones that too small
+    # relative to max eigenvalue in their pixel.
+    eig_ok = (abs(v) > abs(v).max(axis=-1)[:,None] * eigentol)
+
+    # Force each unacceptable eigenmode to 0.
+    U *= eig_ok[:,None,:]
+
+    # Set bad eigenvalues to 1, to avoid the divide-by-zero.
+    v[~eig_ok] = 1.
+
+    # Compute the effective inverse, U (1/diag(v)) U.T.
+    A = (U / v[:,None,:])
+    B = U.transpose(0,2,1)
+    iw = np.matmul(A, B)
+
+    # Reshape the output to match what was passed in.
+    return iw.transpose(1,2,0).reshape(weights.shape)
+
+def _apply_inverse_weights_map(inverse_weights, target):
+    """Apply a map of matrices to a map of vectors.
+
+    Assumes inverse_weights.shape = (a, b, ny, nx) and target.shape =
+    (b, nx, ny); the result has shape (a, nx, ny).
+
+    """
+    iw = inverse_weights.transpose((2,3,0,1))
+    m = target.transpose((1,2,0)).reshape(
+        target.shape[1], target.shape[2], target.shape[0], 1)
+    m1 = np.matmul(iw, m)
+    return m1.transpose(2,3,0,1).reshape(target.shape)

--- a/sotodlib/coords/pmat.py
+++ b/sotodlib/coords/pmat.py
@@ -106,7 +106,8 @@ class P:
     @classmethod
     def for_tod(cls, tod, sight=None, fp=None, geom=None, comps='T',
                 rot=None, cuts=None, threads=None, det_weights=None,
-                timestamps=None, focal_plane=None, boresight=None):
+                timestamps=None, focal_plane=None, boresight=None,
+                wcs_kernel=None):
         if sight is None:
             boresight_cel = tod.get('boresight_cel')
             if boresight_cel is not None:
@@ -131,6 +132,9 @@ class P:
         # Set up the detectors in the focalplane
         fp = _valid_arg(focal_plane, 'focal_plane', src=tod)
         fp = so3g.proj.quat.rotation_xieta(fp.xi, fp.eta, fp.get('gamma'))
+
+        if geom is None and wcs_kernel is not None:
+            geom = helpers.get_footprint(tod, wcs_kernel, sight=sight)
 
         return cls(sight=sight, fp=fp, geom=geom, comps=comps,
                    cuts=cuts, threads=threads, det_weights=det_weights)


### PR DESCRIPTION
Summary of improvements:
- Simpler rules for how coords.P processes arguments and what is cached / not cached.
- Passing wcs_kernel=  causes get_footprint to be called to populate self.geom.
- Speed up weights matrix inversion and application.
- Complete documentation of P methods.

This work was done in parallel with developing a compact source mapmaker and refining the unbiased mapmaker.  The pwg_tutorial on coords still works... unbiased mapmaker works, with minimal modifications.

Please post any reviews / comments within 1 week.