### PR TITLE
Adds stream_id support

### DIFF
--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -868,8 +868,6 @@ class G3tSmurf:
                     Tells you the method used to extract timestamps from the
                     frame data.
                     
-        TODO: Loading for Multiple Stream IDs
-
         TODO: Track down differences between detector sets (tune files) and 
                 information in status object
                 


### PR DESCRIPTION
This PR adds support for multiple Stream-id's when loading data. In order to not mess up existing analysis functions, I'm keeping it as simple as possible for the time being. 

If no stream_id is provided, default behavior is to first check if there are multiple stream_ids in the specified range. If there's only one ID, it'll load the data like before, and if there are multiple it'll throw an error. If a stream_id is specified, it'll only query files that have that stream_id.

If we want to add a way to load multiple stream_ids at once, we can add a function that calls `load_data` with each stream_id separately, but I think this is good enough for now.