### PR TITLE
G3SuperTimestream support

### DIFF
--- a/sotodlib/io/load.py
+++ b/sotodlib/io/load.py
@@ -186,13 +186,22 @@ def unpack_frame_object(fo, field_request, streams, compression_info=None):
             assert(item.name == '*')  # That's the only wildcard we allow right now...
             to_remove.append(item)
             del streams[item.name]
-            for k in fo.keys():
-                to_add.append(Field(k))
-                to_add[-1].opts = item.opts
-                streams[k] = []
+            if isinstance(fo, so3g.G3SuperTimestream):
+                for k in fo.names:
+                    to_add.append(Field(k))
+                    to_add[-1].opts = item.opts
+                    streams[k] = []
+            else:
+                for k in fo.keys():
+                    to_add.append(Field(k))
+                    to_add[-1].opts = item.opts
+                    streams[k] = []
     for item in to_remove:
         field_request.remove(item)
     field_request.extend(to_add)
+
+    if isinstance(fo, so3g.G3SuperTimestream):
+        key_map = {k: i for i, k in enumerate(fo.names)}
 
     for item in field_request:
         if isinstance(item, FieldGroup):
@@ -205,9 +214,13 @@ def unpack_frame_object(fo, field_request, streams, compression_info=None):
             target = fo[item.name]
             unpack_frame_object(target, item, streams[item.name], comp_info)
             if item.timestamp_field is not None:
-                t0, t1, ns = target.start, target.stop, target.n_samples
-                t0, t1 = t0.time / g3core.G3Units.sec, t1.time / g3core.G3Units.sec
-                streams[item.timestamp_field].append(np.linspace(t0, t1, ns))
+                if isinstance(target, so3g.G3SuperTimestream):
+                    streams[item.timestamp_field].append(
+                        np.array(target.times) / g3core.G3Units.sec)
+                else:
+                    t0, t1, ns = target.start, target.stop, target.n_samples
+                    t0, t1 = t0.time / g3core.G3Units.sec, t1.time / g3core.G3Units.sec
+                    streams[item.timestamp_field].append(np.linspace(t0, t1, ns))
             continue
         # This is a simple field.
         item = Field.as_field(item)
@@ -224,7 +237,10 @@ def unpack_frame_object(fo, field_request, streams, compression_info=None):
             m, b = gain.get(key, 1.), offset.get(key, 0.)
             v = np.array(fo[key], dtype='float32') / m + b
         else:
-            v = np.array(fo[key])
+            if isinstance(fo, so3g.G3SuperTimestream):
+                v = fo.data[key_map[key]]
+            else:
+                v = np.array(fo[key])
         streams[key].append(v)
 
 def unpack_frames(filename, field_request, streams):

--- a/sotodlib/io/load.py
+++ b/sotodlib/io/load.py
@@ -31,6 +31,16 @@ from collections import OrderedDict
 
 from .. import core
 
+
+# Interim, Oct. 2021.  Wait a year, remove this caution.
+if hasattr(so3g, 'G3SuperTimestream'):
+    from so3g import G3SuperTimestream
+else:
+    class MockG3SuperTimestream(object):
+        pass
+    G3SuperTimestream = MockG3SuperTimestream
+
+
 class FieldGroup(list):
     """This is essentially a roadmap for decoding data from a
     G3FrameObject.  Each entry in this list is either a string, giving
@@ -186,7 +196,7 @@ def unpack_frame_object(fo, field_request, streams, compression_info=None):
             assert(item.name == '*')  # That's the only wildcard we allow right now...
             to_remove.append(item)
             del streams[item.name]
-            if isinstance(fo, so3g.G3SuperTimestream):
+            if isinstance(fo, G3SuperTimestream):
                 for k in fo.names:
                     to_add.append(Field(k))
                     to_add[-1].opts = item.opts
@@ -200,7 +210,7 @@ def unpack_frame_object(fo, field_request, streams, compression_info=None):
         field_request.remove(item)
     field_request.extend(to_add)
 
-    if isinstance(fo, so3g.G3SuperTimestream):
+    if isinstance(fo, G3SuperTimestream):
         key_map = {k: i for i, k in enumerate(fo.names)}
 
     for item in field_request:
@@ -214,7 +224,7 @@ def unpack_frame_object(fo, field_request, streams, compression_info=None):
             target = fo[item.name]
             unpack_frame_object(target, item, streams[item.name], comp_info)
             if item.timestamp_field is not None:
-                if isinstance(target, so3g.G3SuperTimestream):
+                if isinstance(target, G3SuperTimestream):
                     streams[item.timestamp_field].append(
                         np.array(target.times) / g3core.G3Units.sec)
                 else:
@@ -237,7 +247,7 @@ def unpack_frame_object(fo, field_request, streams, compression_info=None):
             m, b = gain.get(key, 1.), offset.get(key, 0.)
             v = np.array(fo[key], dtype='float32') / m + b
         else:
-            if isinstance(fo, so3g.G3SuperTimestream):
+            if isinstance(fo, G3SuperTimestream):
                 v = fo.data[key_map[key]]
             else:
                 v = np.array(fo[key])

--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -656,11 +656,22 @@ class G3tSmurf:
                              )
         
             data = frame.get('data')
+            sostream_version = frame.get('sostream_version', 0)
             if data is not None:
-                db_frame.n_samples = data.n_samples
-                db_frame.n_channels = len(data)
-                db_frame.start = dt.datetime.fromtimestamp(data.start.time / spt3g_core.G3Units.s)
-                db_frame.stop = dt.datetime.fromtimestamp(data.stop.time / spt3g_core.G3Units.s)
+                if sostream_version >= 2:  # Using SuperTimestreams
+                    db_frame.n_channels = len(data.names)
+                    db_frame.n_samples = len(data.times)
+                    db_frame.start = dt.datetime.fromtimestamp(
+                        data.times[0].time / spt3g_core.G3Units.s
+                    )
+                    db_frame.stop = dt.datetime.fromtimestamp(
+                        data.times[-1].time / spt3g_core.G3Units.s
+                    )
+                else:
+                    db_frame.n_samples = data.n_samples
+                    db_frame.n_channels = len(data)
+                    db_frame.start = dt.datetime.fromtimestamp(data.start.time / spt3g_core.G3Units.s)
+                    db_frame.stop = dt.datetime.fromtimestamp(data.stop.time / spt3g_core.G3Units.s)
 
                 if file_start is None:
                     file_start = db_frame.start


### PR DESCRIPTION
Preliminary work to support using G3SuperTimestream (in development in so3g) in the place of G3TimestreamMap in our data files.  This should still work fine with old so3g, when processing old data.  But if so3g has G3SuperTimestream, this can extract data from files where G3SuperTimestream has been subbed in.

This has only been tested on "load_smurf" compatible data files... the pipe-s0001 or similar format has additional complexity such that we should probably just write a new schema and extractor for it when we go to G3SuperTimestream.