### PR TITLE
Load .g3 file

### DIFF
--- a/docs/g3tsmurf.rst
+++ b/docs/g3tsmurf.rst
@@ -1,3 +1,5 @@
+.. py:module:: sotodlib.io.load_smurf
+
 =========
 G3tSMuRF 
 =========
@@ -14,22 +16,31 @@ Eventually the databasing part will be separated out and migrated to work within
 the Context system and the loading data functions will be altered to load data
 through a Context object. 
 
-.. autoclass:: sotodlib.io.load_smurf.G3tSmurf
-   :special-members: __init__
+
+.. autofunction:: load_file
+.. autofunction:: get_channel_mask
+.. autofunction:: get_channel_info
+
+
+.. autoclass:: G3tSmurf
+   :special-members: __init__, load_data
    :members:
+
+.. autoclass:: SmurfStatus
+   :special-members: from_file, from_time
 
 Database Tables
 ---------------
-.. autoclass:: sotodlib.io.load_smurf.Observations
+.. autoclass:: Observations
    :members:
-.. autoclass:: sotodlib.io.load_smurf.Detsets
+.. autoclass:: Detsets
    :members:
-.. autoclass:: sotodlib.io.load_smurf.ChanAssignments
+.. autoclass:: ChanAssignments
    :members:
-.. autoclass:: sotodlib.io.load_smurf.Bands
+.. autoclass:: Bands
    :members:
 
-.. autoclass:: sotodlib.io.load_smurf.Files
+.. autoclass:: Files
    :members:
-.. autoclass:: sotodlib.io.load_smurf.Frames
+.. autoclass:: Frames
    :members:

--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -15,6 +15,9 @@ import ast
 from collections import namedtuple
 from enum import Enum
 
+import logging
+logger = logging.getLogger(__name__)
+
 from .. import core
 from . import load as io_load
 
@@ -1015,7 +1018,8 @@ class G3tSmurf:
             time (timestamp): Time at which you want the rogue status
 
         Returns:
-            status (SmurfStatus instance): object indexing of rogue variables at specified time.
+            status (SmurfStatus instance): object indexing of rogue variables 
+            at specified time.
         """
         return SmurfStatus.from_time(time, self, show_pb=show_pb)
 
@@ -1463,9 +1467,13 @@ def load_file(filename, dets=None, archive=None, ignore_missing=True,
 
     request = io_load.FieldGroup('root', subreq)
     streams = None
-    for filename in filenames:
-        streams = io_load.unpack_frames(filename, request, streams=streams)
-
+    try:
+        for filename in filenames:
+            streams = io_load.unpack_frames(filename, request, streams=streams)
+    except KeyError:
+        logger.error("Frames do not contain expected fields. Did Channel Mask change during the file?")
+        raise
+        
     count = sum(map(len,streams['time']))
 
     ## Build AxisManager

--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -816,7 +816,8 @@ class G3tSmurf:
                 sids.append(sid)
         return sids
 
-    def load_data(self, start, end, stream_id=None, detset=None, show_pb=True, load_biases=True):
+    def load_data(self, start, end, stream_id=None, detset=None, show_pb=True, 
+                    load_biases=True):
         """
         Loads smurf G3 data for a given time range. For the specified time range
         this will return a chunk of data that includes that time range.
@@ -979,7 +980,7 @@ class G3tSmurf:
             print('Trying a later status, why is the status not at the beginning?')
             self.load_status(timestamps[-1])
             
-        ch_info = get_channel_info(status, mask=None, detset=detset, ch_name_type='sch')
+        ch_info = get_channel_info(status, mask=None, detset=detset)
         session.close()
 
         ## Build AxisManager

--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -876,9 +876,6 @@ class G3tSmurf:
                 information in status object
                 
         TODO: Track down "Lazy-loaded attribute for Channels.band"
-        
-        TODO: Data loaded here has some strange extra points. Likely due to frame indexing
-            or some other error. Track down.
         """
         session = self.Session()
 

--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -857,7 +857,7 @@ class G3tSmurf:
             show_pb : bool, optional: 
                 If True, will show progress bar.
             load_biases : bool, optional 
-                If T'darue, will return biases.
+                If True, will return biases.
 
         Returns
         --------

--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -857,7 +857,9 @@ class G3tSmurf:
             stream_id : String 
                 stream_id to load, in case there are multiple
             dets : list or None
-                list of detectors to load, uses get_channel_mask options
+                If not None, it should be a list that can be sent to get_channel_mask.
+                Called dets for sotodlib compatibility. This function only looks at 
+                SMuRF channels.
             detset : string
                 the name of the detector set (tuning file) to load
             show_pb : bool, optional: 
@@ -1187,10 +1189,12 @@ def get_channel_mask(ch_list, status, archive=None, ignore_missing=True):
     ch_list : list
         List of desired channels the type of each list element is used
         to determine what it is:
-        int : absolute readout channel
-        (int, int) : band, channel
-        string : channel name (archive can not be None)
-        float : frequency in the smurf status (or should we use channel assignment?)
+
+        * int : absolute readout channel
+        * (int, int) : band, channel
+        * string : channel name (archive can not be None)
+        * float : frequency in the smurf status (or should we use channel assignment?)
+
     status : SmurfStatus instance
         Status to use to generate channel loading mask
     archive : G3tSmurf instance

--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -926,7 +926,7 @@ class G3tSmurf:
             status = None
         
         aman = load_file( flist, status=status, dets=dets,
-                         archive=self, detset=detset)
+                         archive=self, detset=detset, show_pb=show_pb)
         msk = np.all([aman.timestamps >= start.timestamp(),
                       aman.timestamps < end.timestamp()], axis=0)
         idx = np.where(msk)[0]
@@ -1384,7 +1384,7 @@ def _get_timestamps(streams, load_type=None):
         
 def load_file(filename, dets=None, ignore_missing=True, 
              load_biases=True, load_primary=True, 
-             status=None, archive=None, detset=None):
+             status=None, archive=None, detset=None, show_pb=True):
     """Load data from file where there may not be a connected archive.
 
     Args
@@ -1436,7 +1436,7 @@ def load_file(filename, dets=None, ignore_missing=True,
     request = io_load.FieldGroup('root', subreq)
     streams = None
     try:
-        for filename in filenames:
+        for filename in tqdm( filenames , total=len(filenames), disable=(not show_pb)):
             streams = io_load.unpack_frames(filename, request, streams=streams)
     except KeyError:
         logger.error("Frames do not contain expected fields. Did Channel Mask change during the file?")


### PR DESCRIPTION
This PR does a fair bit of updates / rearranging to the data loading functions in load_smurf. The goal is to expand functionality and move toward full `sotodlib` integration without breaking any existing analysis code. 

Main updates: 

- `load_file` function that takes any SO style `.g3` file (or list of files) and returns a correctly formatted AxisManager
- `get_channel_mask` function that connects a user's request for different channels to what exists in a file or observation. When the `dets` kwarg is passed to either `load_file` or `G3tSmurf.load_data` only the requested channels will be loaded into memory. 
- `G3tSmurf.load_data` now uses `load_file` under the hood. Right now this is slightly less optimized than before, because `sotodlib.io.load.unpack_frames` doesn't have Seek capability, likely a good thing to put on the todo list.
- New timing function that calculates timestamps off the whole loaded dataset instead of frame-by-frame
- Expand docs to include new docstrings
- Add in logging for this module