### PR TITLE
Adding fix to load_file to load status from start of an observation

### DIFF
--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -2086,7 +2086,16 @@ def load_file(filename, channels=None, ignore_missing=True,
         logger.error("No files provided to load")
     
     if status is None:
-        status = SmurfStatus.from_file(filenames[0])
+        try:    
+            logger.warning('Loading status frame from the file at the start'
+                            ' of the corresponding observation.')
+            file_id = filenames[0].split('/')[-1][10:]
+            status_fp = filenames[0].replace(file_id, '_000.g3')
+            status = SmurfStatus.from_file(status_fp)
+        except Exception as e:
+            logger.error(f'Error when trying to load status from {status_fp}, maybe the file doesn\'t exist?'
+                          'Please load the status manually.')
+            raise e
 
     if channels is not None:
         ch_mask = get_channel_mask(channels, status, archive=archive, 


### PR DESCRIPTION
Adds functionality in load_file so if a user tries to load a g3 file from the middle of an observation, it loads the full status information from the g3 file at the start of the observation. If this fails because of reasons (most likely it tries to load a file that doesn't exist), provides an error message and raises an exception. Closes https://github.com/simonsobs/sotodlib/issues/182, but does not address obsfiledb things yet, but can easily add this (just wasn't sure what was necessary right now). Tested this on a variety of observations and it had no problems, but happy to add more if necessary. 