### PR TITLE
Context tuneup

### DIFF
--- a/docs/context.rst
+++ b/docs/context.rst
@@ -204,7 +204,8 @@ Context system:
 ``obs_loader_type``
     A string, giving the name of a loader function that should be used
     to load the TOD.  The functions are registered in the module
-    variable ``sotodlib.io.load.OBSLOADER_REGISTRY``.
+    variable ``sotodlib.core.OBSLOADER_REGISTRY``; also see
+    :func:`sotodlib.core.context.obsloader_template`.
 
 ``metadata``
 
@@ -252,6 +253,16 @@ Context
 .. autoclass:: Context
    :special-members: __init__
    :members:
+
+obsloader
+---------
+
+Data formats are abstracted in the Context system, and "obsloader"
+functions provide the implementations to load data for a particular
+storage format.  The API is documented in the ``obsloader_template``
+function:
+
+.. autofunction:: sotodlib.core.context.obsloader_template
 
 SuperLoader
 -----------

--- a/sotodlib/core/__init__.py
+++ b/sotodlib/core/__init__.py
@@ -5,7 +5,7 @@
 This module has containers and in-memory structures for data and metadata.
 
 """
-from .context import Context
+from .context import Context, OBSLOADER_REGISTRY
 
 from .axisman import AxisManager
 from .axisman import IndexAxis, OffsetAxis, LabelAxis

--- a/sotodlib/core/axisman.py
+++ b/sotodlib/core/axisman.py
@@ -672,7 +672,7 @@ class AxisManager:
         Axis.  The Axis definition and all data fields mapped to that
         axis will be modified.
         
-        Arugments:
+        Arguments:
           axis_name (str): The name of the Axis.
           selector (slice or special): Selector, in a form understood
             by the underlying Axis class (see the .restriction method

--- a/sotodlib/core/context.py
+++ b/sotodlib/core/context.py
@@ -167,7 +167,7 @@ class Context(odict):
                 = metadata.SuperLoader(self)
 
     def get_obs(self, obs_id=None, dets=None, detsets=None,
-                loader_type=None, logic_only=False):
+                loader_type=None, logic_only=False, filename=None):
         """Load TOD and supporting metadata for a particular observation id.
         The detectors to read can be specified through colon-coding in
         obs_id, through dets, or through detsets.
@@ -177,6 +177,15 @@ class Context(odict):
 
         """
         detspec = {}
+
+        if filename is not None:
+            if obs_id is not None or detsets is not None:
+                logger.warning(f'Passing filename={filename} to get_obs causes '
+                               f'obs_id={obs_id} and detsets={detsets} to be ignored.')
+            # Resolve this to an obs_id / detset combo.
+            info = self.obsfiledb.lookup_file(filename, prefix='', resolve_paths=False)
+            obs_id = info['obs_id']
+            detsets = info['detsets']
 
         # Handle the case that this is a row from a obsdb query.
         if isinstance(obs_id, dict):

--- a/sotodlib/core/context.py
+++ b/sotodlib/core/context.py
@@ -220,7 +220,7 @@ class Context(odict):
                                      'in re-restriction on property "%s"' % (t, prop))
                 detspec[prop] = t
 
-        # Start the list of detector selectors.
+        # Start a list of det specs ... see DetDb.intersect.
         dets_selection = [detspec]
 
         # Did user give a list of dets (or detspec)?
@@ -244,8 +244,24 @@ class Context(odict):
 
         # Make the final list of dets -- force resolve it to a list,
         # not a detspec.
-        dets = self.detdb.intersect(*dets_selection,
-                                    resolve=True)
+        if self.detdb is None:
+            # Try to resolve this without a DetDb (if you do this
+            # better, maybe make it a static method of DetDb.
+            dets = None
+            for ds in dets_selection:
+                if isinstance(ds, dict):
+                    if len(ds) != 0:
+                        raise ValueError("Complex det request can't be processed "
+                                         "without a detdb; spec=f{dets_selection}")
+                else:
+                    if dets is None:
+                        dets = set(ds)
+                    else:
+                        dets.intersection_update(ds)
+            dets = list(dets)
+        else:
+            dets = self.detdb.intersect(*dets_selection,
+                                        resolve=True)
 
         # The request to the metadata loader should include obs_id and
         # the detector selection.

--- a/sotodlib/core/metadata/loader.py
+++ b/sotodlib/core/metadata/loader.py
@@ -8,7 +8,9 @@ REGISTRY = {
 
 class SuperLoader:
     def __init__(self, context=None, detdb=None, obsdb=None, working_dir=None):
-        """Args:
+        """Metadata batch loader.
+
+        Args:
           context (Context): context, from which detdb and obsdb will
             be pulled unless they are specified explicitly.
           detdb (DetDb): detdb to use when resolving detector axis.

--- a/sotodlib/core/metadata/loader.py
+++ b/sotodlib/core/metadata/loader.py
@@ -172,6 +172,9 @@ class SuperLoader:
                 loader_object = loader_class(detdb=self.detdb, obsdb=self.obsdb)
                 mi1 = loader_object.from_loadspec(index_line)
                 # restrict to index_line...
+                if (self.detdb is None and
+                    len([k for k in index_line if k.startswith('dets:')])):
+                    raise ValueError(f"Metadata not loadable without detdb: {index_line}")
                 mi2 = mi1.restrict_dets(index_line, detdb=self.detdb)
                 results.append(mi2)
 

--- a/sotodlib/core/metadata/obsfiledb.py
+++ b/sotodlib/core/metadata/obsfiledb.py
@@ -260,7 +260,69 @@ class ObsFileDb:
             output[r[0]].append((os.path.join(prefix, r[1]), r[2], r[3]))
         return output
 
+    def lookup_file(self, filename, resolve_paths=True, prefix=None, fail_ok=False):
+        """Determine what, if any, obs_id (and detset and sample range) is
+        associated with the specified data file.
+
+        Args:
+          filename (str): a string corresponding to a file that is
+            covered by this db.  See note on how this is resolved.
+          resolve_paths (bool): If True, then the incoming filename is
+            treated as a path to a specific file on disk, and the
+            database is queried for files that also resolve to that
+            are equivalent to that same file on disk (accounting for
+            prefix).  If False, then the incoming filename is taken as
+            opaque text to match against the corresponding entries in
+            the obsfiledb file "name" column (including whatever path
+            information is in either of those strings).
+          fail_ok (bool): If True, then None is returned if the
+            filename is not found in the db (instead of raising
+            RuntimeError).
+
+        Returns:
+          A dict with entries:
+          - ``obs_id``: The obs_id
+          - ``detsets``: A list containing the name of the single detset
+            covered by this file.
+          - ``sample_range``: A tuple with the start and stop sample
+            indices for this file.
+
+        """
+        if prefix is None:
+            prefix = self.prefix
+
+        if resolve_paths:
+            # Clarify our target ...
+            filename = os.path.realpath(filename)
+            basename = os.path.split(filename)[1]
+            # Do a non-conclusive match against the basename ...
+            c = self.conn.execute(
+                'select name, obs_id, detset, sample_start, sample_stop '
+                'from files where name like ?', ('%' + basename, ))
+            rows = c.fetchall()
+            # Keep only the rows that are definitely our target file.
+            rows = [r for r in rows if os.path.realpath(prefix + r[0]) == filename]
+        else:
+            # Do literal exact matching of filename to database.
+            c = self.conn.execute(
+                'select name, obs_id, detset, sample_start, sample_stop '
+                'from files where name=?', (filename, ))
+            rows = c.fetchall()
+
+        if len(rows) == 0:
+            if fail_ok:
+                return None
+            raise RuntimeError('No match found for "%s"' % filename)
+        if len(rows) > 1:
+            raise RuntimeError('Multiple matches found for "%s"' % filename)
+        _, obs_id, detset, start, stop = tuple(rows[0])
+
+        return {'obs_id': obs_id,
+                'detsets': [detset],
+                'sample_range': (start, stop)}
+
     def verify(self, prefix=None):
+
         """Check the filesystem for the presence of files described in the
         database.  Returns a dictionary containing this information in
         various forms; see code for details.

--- a/sotodlib/core/metadata/obsfiledb.py
+++ b/sotodlib/core/metadata/obsfiledb.py
@@ -54,8 +54,9 @@ class ObsFileDb:
     #: The sqlite3 database connection.
     conn = None
 
-    #: The filename prefix to apply to all filename results returned
-    #: from this database.
+    #: Path relative to which filenames in the database should be
+    #: interpreted.  This only applies to relative filenames (those not
+    #: starting with /).
     prefix = ''
 
     def __init__(self, map_file=None, prefix=None, init_db=True, readonly=False):
@@ -301,7 +302,8 @@ class ObsFileDb:
                 'from files where name like ?', ('%' + basename, ))
             rows = c.fetchall()
             # Keep only the rows that are definitely our target file.
-            rows = [r for r in rows if os.path.realpath(prefix + r[0]) == filename]
+            rows = [r for r in rows
+                    if os.path.realpath(os.path.join(prefix, r[0])) == filename]
         else:
             # Do literal exact matching of filename to database.
             c = self.conn.execute(

--- a/sotodlib/g3_condition.py
+++ b/sotodlib/g3_condition.py
@@ -4,9 +4,6 @@
 
 This module contains code for conditioning G3Timestream data in G3Frames
 
-Attributes:
-    MeanSubtract (DataG3Module): Inline definition for mean subtracting data
-    MedianSubtract (DataG3Module): Inline definition for median subtracting data
 """
 import numpy as np
 import scipy.signal as signal

--- a/sotodlib/io/load.py
+++ b/sotodlib/io/load.py
@@ -412,31 +412,18 @@ def load_file(filename, dets=None, signal_only=False):
     return aman
 
 
-def load_observation(db, obs_id, dets=None, prefix=None, samples=None,
+def load_observation(db, obs_id, dets=None, samples=None, prefix=None,
                      **kwargs):
-    """Load the data for some observation.  You can restrict to only some
-    detectors. Coming soon: also restrict by time range / sample
-    index.
+    """Obsloader function for TOAST simulate data -- this function matches
+    output from pipe-s0001/s0002 (and SSO sims in 2019-2021).
 
-    This specifically targets the pipe-s0001/s0002 sim format.
-
-    Arguments:
-
-      db (ObsFileDb): The database describing this observation file
-        set.
-      obs_id (str): The identifier of the observation.
-      dets (list of str): The detector names of interest.  If None,
-        loads all dets present in this observation.  To load
-        only the ancillary data, pass an empty list.
-      prefix (str): The root address of the data files.  If not
-        specified, the prefix is taken from the ObsFileDb.
-
-    Returns an AxisManager with the data.
+    See API template, `sotodlib.core.context.obsloader_template`, for
+    details.
 
     """
-    if len(kwargs):
-        raise ValueError("This loader function received unimplemented args:"
-                         f"{kwargs}")
+    if any([v is not None for v in kwargs.values()]):
+        raise RuntimeError(
+            f"This loader function does not understand kwargs: f{kwargs}")
 
     if prefix is None:
         prefix = db.prefix
@@ -574,18 +561,14 @@ def hstack_into(dest, src_arrays):
     return dest
 
 
-#: OBSLOADER_REGISTRY will be accessed by the Context system to load
-#: TOD.  The signature of functions here is:
-#:
-#:  loader(db, obs_id, dets=None, prefix=None)
-#:
-#: Here db is an ObsFileDb, obs_id is a string, dets is a list of
-#: string names of readout channels, and prefix is a string that overrides
-#: the path prefix of ObsFileDb.
-#:
-#: "This is an interim solution and the API will change", he said in
-#: March 2020.
-OBSLOADER_REGISTRY = {
-    'pipe-s0001': load_observation,
-    'default': load_observation,
+# Register the loaders defined here.
+core.OBSLOADER_REGISTRY.update(
+    {
+        'pipe-s0001': load_observation,
+        'default': load_observation,
     }
+)
+
+
+# Deprecated alias (used to live here...)
+OBSLOADER_REGISTRY = core.OBSLOADER_REGISTRY

--- a/sotodlib/io/load.py
+++ b/sotodlib/io/load.py
@@ -163,10 +163,11 @@ class FieldGroup(list):
                 dest[k] = src[k]
 
 class Field:
-    def __init__(self, name, optional=False, wildcard=False):
+    def __init__(self, name, optional=False, wildcard=False, oversample=1):
         self.name = name
         self.wildcard = wildcard
         self.opts = {'optional': optional}
+        self.oversample = oversample
 
     @staticmethod
     def as_field(item):
@@ -177,7 +178,8 @@ class Field:
         raise TypeError('Cannot promote %s to Field.' % item)
 
 
-def unpack_frame_object(fo, field_request, streams, compression_info=None):
+def unpack_frame_object(fo, field_request, streams, compression_info=None,
+                        offset=0, max_count=None):
     """Unpack requested fields from a G3FrameObject, and update a data structure.
     
     Arguments:
@@ -213,24 +215,36 @@ def unpack_frame_object(fo, field_request, streams, compression_info=None):
     if isinstance(fo, G3SuperTimestream):
         key_map = {k: i for i, k in enumerate(fo.names)}
 
+    def our_slice(n, oversamp):
+        # returns (range size, slice)
+        if n <= offset:
+            return 0, slice(0, 0)
+        n = n - offset
+        if max_count is not None:
+            n = min(n, max_count)
+        return n, slice(offset * oversamp, (offset + n) * oversamp)
+
+    _consumed = 0
     for item in field_request:
         if isinstance(item, FieldGroup):
             if item.compression:
-                gain = fo.get('compressor_gain_%s' % item.name, {})
-                offset = fo.get('compressor_offset_%s' % item.name, {})
-                comp_info = (gain, offset)
+                _gain = fo.get('compressor_gain_%s' % item.name, {})
+                _offset = fo.get('compressor_offset_%s' % item.name, {})
+                comp_info = (_gain, _offset)
             else:
                 comp_info = None
             target = fo[item.name]
-            unpack_frame_object(target, item, streams[item.name], comp_info)
-            if item.timestamp_field is not None:
+            _consumed = unpack_frame_object(target, item, streams[item.name], comp_info,
+                                            offset=offset, max_count=max_count)
+            _n, sl = our_slice(_consumed, 1)
+            if _n > 0 and  item.timestamp_field is not None:
                 if isinstance(target, G3SuperTimestream):
                     streams[item.timestamp_field].append(
-                        np.array(target.times) / g3core.G3Units.sec)
+                        np.array(target.times)[sl] / g3core.G3Units.sec)
                 else:
                     t0, t1, ns = target.start, target.stop, target.n_samples
                     t0, t1 = t0.time / g3core.G3Units.sec, t1.time / g3core.G3Units.sec
-                    streams[item.timestamp_field].append(np.linspace(t0, t1, ns))
+                    streams[item.timestamp_field].append(np.linspace(t0, t1, ns)[sl])
             continue
         # This is a simple field.
         item = Field.as_field(item)
@@ -243,17 +257,21 @@ def unpack_frame_object(fo, field_request, streams, compression_info=None):
                 assert(key not in streams)
                 continue
         if compression_info is not None:
-            gain, offset = compression_info
-            m, b = gain.get(key, 1.), offset.get(key, 0.)
+            _gain, _offset = compression_info
+            m, b = _gain.get(key, 1.), _offset.get(key, 0.)
             v = np.array(fo[key], dtype='float32') / m + b
         else:
             if isinstance(fo, G3SuperTimestream):
                 v = fo.data[key_map[key]]
             else:
                 v = np.array(fo[key])
-        streams[key].append(v)
+        _consumed = len(v) // item.oversample
+        _n, sl = our_slice(_consumed, item.oversample)
+        if _n:
+            streams[key].append(v[sl])
+    return _consumed
 
-def unpack_frames(filename, field_request, streams):
+def unpack_frames(filename, field_request, streams, samples=None):
     """Read frames from the specified file and expand the data by stream.
     Only the requested fields, specified through *_fields arguments,
     are expanded.
@@ -264,6 +282,9 @@ def unpack_frames(filename, field_request, streams):
       streams: Structure to which to append the
         streams from this file (perhaps obtained from running
         unpack_frames on a preceding file).
+      samples (int, int): Start and end of sample range to unpack
+        *from this file*.  First argument must be non-negative.  Second
+        argument may be None, indicating to read forever.
 
     Returns:
       streams (structure containing lists of numpy arrays).
@@ -271,15 +292,30 @@ def unpack_frames(filename, field_request, streams):
     """
     if streams is None:
         streams = field_request.empty()
+    if samples is None:
+        offset = 0
+        to_read = None
+    else:
+        offset, to_read = samples
+        if to_read is not None:
+            to_read -= offset
 
     reader = so3g.G3IndexedReader(filename)
-    while True:
+    while to_read is None or to_read > 0:
         frames = reader.Process(None)
         if len(frames) == 0:
             break
         frame = frames[0]
-        if frame.type == g3core.G3FrameType.Scan:
-            unpack_frame_object(frame, field_request, streams)
+        if frame.type != g3core.G3FrameType.Scan:
+            continue
+        _consumed = unpack_frame_object(
+            frame, field_request, streams, offset=offset, max_count=to_read)
+        offset -= _consumed
+        if offset < 0:
+            if to_read is not None:
+                to_read += offset
+            offset = 0
+
     return streams
 
 
@@ -309,10 +345,10 @@ def load_file(filename, dets=None, signal_only=False):
         FieldGroup('boresight', ['az', 'el', 'roll']),
         Field('hwp_angle', optional=True),
         Field('corotator_angle', optional=True),
-        'site_position',
-        'site_velocity',
-        'boresight_azel',
-        'boresight_radec',
+        Field('site_position', oversample=3),
+        Field('site_velocity', oversample=3),
+        Field('boresight_azel', oversample=4),
+        Field('boresight_radec', oversample=4),
     ])
     request = FieldGroup('root', subreq)
 
@@ -376,7 +412,8 @@ def load_file(filename, dets=None, signal_only=False):
     return aman
 
 
-def load_observation(db, obs_id, dets=None, prefix=None):
+def load_observation(db, obs_id, dets=None, prefix=None, samples=None,
+                     **kwargs):
     """Load the data for some observation.  You can restrict to only some
     detectors. Coming soon: also restrict by time range / sample
     index.
@@ -397,6 +434,10 @@ def load_observation(db, obs_id, dets=None, prefix=None):
     Returns an AxisManager with the data.
 
     """
+    if len(kwargs):
+        raise ValueError("This loader function received unimplemented args:"
+                         f"{kwargs}")
+
     if prefix is None:
         prefix = db.prefix
         if prefix is None:
@@ -435,7 +476,8 @@ def load_observation(db, obs_id, dets=None, prefix=None):
     aman = None
 
     for detset, dets in dets_by_detset.items():
-        c = db.conn.execute('select name from files '
+        c = db.conn.execute('select name, sample_start, sample_stop '
+                            'from files '
                             'where obs_id=? and detset=? ' +
                             'order by sample_start', (obs_id, detset))
         subreq = [
@@ -447,24 +489,36 @@ def load_observation(db, obs_id, dets=None, prefix=None):
                 FieldGroup('boresight', ['az', 'el', 'roll']),
                 Field('hwp_angle', optional=True),
                 Field('corotator_angle', optional=True),
-                'site_position',
-                'site_velocity',
-                'boresight_azel',
-                'boresight_radec',
+                Field('site_position', oversample=3),
+                Field('site_velocity', oversample=3),
+                Field('boresight_azel', oversample=4),
+                Field('boresight_radec', oversample=4),
             ])
         request = FieldGroup('root', subreq)
 
+        if samples:
+            sample_start, sample_stop = samples
+        else:
+            sample_start, sample_stop = 0, None
+
+        stop = sample_stop
+
         streams = None
         for row in c:
-            f = row[0]
-            streams = unpack_frames(prefix+f, request, streams)
+            f, file_start, file_stop = row
+            assert(file_start is not None)
+            start = max(0, sample_start - file_start)
+            if sample_stop is not None:
+                stop = sample_stop - file_start
+            streams = unpack_frames(
+                prefix+f, request, streams, samples=(start, stop))
 
         if aman is None:
             # Create AxisManager now that we know the sample count.
             count = sum(map(len,streams['timestamps']))
             aman = core.AxisManager(
                 core.LabelAxis('dets', [p[1] for p in pairs_req]),
-                core.OffsetAxis('samps', count, 0, obs_id),
+                core.OffsetAxis('samps', count, sample_start, obs_id),
             )
             aman.wrap('signal', np.zeros(aman.shape, 'float32'),
                       [(0, 'dets'), (1, 'samps')])

--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -1769,6 +1769,9 @@ def load_file(filename, channels=None, ignore_missing=True,
             raise e
 
     if channels is not None:
+        if len(channels) == 0:
+            logger.error("Requested empty list of channels. Use channels=None to "
+                         "load all channels.")
         ch_mask = get_channel_mask(channels, status, archive=archive, 
                                    obsfiledb=obsfiledb,
                                    ignore_missing=ignore_missing)

--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -1834,7 +1834,16 @@ def load_file(filename, channels=None, ignore_missing=True,
 
     return aman
 
-def load_g3tsmurf_obs(db, obs_id, dets=None):
+def load_g3tsmurf_obs(db, obs_id, dets=None, **kwargs):
+    """Obsloader function for g3tsmurf data archives.
+
+    See API template, `sotodlib.core.context.obsloader_template`, for
+    details.
+
+    """
+    if any([v is not None for v in kwargs.values()]):
+        raise RuntimeError(
+            f"This loader function does not understand kwargs: f{kwargs}")
     c = db.conn.execute('select name from files '
                     'where obs_id=?' +
                     'order by start', (obs_id,))
@@ -1842,5 +1851,5 @@ def load_g3tsmurf_obs(db, obs_id, dets=None):
     return load_file(flist, dets, obsfiledb=db)
 
 
-io_load.OBSLOADER_REGISTRY['g3tsmurf'] = load_g3tsmurf_obs
+core.OBSLOADER_REGISTRY['g3tsmurf'] = load_g3tsmurf_obs
 

--- a/tests/test_obsfiledb.py
+++ b/tests/test_obsfiledb.py
@@ -114,5 +114,24 @@ class TestObsFileDB(unittest.TestCase):
         results = db.verify()
         assert(all([r[0] for r in results['raw']]))
 
+    def test_040_lookups(self):
+        db = self.get_simple_db(prepath='somewhere/else/')
+        target = 'somewhere/else/obs0_group0_0000.g3'
+        for item, result in enumerate([
+                db.lookup_file(target, resolve_paths=False),
+                db.lookup_file(self.test_dir + target),
+                db.lookup_file(self.test_dir + target, resolve_paths=True),
+                db.lookup_file('x/' + target, prefix='x/'),
+                db.lookup_file('notx/../x/' + target, prefix='x/'),
+                ]):
+            self.assertEqual(result['obs_id'], 'obs0', 'Subcase #%i' % item)
+
+        assert(db.lookup_file('obsXYZ_.g3', fail_ok=True) is None)
+        with self.assertRaises(RuntimeError):
+            db.lookup_file('obsXYZ_.g3')
+        with self.assertRaises(RuntimeError):
+            db.lookup_file('notx/../x/' + target, resolve_paths=False)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_obsfiledb.py
+++ b/tests/test_obsfiledb.py
@@ -119,8 +119,8 @@ class TestObsFileDB(unittest.TestCase):
         target = 'somewhere/else/obs0_group0_0000.g3'
         for item, result in enumerate([
                 db.lookup_file(target, resolve_paths=False),
-                db.lookup_file(self.test_dir + target),
-                db.lookup_file(self.test_dir + target, resolve_paths=True),
+                db.lookup_file(self.test_dir + '/' + target),
+                db.lookup_file(self.test_dir + '/' + target, resolve_paths=True),
                 db.lookup_file('x/' + target, prefix='x/'),
                 db.lookup_file('notx/../x/' + target, prefix='x/'),
                 ]):


### PR DESCRIPTION
New features:
* samples argument to Context.get_obs
* better chance that get_obs can work in absence of a DetDb
* ObsFileDb.lookup_file enables Context.get_obs(filename=...)

Bug fix / reorganization:
* metadata is looked up relative to the metadata index (the database file)
* obsloader registry lives in context.py