### PR TITLE
Filter upgrades

### DIFF
--- a/.github/workflows/install_deps.sh
+++ b/.github/workflows/install_deps.sh
@@ -10,7 +10,7 @@ python3 -m pip install --upgrade pip
 # We upgrade scipy to fix an incompatibility with numpy
 
 python3 -m pip install --upgrade scipy
-python3 -m pip install nose toml mpi4py toast-cmb quaternionarray
+python3 -m pip install nose toml mpi4py toast-cmb quaternionarray pyfftw
 
 # Install S.O. dependencies
 python3 -m pip install pixell

--- a/docs/tod_ops.rst
+++ b/docs/tod_ops.rst
@@ -11,9 +11,23 @@ including time and Fourier domain filtering, PCA.
 Fourier space filters
 =====================
 
-Applying Fourier space filters is facilitated by the ``fourier_filter`` function:
+Applying Fourier space filters is facilitated by the
+``fourier_filter`` function:
 
 .. autofunction:: fourier_filter
+
+
+Here's an example, assuming you have time-ordered data in an
+AxisManager ``tod``.  Note how we combine two Fourier space filters
+using the multiplication operator::
+
+  # Filter with a smooth-edged band, passing 1 Hz to 10 Hz.
+  filt = tod_ops.filters.high_pass_sine(1.) * tod_ops.filters.low_pass_sine2(10.)
+  tod_ops.filters.fourier_filter(tod, filt)
+
+Several filters are described in :mod:`sotodlib.tod_ops.filters`.  See the
+source code for conventions on defining and wrapping new filters to be
+compatible with this system.
 
 
 tod_ops.filters
@@ -28,6 +42,8 @@ be auto-documented here.
 
 .. autofunction:: low_pass_butter4
 .. autofunction:: high_pass_butter4
+.. autofunction:: timeconst_filter
+.. autofunction:: timeconst_filter_single
 .. autofunction:: tau_filter
 .. autofunction:: gaussian_filter
 .. autofunction:: low_pass_sine2

--- a/sotodlib/tod_ops/detrend.py
+++ b/sotodlib/tod_ops/detrend.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 def detrend_data(tod, method='linear', axis_name='samps', 
-            signal_name='signal'):
+                 signal_name='signal', count=10):
     
     """Returns detrended data. Decide for yourself if it goes
         into the axis manager. Generally intended for use before filter.
@@ -18,11 +18,16 @@ def detrend_data(tod, method='linear', axis_name='samps',
         
         signal_name: the name of the signal to detrend. defaults to 'signal'
             if it isn't 2D it is made to be.
-        
+
+        count: Number of samples to use, on each end, when measuring
+            mean level for 'linear' detrend.  Values larger than 1
+            suppress the influence of white noise.
+
     Returns:
         
         detrended signal: does not actually detrend the data in the axis
             manager, let's you decide if you want to do that.
+
     """
     assert len(tod._assignments[signal_name]) <= 2
         
@@ -46,7 +51,8 @@ def detrend_data(tod, method='linear', axis_name='samps',
         signal = signal - np.mean(signal, axis=1)[:,None]
     elif method == 'linear':
         x = np.linspace(0,1, axis.count)
-        slopes = signal[:,-1]-signal[:,0]
+        count = max(1, min(count, signal.shape[-1] // 2))
+        slopes = signal[:,-count:].mean(axis=-1)-signal[:,:count].mean(axis=-1)
         signal = signal - slopes[:,None]*x 
         signal -= np.mean(signal, axis=1)[:,None]
     else:

--- a/sotodlib/tod_ops/fft_ops.py
+++ b/sotodlib/tod_ops/fft_ops.py
@@ -161,3 +161,21 @@ def find_inferior_integer(target, primes=[2,3,5,7,11,13]):
         if (best_friend * base) >= best:
             best = best_friend * base
     return int(best)
+
+def find_superior_integer(target, primes=[2,3,5,7,11,13]):
+    """Find the smallest integer less than or equal to target whose prime
+    factorization contains only the integers listed in primes.
+
+    """
+    p = primes[0]
+    n = np.ceil(np.log(target) / np.log(p))
+    best = p**n
+    if len(primes) == 1:
+        return int(best)
+    while n > 0:
+        n -= 1
+        base = p**n
+        best_friend = find_superior_integer(target / base, primes[1:])
+        if (best_friend * base) <= best:
+            best = best_friend * base
+    return int(best)

--- a/tests/test_tod_ops.py
+++ b/tests/test_tod_ops.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2021 Simons Observatory.
+# Full license can be found in the top level "LICENSE" file.
+
+"""Check tod_ops routines.
+
+"""
+
+import unittest
+import numpy as np
+import pylab as pl
+
+from sotodlib import core, tod_ops
+
+SAMPLE_FREQ_HZ = 100.
+
+def get_tod(sig_type='trendy'):
+    tod = core.AxisManager(core.LabelAxis('dets', ['a', 'b', 'c']),
+                           core.IndexAxis('samps', 1000))
+    tod.wrap_new('signal', ('dets', 'samps'), dtype='float32')
+    tod.wrap_new('timestamps', ('samps',))[:] = (
+        np.arange(tod.samps.count) / SAMPLE_FREQ_HZ)
+    if sig_type == 'trendy':
+        x = np.linspace(0, 1., tod.samps.count)
+        tod.signal[:] = [(i+1) + (i+1)**2 * x for i in range(tod.dets.count)]
+    elif sig_type == 'white':
+        tod.signal = np.random.normal(size=tod.shape)
+    elif sig_type == 'red':
+        tod.signal = np.random.normal(size=tod.shape)
+        tod.signal[:] = np.cumsum(tod.signal, axis=1)
+    else:
+        raise RuntimeError(f'sig_type={sig_type}?')
+    return tod
+
+class FactorsTest(unittest.TestCase):
+    def test_inf(self):
+        f = tod_ops.fft_ops.find_inferior_integer
+        self.assertEqual(f(257), 256)
+        self.assertEqual(f(28), 28)
+        self.assertEqual(f(2**2 * 7**8 + 1), 2**2 * 7**8)
+
+    def test_sup(self):
+        f = tod_ops.fft_ops.find_superior_integer
+        self.assertEqual(f(255), 256)
+        self.assertEqual(f(28), 28)
+        self.assertEqual(f(2**2 * 7**8 - 1), 2**2 * 7**8)
+
+class PcaTest(unittest.TestCase):
+    """Test the pca module."""
+    def test_basic(self):
+        tod = get_tod('trendy')
+        amps0 = tod.signal.max(axis=1) - tod.signal.min(axis=1)
+        modes = tod_ops.pca.get_trends(tod, remove=True)
+        amps1 = tod.signal.max(axis=1) - tod.signal.min(axis=1)
+        print(f'Amplitudes from {amps0} to {amps1}.')
+        self.assertTrue(np.all(amps1 < amps0 * 1e-6))
+
+class FilterTest(unittest.TestCase):
+    def test_basic(self):
+        """Test that fourier filters reduce RMS of white noise."""
+        tod = get_tod('white')
+        sigma0 = tod.signal.std(axis=1)
+        f0 = SAMPLE_FREQ_HZ
+        fc = f0 / 4
+        for filt in [
+                tod_ops.filters.high_pass_butter4(fc),
+                tod_ops.filters.low_pass_sine2(fc),
+                tod_ops.filters.low_pass_butter4(fc),
+                tod_ops.filters.low_pass_sine2(fc),
+                tod_ops.filters.gaussian_filter(fc, f_sigma=f0 / 10),
+                tod_ops.filters.gaussian_filter(0, f_sigma=f0 / 10),
+        ]:
+            f = np.fft.fftfreq(tod.samps.count) * f0
+            y = filt(f, tod)
+            sig_filt = tod_ops.fourier_filter(tod, filt)
+            sigma1 = sig_filt.std(axis=1)
+            self.assertTrue(np.all(sigma1 < sigma0))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Key changes:
- New tests, covering some (but not much) of tod_ops module.
- The fourier filter framework also exposes an "apply" method, that can be faster in some applications.
- fourier_filter will pad to any nice FFT number, not necessarily 2^n.
- New names for timeconstant (de-)convolution filters; deprecates "tau_filter".
- Made some important filter arguments non-optional; better arg names.
- More docs.