### PR TITLE
G3tsmurf Misc updates

### DIFF
--- a/pipelines/update_g3tsmurf_database.py
+++ b/pipelines/update_g3tsmurf_database.py
@@ -21,11 +21,11 @@ if __name__ == '__main__':
     
     parser.add_argument('--update-delay', help="Days to subtract from now to set as minimum ctime",
                                default=2, type=float)
-    parser.add_argument('--from_scratch', action="store_true")
+    parser.add_argument('--from-scratch', help="Builds or updates database from scratch",
+                        action="store_true")
     
     args = parser.parse_args()
     
-    print(args.__dict__)
     if args.timestream_folder is None:
         args.timestream_folder = os.path.join( args.data_prefix, 'timestreams/')
        

--- a/pipelines/update_g3tsmurf_database.py
+++ b/pipelines/update_g3tsmurf_database.py
@@ -1,0 +1,57 @@
+import os
+
+import datetime as dt
+import numpy as np
+import argparse
+
+from sotodlib.io.load_smurf import G3tSmurf, Observations, dump_DetDb
+
+
+if __name__ == '__main__':
+    
+    parser = argparse.ArgumentParser()
+    parser.add_argument('data_prefix', help="The prefix to data locations, use individual"
+                                            "locations flags if data is stored in non-standard folders")
+    parser.add_argument('db_path', help="Path to Database to update")
+    
+    parser.add_argument('--timestream-folder', help="Absolute path to folder with .g3 timestreams. Overrides data_prefix")
+    parser.add_argument('--smurf-folder', help="Absolute path to folder with pysmurf archived data. Overrides data_prefix")
+    
+    parser.add_argument('--detdb-filename', help="File for dumping the context detector database")
+    
+    parser.add_argument('--update-delay', help="Days to subtract from now to set as minimum ctime",
+                               default=2, type=float)
+    parser.add_argument('--from_scratch', action="store_true")
+    
+    args = parser.parse_args()
+    
+    print(args.__dict__)
+    if args.timestream_folder is None:
+        args.timestream_folder = os.path.join( args.data_prefix, 'timestreams/')
+       
+    if args.smurf_folder is None:
+        args.smurf_folder = os.path.join( args.data_prefix, 'smurf/')
+    
+    
+    SMURF = G3tSmurf(args.timestream_folder, 
+                     db_path=args.db_path,
+                     meta_path=args.smurf_folder)
+
+    if args.from_scratch:
+        print("Building Database from Scratch, May take awhile")
+        min_time = dt.datetime.utcfromtimestamp(int(1.6e9))
+    else:
+        min_time = dt.datetime.now() - dt.timedelta(days=args.update_delay)
+        
+    SMURF.index_archive(min_ctime=min_time.timestamp())
+    SMURF.index_metadata(min_ctime=min_time.timestamp())
+
+    session = SMURF.Session()
+
+    new_obs = session.query(Observations).filter( Observations.start >= min_time).all()
+    for obs in new_obs:
+        SMURF.update_observation_files(obs, session, force=True)
+
+    if args.detdb_filename is not None:
+        dump_DetDb(SMURF, args.detdb_filename)
+

--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -1107,7 +1107,7 @@ class G3tSmurf:
                                 ctime = int(name.split('_')[0])
                             except ValueError:
                                 ctime = actime
-                            fname = ('_'.join(name.split('_')[1:])).split('.')[0]
+                            fname = '_'.join(name.split('_')[1:])
                             yield (fname, stream_id, ctime, os.path.join(root, name))
                         except GeneratorExit:
                             return

--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -2019,7 +2019,7 @@ def load_file(filename, channels=None, ignore_missing=True,
         always have fields `timestamps`, `signal`, `flags`(FlagManager),
         `ch_info` (AxisManager with `bands`, `channels`, `frequency`, etc).
     """   
-    logger.info(f"Axis Manager will have {det_axis} and samps axes")
+    logger.debug(f"Axis Manager will have {det_axis} and samps axes")
  
     if isinstance(filename, str):
         filenames = [filename]

--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -1562,7 +1562,7 @@ class SmurfStatus:
         
         self._make_tags()
         
-    def _make_tags(self, delimiters=',|/|\\t| '):
+    def _make_tags(self, delimiters=',|\\t| '):
         """Build list of tags from SMuRF status
         """
         tags = self.status.get('AMCc.SmurfProcessor.SOStream.stream_tag')
@@ -1635,7 +1635,14 @@ class SmurfStatus:
         if stream_id is not None:
             q = q.join(Files).filter(Files.stream_id==stream_id)
         else:
-            logger.warning(f"No stream_id given for finding status, not checking for one")
+            sids = archive._stream_ids_in_range(q[0].time, time)
+            if len(sids) > 1:
+                raise ValueError(
+                    "Multiple stream_ids exist in the given range! "
+                    "Must choose one to load SmurfStatus.\n"
+                    f"stream_ids: {sids}"
+                )
+        
         if q.count()==0:
             logger.error(f"No Frames found before time: {time}, stream_id: {stream_id}")
         

--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -121,9 +121,9 @@ class Tags(Base):
     """Tags used to mark Observations.
     
     To have these automatically added, use
-    stream_g3_on( S, tag= 'tag1,tag2')
+    sodetlib.smurf_funct.smurf_ops.stream_g3_on( S, tag= 'tag1,tag2')
     or 
-    take_g3_data(S, dur, tag='tag1,tag2')
+    sodetlib.smurf_funct.smurf_ops.take_g3_data(S, dur, tag='tag1,tag2')
     
     Note, this table is not relationally mapped to the Observation.tag column.
         It is set up to match the Context design

--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -1607,7 +1607,7 @@ def get_channel_mask(ch_list, status, archive=None, obsfiledb=None,
                 if session is not None:
                     channel = session.query(Channels).filter(Channels.name==ch).one_or_none()
                     if channel is None:
-                        if not ignore_mission:
+                        if not ignore_missing:
                             raise ValueError(f"channel {ch} not found in G3tSmurf Archive")
                         continue
                     b,c = channel.band, channel.channel
@@ -1615,7 +1615,7 @@ def get_channel_mask(ch_list, status, archive=None, obsfiledb=None,
                     c = obsfiledb.conn.execute('select band,channel from channels where name=?',(ch,))
                     c = [(r[0],r[1]) for r in c]
                     if len(c) == 0:
-                        if not ignore_mission:
+                        if not ignore_missing:
                             raise ValueError(f"channel {ch} not found in obsfiledb")
                         continue
                     b,c = c[0]


### PR DESCRIPTION
This PR fixes a laundry list of issues:  #170 , #160, #137 , #173, #138, #135

Nothing should be breaking existing code. 

highlights:
1. Adds tag tracking to observations, automatically applying tags set at the time of taking the data
2. Adds some new generators that makes it easier to search through the SMuRF folder for things
3. Adds an "official" database update script into pipelines so we can standardize how that's called
4. Many bug fixes.

