### PR TITLE
Update installation dependencies and add requirements to setup.py

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -34,7 +34,6 @@ Create a new conda environment::
   %> conda create --copy -m -p ${HOME}/software/so
   %> conda activate ~/software/so
   %> conda install pip numpy scipy matplotlib
-  %> pip install quaternionarray
 
 ... Or Use Virtualenv and Pip
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -46,10 +45,8 @@ it::
   %> virtualenv -p python3 ${HOME}/software/so
   %> source ${HOME}/software/so/bin/activate
 
-Now use pip to install the dependencies we need::
-
-    %> pip install numpy scipy matplotlib
-    %> pip install quaternionarray
+pip installable external dependencies will be automatically installed when pip
+installing the sotodlib package.
 
 
 S.O. Affiliated Dependencies

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -56,8 +56,13 @@ Activate / load your python stack from the previous section.  Since you created
 a conda environment or virtualenv directory specifically for S.O. tools, you
 can always delete that directory and make a new one as needed.
 
-Currently the sotodlib package does not require any other S.O. packages.  In
-the future, it will require sotoddb and so3g as dependencies.
+sotodlib requires the following affiliated packages:
+
+- `so3g`_
+- `spt3g_software`_
+
+.. _so3g: https://github.com/simonsobs/so3g
+.. _spt3g_software: https://github.com/CMB-S4/spt3g_software
 
 
 Installing sotodlib

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup_opts["author_email"] = "so_software@simonsobservatory.org"
 setup_opts["url"] = "https://github.com/simonsobs/sotodlib"
 setup_opts["packages"] = find_packages(where=".", exclude="tests")
 setup_opts["license"] = "MIT"
-setup_opts["requires"] = ["Python (>3.4.0)", ]
+setup_opts["requires"] = ["Python (>3.7.0)", ]
 setup_opts["scripts"] = pipes
 setup_opts["include_package_data"] = True
 setup_opts["install_requires"] = [

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,9 @@ setup_opts["install_requires"] = [
     'matplotlib',
     'quaternionarray',
     'PyYAML',
+    'toml',
+    'skyfield',
+    'pixell',
 ]
 
 # Command Class dictionary.

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,13 @@ setup_opts["license"] = "MIT"
 setup_opts["requires"] = ["Python (>3.4.0)", ]
 setup_opts["scripts"] = pipes
 setup_opts["include_package_data"] = True
+setup_opts["install_requires"] = [
+    'numpy',
+    'scipy',
+    'matplotlib',
+    'quaternionarray',
+    'PyYAML',
+]
 
 # Command Class dictionary.
 # Begin with the versioneer command class dictionary.


### PR DESCRIPTION
## Description
This PR adds the required packages (that I know of anyway) to the `install_requires` option within `setup.py`. I also updated the intro docs page for installation. 

The thing this doesn't really solve (and I'm not sure it should) is providing any description of installing spt3g/so3g within conda. If a new sotodlib user chooses to use conda, then they might run into difficulty there.

## Motivation
This was motivated by a user installing sotodlib, but finding so3g and PyYAML to be missing. They pointed out that the docs didn't list so3g as a requirement.

I took the approach of adding to setup.py since it should reduce the need for the user to manually install packages, as the dependencies will be checked and installed when running `pip install .` to install sotodlib.

For conda users, I believe they should still install packages available via conda manually first, then pip will make sure remaining packages are installed.

## Testing
I tested this by installing sotdolib with both pip and conda on a clean Ubuntu 20.04 system. The only packages I find missing now when running the tests are spt3g and so3g (so I don't think I'm missing any in the list added to `setup.py`.)