### PR TITLE
Update G3tSmurf databases to better match Obsfiledb

### DIFF
--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -88,8 +88,8 @@ class Observations(Base):
         yet.
     files : list of SQLAlchemy instances of Files
         The list of .g3 files in this observation built through a relationship
-        to the Files table. [f.path for f in Observation.files] will return
-        paths to all the files.
+        to the Files table. [f.name for f in Observation.files] will return
+        absolute paths to all the files.
     tunesets : list of SQLAlchemy instances of TuneSets 
         The TuneSets used in this observation. There is expected to be
         one per stream_id (SMuRF crate slot). 
@@ -1496,7 +1496,7 @@ class SmurfStatus:
         }
         cur_file = None
         for frame_info in tqdm(status_frames, disable=(not show_pb)):
-            file = frame_info.file.path
+            file = frame_info.file.name
             if file != cur_file:
                 reader = so3g.G3IndexedReader(file)
                 cur_file = file


### PR DESCRIPTION
Small-ish update to the Files table now that `Obsfiledb` works with absolute paths. Meaning more `Obsfiledb` features will work correctly.

Renames that `path` column to `name`, meaning `name` now contains for full absolute path to each file. 

This update requires an SQL update to existing G3tSmurf databases. Update script can be found here: https://github.com/simonsobs/pwg-scripts/blob/master/pwg-duf/g3tsmurf_obsabspath/change_file_name_path.sql

I recommend you:
1. Make a copy of your database, 
2. Run: 
```
prompt> sqlite3 your_copied_database.db < change_file_name_path.sql
```
3. Pull sotodlib changes. 
4. Connect to your copied database and check you can correctly make a session.
5. remove old database / rename as desired.