### PR TITLE
single metadata edge case

### DIFF
--- a/sotodlib/core/context.py
+++ b/sotodlib/core/context.py
@@ -247,8 +247,9 @@ class Context(odict):
         # Load metadata.
         metadata_list = self._get_warn_missing('metadata', [])
         # edge case when only one entry in metadata
-        if type(metadata_list) == dict:
-            metadata_list=[metadata_list]
+        if not isinstance(metadata_list, list):
+            raise ValueError(f"Expected metadata list not {type(metadata_list)}."
+                             " Check .yaml Formatting")
         meta = self.loader.load(metadata_list, request)
 
         # Load TOD.

--- a/sotodlib/core/context.py
+++ b/sotodlib/core/context.py
@@ -246,6 +246,9 @@ class Context(odict):
 
         # Load metadata.
         metadata_list = self._get_warn_missing('metadata', [])
+        # edge case when only one entry in metadata
+        if type(metadata_list) == dict:
+            metadata_list=[metadata_list]
         meta = self.loader.load(metadata_list, request)
 
         # Load TOD.

--- a/sotodlib/core/context.py
+++ b/sotodlib/core/context.py
@@ -247,8 +247,8 @@ class Context(odict):
         # Load metadata.
         metadata_list = self._get_warn_missing('metadata', [])
         if not isinstance(metadata_list, list):
-            raise ValueError(f"Expected metadata list not {type(metadata_list)}."
-                             " Check .yaml Formatting")
+            raise ValueError(f"Context metadata entry has type {type(metadata_list)} "
+                            "but should be a list. Check .yaml formatting")
         meta = self.loader.load(metadata_list, request)
 
         # Load TOD.

--- a/sotodlib/core/context.py
+++ b/sotodlib/core/context.py
@@ -246,7 +246,6 @@ class Context(odict):
 
         # Load metadata.
         metadata_list = self._get_warn_missing('metadata', [])
-        # edge case when only one entry in metadata
         if not isinstance(metadata_list, list):
             raise ValueError(f"Expected metadata list not {type(metadata_list)}."
                              " Check .yaml Formatting")


### PR DESCRIPTION
@mhasself  I'm not sure if this is how you'd like to fix it. But I found an edge case in context where if there's only one listed metadata entry to loaders fail. `SuperLoader.load( spec_list, request)` expects as list for `spec_list` and with one metadata entry it's just getting that single dictionary. 