### PR TITLE
Use static polarization weights, not celestial weights

### DIFF
--- a/sotodlib/toast/sim_hwpss.py
+++ b/sotodlib/toast/sim_hwpss.py
@@ -27,6 +27,10 @@ class OpSimHWPSS(toast.Operator):
             raise RuntimeError(f"{fname_hwpss} does not exist!")
         self.fname_hwpss = fname_hwpss
 
+        # theta is the incident angle, also known as the radial distance
+        #     to the boresight.
+        # chi is the HWP rotation angle
+
         with open(fname_hwpss, "rb") as fin:
             self.thetas, self.chis, self.all_stokes = pickle.load(fin)
 
@@ -56,25 +60,22 @@ class OpSimHWPSS(toast.Operator):
                 # Get incident angle
                 
                 det_quat = focalplane[det]["quat"]
-                theta, phi = qa.to_position(det_quat)
+                det_theta, det_phi, det_psi = qa.to_angles(det_quat)
                 
                 # Get observing elevation
                 
-                try:
-                    # Some TOD classes provide a shortcut to Az/El
-                    az, el = tod.read_azel(detector=det)
-                except Exception as e:
-                    azelquat = tod.read_pntg(detector=det, azel=True)
-                    el = np.pi / 2 - qa.to_position(azelquat)[0]
+                azelquat = tod.read_pntg(detector=det, azel=True)
+                el = np.pi / 2 - qa.to_position(azelquat)[0]
 
                 # Get polarization weights
 
-                weights = tod.cache.reference("weights_{}".format(det))
-                iweights, qweights, uweights = weights.T
+                iweights = np.ones(signal.size)
+                qweights = np.cos(2 * det_psi)
+                uweights = np.sin(2 * det_psi)
         
                 # Interpolate HWPSS to incident angle
 
-                theta_deg = np.degrees(theta)
+                theta_deg = np.degrees(det_theta)
                 itheta_high = np.searchsorted(self.thetas, theta_deg)
                 itheta_low = itheta_high - 1
 


### PR DESCRIPTION
This bug effectively made the HWPSS signal time-dependent. Many thanks to @Helbouha for reporting it!