### PR TITLE
Coord sys revamp

### DIFF
--- a/docs/coords.rst
+++ b/docs/coords.rst
@@ -258,7 +258,7 @@ Coordinate Conversions
 
 .. autofunction:: get_radec
 .. autofunction:: get_horiz
-.. autoclass:: ToastishQuat
+.. autoclass:: ScalarLastQuat
    :members:
 
 Map and Geometry helpers

--- a/docs/coords.rst
+++ b/docs/coords.rst
@@ -258,6 +258,8 @@ Coordinate Conversions
 
 .. autofunction:: get_radec
 .. autofunction:: get_horiz
+.. autoclass:: ToastishQuat
+   :members:
 
 Map and Geometry helpers
 ------------------------

--- a/sotodlib/coords/__init__.py
+++ b/sotodlib/coords/__init__.py
@@ -1,6 +1,6 @@
 from .pmat import P
 from .helpers import (
     get_radec, get_horiz, get_footprint, get_wcs_kernel, get_supergeom,
-    Timer, DEG,
+    Timer, DEG, ToastishQuat
 )
 from . import planets

--- a/sotodlib/coords/__init__.py
+++ b/sotodlib/coords/__init__.py
@@ -1,6 +1,6 @@
 from .pmat import P
 from .helpers import (
     get_radec, get_horiz, get_footprint, get_wcs_kernel, get_supergeom,
-    Timer, DEG, ToastishQuat
+    Timer, DEG, ScalarLastQuat
 )
 from . import planets

--- a/sotodlib/coords/helpers.py
+++ b/sotodlib/coords/helpers.py
@@ -435,14 +435,14 @@ def _apply_inverse_weights_map(inverse_weights, target):
     return m1.transpose(2,3,0,1).reshape(target.shape)
 
 
-class ToastishQuat(np.ndarray):
+class ScalarLastQuat(np.ndarray):
     """Wrapper class for numpy arrays carrying quaternions with the ijk1
     signature.
 
-    The practice in TOAST and quaternionarray is to store quaternions
-    in numpy arrays with shape (..., 4), with the real part of the
-    quaternion at index [..., 3].  In contrast, spt3g_software uses
-    signature 1ijk.
+    The practice in many codes, including TOAST, quaternionarray, and
+    scipy is to store quaternions in numpy arrays with shape (..., 4),
+    with the real part of the quaternion at index [..., 3].  In
+    contrast, spt3g_software inherits the 1ijk from boost.
 
     This class serves two main purposes:
 
@@ -461,7 +461,7 @@ class ToastishQuat(np.ndarray):
     to ijk1 signature::
 
       q_g3 = spt3g.core.quat(1.,2.,3.,4.)
-      q_tq = ToastishQuat(q_g3)
+      q_tq = ScalarLastQuat(q_g3)
       q_g3_again = q_tq.to_g3()
 
       print(q_g3, q_tq, q_g3_again)

--- a/sotodlib/sim_hardware.py
+++ b/sotodlib/sim_hardware.py
@@ -15,7 +15,7 @@ import quaternionarray as qa
 
 import so3g.proj.quat as so3q
 
-from .coords import ToastishQuat
+from .coords import ScalarLastQuat
 
 from .core import Hardware
 
@@ -744,11 +744,11 @@ def sim_telescope_detectors(hw, tele, tube_slots=None):
 
     # Transform quats from left-handed layout coordinates to
     # right-handed TOAST-compatible coordintes -- see note at top of
-    # this file.  Note the ToastishQuat is just helping us convert to
+    # this file.  Note the ScalarLastQuat is just helping us convert to
     # and from 3g quats.
-    quats_in = ToastishQuat([d['quat'] for d in alldets.values()])  # shape (n, 4)
+    quats_in = ScalarLastQuat([d['quat'] for d in alldets.values()])  # shape (n, 4)
     xi, eta, gamma = so3q.decompose_xieta(quats_in.to_g3())
-    quats_out = ToastishQuat(so3q.rotation_xieta(eta, xi, np.pi/2 - gamma))
+    quats_out = ScalarLastQuat(so3q.rotation_xieta(eta, xi, np.pi/2 - gamma))
     for d, q in zip(alldets.values(), quats_out):
         d['quat'] = q
 

--- a/sotodlib/sim_hardware.py
+++ b/sotodlib/sim_hardware.py
@@ -13,7 +13,62 @@ import numpy as np
 
 import quaternionarray as qa
 
+import so3g.proj.quat as so3q
+
+from .coords import ToastishQuat
+
 from .core import Hardware
+
+# Important note on coordinate systems
+#
+# The functions in this module help to lay out the detectors in the
+# focal plane by combining various components, such as assembling
+# rhombi into wafers and wafers into optical tubes.  This is done in a
+# cartesian projection plane with axes oriented like this:
+#
+#        Layout coordinates here
+#        -----------------------
+#
+#      Y^                   O
+#       |                  O O
+#       |                   O O
+#       |                  O + O
+#       +-----> X           O O O
+#
+#   (Z into the page)     Some dets
+#
+# with the idea being that the detectors are sensitive to radiation
+# coming from some point on the sphere (x, y, z) near z=1.  In the
+# final layout, that one would want to rigidly attach to the
+# boresight, the X-axis points in the direction of increasing azimuth
+# and the Y-axis in the direction of increasing elevation.  The
+# encoded quaternion is the rotation that takes vectors in detector
+# coordinates to vectors in this system.
+#
+# However, this XYZ cartesian system is left-handed, and thus does not
+# naturally connect with the pointing codes used in TOAST (and so3g).
+# What is needed for TOAST is illustrated here:
+#
+#     TOAST focal plane coordinates
+#     -----------------------------
+#
+#      X^                   O
+#       |                  O O
+#       |                   O O
+#       |                  O + O
+#       +-----> Y           O O O
+#
+#   (Z into the page)   Those same dets
+#
+# Here's how this discrepancy is dealt with.  In this module, the
+# final quaternion stored in each detector's info dict is transformed,
+# right at the end, from the left-handed layout system into the
+# right-handed TOAST focal plane system.  When decoding the "quat"
+# property of detectors for plotting, the "X" and "Y" coordinates so
+# extracted must not be naively plotted as pylab.scatter(x, y)!  To
+# show the layout "as it would project onto the sky", you want
+# pylab.scatter(y, x).  (See vis_hardware, for example.)
+
 
 # FIXME:  much of this code is copy/pasted from the toast source, simply to
 # avoid a dependency.  Once we can "pip install toast", we should consider
@@ -686,8 +741,18 @@ def sim_telescope_detectors(hw, tele, tube_slots=None):
                 alldets.update(dets)
                 windx += 1
             tindx += 1
-    return alldets
 
+    # Transform quats from left-handed layout coordinates to
+    # right-handed TOAST-compatible coordintes -- see note at top of
+    # this file.  Note the ToastishQuat is just helping us convert to
+    # and from 3g quats.
+    quats_in = ToastishQuat([d['quat'] for d in alldets.values()])  # shape (n, 4)
+    xi, eta, gamma = so3q.decompose_xieta(quats_in.to_g3())
+    quats_out = ToastishQuat(so3q.rotation_xieta(eta, xi, np.pi/2 - gamma))
+    for d, q in zip(alldets.values(), quats_out):
+        d['quat'] = q
+
+    return alldets
 
 def get_example():
     """Return an example Hardware config with the required sections.

--- a/sotodlib/vis_hardware.py
+++ b/sotodlib/vis_hardware.py
@@ -69,8 +69,35 @@ proceeding with the default matplotlib backend"""
         )
         import matplotlib.pyplot as plt
 
+    # If you rotate the zaxis by quat, then the X axis is upwards in
+    # the focal plane and the Y axis is to the right.  (This is what
+    # TOAST expects.)  Below we use "x" and "y" for those directions,
+    # and in plotting functions pass them in the order (y, x).
+
     xaxis = np.array([1.0, 0.0, 0.0], dtype=np.float64)
     zaxis = np.array([0.0, 0.0, 1.0], dtype=np.float64)
+    quats = np.array([p['quat'] for p in dets.values()]).astype(float)
+    pos = qa.rotate(quats, zaxis)  # shape (n_det, 3)
+
+    # arc_factor returns a scaling that can be used to reproject (X,
+    # Y) to units corresponding to the angle subtended from (0,0,1) to
+    # (X, Y, sqrt(X^2 + Y^2)).  This is called "ARC" (Zenithal
+    # Equidistant) projection in FITS.
+    def arc_factor(x, y):
+        r = (x**2 + y**2)**.5
+        if r < 1e-6:
+            return 1. + r**2/6
+        return np.arcsin(r)/r
+    detx = {k: p[0] * 180.0 / np.pi * arc_factor(p[0], p[1])
+            for k, p in zip(dets.keys(), pos)}
+    dety = {k: p[1] * 180.0 / np.pi * arc_factor(p[0], p[1])
+            for k, p in zip(dets.keys(), pos)}
+
+    # The detang is the polarization angle, measured CCW from vertical.
+    pol = qa.rotate(quats, xaxis)  # shape (n_det, 3)
+    detang = {k: np.arctan2(p[1], p[0])
+              for k, p in zip(dets.keys(), pol)}
+
     wmin = 1.0
     wmax = -1.0
     hmin = 1.0
@@ -78,21 +105,11 @@ proceeding with the default matplotlib backend"""
     if (width is None) or (height is None):
         # We are autoscaling.  Compute the angular extent of all detectors
         # and add some buffer.
-        for d, props in dets.items():
-            quat = np.array(props["quat"]).astype(np.float64)
-            dir = qa.rotate(quat, zaxis).flatten()
-            if (dir[0] > wmax):
-                wmax = dir[0]
-            if (dir[0] < wmin):
-                wmin = dir[0]
-            if (dir[1] > hmax):
-                hmax = dir[1]
-            if (dir[1] < hmin):
-                hmin = dir[1]
-        wmin = np.arcsin(wmin) * 180.0 / np.pi
-        wmax = np.arcsin(wmax) * 180.0 / np.pi
-        hmin = np.arcsin(hmin) * 180.0 / np.pi
-        hmax = np.arcsin(hmax) * 180.0 / np.pi
+        if len(detx):
+            _y = np.array(list(dety.values()))
+            _x = np.array(list(detx.values()))
+            wmin, wmax = _y.min(), _y.max()
+            hmin, hmax = _x.min(), _x.max()
         wbuf = 0.1 * (wmax - wmin)
         hbuf = 0.1 * (hmax - hmin)
         wmin -= wbuf
@@ -121,10 +138,8 @@ proceeding with the default matplotlib backend"""
                 wafer_centers[dwslot]["x"] = 0.0
                 wafer_centers[dwslot]["y"] = 0.0
                 wafer_centers[dwslot]["n"] = 0
-            quat = np.array(props["quat"]).astype(np.float64)
-            dir = qa.rotate(quat, zaxis).flatten()
-            wafer_centers[dwslot]["x"] += np.arcsin(dir[0]) * 180.0 / np.pi
-            wafer_centers[dwslot]["y"] += np.arcsin(dir[1]) * 180.0 / np.pi
+            wafer_centers[dwslot]["x"] += detx[d]
+            wafer_centers[dwslot]["y"] += dety[d]
             wafer_centers[dwslot]["n"] += 1
         for k in wafer_centers.keys():
             wafer_centers[k]["x"] /= wafer_centers[k]["n"]
@@ -132,13 +147,13 @@ proceeding with the default matplotlib backend"""
 
     if bandcolor is None:
         bandcolor = default_band_colors
-    xfigsize = 10.0
-    yfigsize = xfigsize * (height / width)
+    wfigsize = 10.0
+    hfigsize = wfigsize * (height / width)
     figdpi = 75
-    yfigpix = int(figdpi * yfigsize)
-    ypixperdeg = yfigpix / height
+    hfigpix = int(figdpi * hfigsize)
+    hpixperdeg = hfigpix / height
 
-    fig = plt.figure(figsize=(xfigsize, yfigsize), dpi=figdpi)
+    fig = plt.figure(figsize=(wfigsize, hfigsize), dpi=figdpi)
     ax = fig.add_subplot(1, 1, 1)
 
     ax.set_xlabel("Degrees", fontsize="large")
@@ -149,9 +164,9 @@ proceeding with the default matplotlib backend"""
     # Draw wafer labels in the background
     if labels:
         # Compute the font size to use for detector labels
-        fontpix = 0.2 * ypixperdeg
+        fontpix = 0.2 * hpixperdeg
         for k, v in wafer_centers.items():
-            ax.text(v["x"] + 0.2, v["y"], k,
+            ax.text(v["y"] + 0.2, v["x"], k,
                     color='k', fontsize=fontpix, horizontalalignment='center',
                     verticalalignment='center',
                     bbox=dict(fc='white', ec='none', pad=0.2, alpha=1.0))
@@ -166,20 +181,13 @@ proceeding with the default matplotlib backend"""
         # radius in degrees
         detradius = 0.5 * fwhm / 60.0
 
-        # rotation from boresight
-        rdir = qa.rotate(quat, zaxis).flatten()
-        ang = np.arctan2(rdir[1], rdir[0])
-
-        orient = qa.rotate(quat, xaxis).flatten()
-        polang = np.arctan2(orient[1], orient[0])
-
-        mag = np.arccos(rdir[2]) * 180.0 / np.pi
-        xpos = mag * np.cos(ang)
-        ypos = mag * np.sin(ang)
+        # Position and polarization angle
+        xpos, ypos = detx[d], dety[d]
+        polang = detang[d]
 
         detface = bandcolor[band]
 
-        circ = plt.Circle((xpos, ypos), radius=detradius, fc=detface,
+        circ = plt.Circle((ypos, xpos), radius=detradius, fc=detface,
                           ec="black", linewidth=0.05*detradius)
         ax.add_artist(circ)
 
@@ -196,22 +204,21 @@ proceeding with the default matplotlib backend"""
         if pol == "B":
             detcolor = (0.0, 0.0, 1.0, 1.0)
 
-        ax.arrow(xtail, ytail, dx, dy, width=0.1*detradius,
+        ax.arrow(ytail, xtail, dy, dx, width=0.1*detradius,
                  head_width=0.3*detradius, head_length=0.3*detradius,
                  fc=detcolor, ec="none", length_includes_head=True)
 
         if labels:
             # Compute the font size to use for detector labels
-            fontpix = 0.1 * detradius * ypixperdeg
-            ax.text((xpos), (ypos), pixel,
+            fontpix = 0.1 * detradius * hpixperdeg
+            ax.text(ypos, xpos, pixel,
                     color='k', fontsize=fontpix, horizontalalignment='center',
                     verticalalignment='center',
                     bbox=dict(fc='white', ec='none', pad=0.2, alpha=1.0))
-            xsgn = 1.0
-            if dx < 0.0:
-                xsgn = -1.0
-            labeloff = 1.0 * xsgn * fontpix * len(pol) / ypixperdeg
-            ax.text((xtail+1.0*dx+labeloff), (ytail+1.0*dy), pol,
+            labeloff = fontpix * len(pol) / hpixperdeg
+            if dy < 0:
+                labeloff = -labeloff
+            ax.text((ytail+1.0*dy+labeloff), (xtail+1.0*dx), pol,
                     color='k', fontsize=fontpix, horizontalalignment='center',
                     verticalalignment='center',
                     bbox=dict(fc='none', ec='none', pad=0, alpha=1.0))

--- a/tests/test_coords.py
+++ b/tests/test_coords.py
@@ -147,6 +147,27 @@ class CoordsUtilsTest(unittest.TestCase):
         self.assertIs(_valid_arg(tod.get('b')), None)
         self.assertIs(_valid_arg(tod.get('b'), 'a', src=tod), tod.a)
 
+    def test_toastish_quat(self):
+        test_array = np.array([[2,3,4,1],[90,100,23,14]])
+
+        # Convert one quat
+        qa = coords.ToastishQuat(test_array[0])
+        self.assertIsInstance(qa, np.ndarray)
+        q3 = qa.to_g3()
+        self.assertIsInstance(q3, so3g.proj.quat.quat)
+        self.assertEqual(q3.a, 1)
+        qb = coords.ToastishQuat(q3)
+        np.testing.assert_array_equal(qa, qb)
+
+        # Convert a vector of quats
+        qa = coords.ToastishQuat(test_array)
+        v3 = qa.to_g3()
+        self.assertIsInstance(v3, so3g.proj.quat.G3VectorQuat)
+        self.assertEqual(v3[0].a, 1)
+        self.assertEqual(v3[1].a, 14)
+        qb = coords.ToastishQuat(v3)
+        np.testing.assert_array_equal(qa, qb)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_coords.py
+++ b/tests/test_coords.py
@@ -147,25 +147,25 @@ class CoordsUtilsTest(unittest.TestCase):
         self.assertIs(_valid_arg(tod.get('b')), None)
         self.assertIs(_valid_arg(tod.get('b'), 'a', src=tod), tod.a)
 
-    def test_toastish_quat(self):
+    def test_scalar_last_quat(self):
         test_array = np.array([[2,3,4,1],[90,100,23,14]])
 
         # Convert one quat
-        qa = coords.ToastishQuat(test_array[0])
+        qa = coords.ScalarLastQuat(test_array[0])
         self.assertIsInstance(qa, np.ndarray)
         q3 = qa.to_g3()
         self.assertIsInstance(q3, so3g.proj.quat.quat)
         self.assertEqual(q3.a, 1)
-        qb = coords.ToastishQuat(q3)
+        qb = coords.ScalarLastQuat(q3)
         np.testing.assert_array_equal(qa, qb)
 
         # Convert a vector of quats
-        qa = coords.ToastishQuat(test_array)
+        qa = coords.ScalarLastQuat(test_array)
         v3 = qa.to_g3()
         self.assertIsInstance(v3, so3g.proj.quat.G3VectorQuat)
         self.assertEqual(v3[0].a, 1)
         self.assertEqual(v3[1].a, 14)
-        qb = coords.ToastishQuat(v3)
+        qb = coords.ScalarLastQuat(v3)
         np.testing.assert_array_equal(qa, qb)
 
 


### PR DESCRIPTION
Resolves #157.

It was necessary to alter both the plotting code and the layout generation code.  Instead of totally rewriting all the layout code in a right-handed system, this rewrites the 'quat' field in the detector info, once everything is done.  The plotting code was fixed mostly by transposing X and Y in all matplotlib calls.  I tweaked some labeling and coordinate code along the way to address minor issues with the plotting that I noticed.

The plots produced by so_hardware_plot are unchanged, compared to before, except for small changes in the axis ranges and new wafer label sizes.  But the plots now do represent the focal plane as TOAST will use it.

To allow me to use G3 quat code I'm also putting in the "ToastishQuat" wrapper -- I had originally planned to put this into so3g.proj.quat but it is needed here now (and can be moved / duplicated there later).
