### PR TITLE
G3t Smurf Add Sample Counting

### DIFF
--- a/sotodlib/io/load.py
+++ b/sotodlib/io/load.py
@@ -211,10 +211,10 @@ def unpack_frame_object(fo, field_request, streams, compression_info=None,
     for item in to_remove:
         field_request.remove(item)
     field_request.extend(to_add)
-
+    
     if isinstance(fo, G3SuperTimestream):
         key_map = {k: i for i, k in enumerate(fo.names)}
-
+        
     def our_slice(n, oversamp):
         # returns (range size, slice)
         if n <= offset:
@@ -237,12 +237,11 @@ def unpack_frame_object(fo, field_request, streams, compression_info=None,
             _consumed = unpack_frame_object(target, item, streams[item.name], comp_info,
                                             offset=offset, max_count=max_count)
             _n, sl = our_slice(_consumed, 1)
-
             # Check and slice timestamp field independently -- must
             # work even if no dets requested led to _n=0 above.
             if item.timestamp_field is not None:
                 if isinstance(target, G3SuperTimestream):
-                    timesv = np.array(target.times)[sl] / g3core.G3Units.sec
+                    timesv = np.array(target.times) / g3core.G3Units.sec
                 else:
                     t0, t1, ns = target.start, target.stop, target.n_samples
                     t0, t1 = t0.time / g3core.G3Units.sec, t1.time / g3core.G3Units.sec
@@ -272,6 +271,7 @@ def unpack_frame_object(fo, field_request, streams, compression_info=None,
                 v = np.array(fo[key])
         _consumed = len(v) // item.oversample
         _n, sl = our_slice(_consumed, item.oversample)
+
         if _n:
             streams[key].append(v[sl])
     return _consumed

--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -935,7 +935,7 @@ class G3tSmurf:
 
     def lookup_file(self, filename, fail_ok=False):
         """Lookup a file's observations details in database. Meant to look
-        and act like core.metadata.obsfiledb.lookup_file
+        and act like core.metadata.obsfiledb.lookup_file.
         """
         session = self.Session()
         file = session.query(Files).filter(Files.name==filename).one_or_none()
@@ -945,7 +945,7 @@ class G3tSmurf:
             return None
 
         return { 'obs_id': file.obs_id,
-                 'detsets' : file.detset,
+                 'detsets' : [file.detset],
                  'sample_range' :(file.sample_start, file.sample_stop)}
 
     def _stream_ids_in_range(self, start, end):
@@ -1704,7 +1704,9 @@ def get_channel_info(status, mask=None, archive=None, obsfiledb=None,
     return ch_info
 
 def _get_sample_info(filenames):
-    """Scan through a list of files and count samples.
+    """Scan through a list of files and count samples. Starts counting
+    from the first file in the list. Used in load_file for sample restiction
+    if no database connection is available.
     
     Args
     -----
@@ -1715,7 +1717,8 @@ def _get_sample_info(filenames):
     --------
     out : list
         a list of dictionaries formatted for load_file. 
-        in the pattern of [ {filename: filename, sample_range: (sample_start, sample_stop)}]
+        in the pattern of [ {filename: filename, 
+                            sample_range: (sample_start, sample_stop)}]
     """
     out = []
     start = 0


### PR DESCRIPTION
This implements the new Context loading over a sample range for the G3tSmurf loaders. I went ahead and implemented things so that a sample range could be passed to `load_file` with both database backends or with no connection to a database. (The "no database" version is pretty inefficient but I decided I wasn't going to be too worried about that case.)

Doing this I realized I'd messed up the sample counting in a previous update so I've fixed that here. And since that requires fixing already existing databases I went ahead and also added the first half of the "end of observation" fixing discussed in this issue: https://github.com/simonsobs/sotodlib/issues/224 

I believe this should close #193, and #178

### So to Update existing observation/file entries (something to run overnight):
```
from sotodlib.io.load_smurf import G3tSmurf, Observations
from tqdm import tqdm

SMURF = G3tSmurf( wherever )

session = SMURF.Session()
obs_list = session.query(Observations).all()

for obs in tqdm(obs_list, total=len(obs_list)):
    try:
        SMURF.update_observation_files(obs, session, force=True)
    except:
        print(f"Failed on {obs.obs_id}")
        session.rollback()
```