### PR TITLE
Bugfix for multiple channel assignments in the same folder

### DIFF
--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -958,12 +958,12 @@ class G3tSmurf:
                     # decide if this is the last channel assignment in the directory
                     # needed because we often get multiple channel assignments in the same folder
                     root = os.path.join("/", *path.split("/")[:-1])
-                    cha_times = [
-                        int(f.split("_")[0]) for f in os.listdir(root) if pattern in f
-                    ]
+                    fname = path.split('/')[-1]
+                    fband = int(re.findall('b\d.txt', fname)[0][1])
+                    cha_times = [int(f.split('_')[0]) for f in os.listdir(root) if f'b{fband}.txt'
+                                 in f.split('_')[-1]]
                     if ctime != np.max(cha_times):
                         continue
-                    fname = path.split("/")[-1]
                     logger.debug(
                         f"Add new channel assignment: {stream_id},{ctime}, {path}"
                     )


### PR DESCRIPTION
This closes https://github.com/simonsobs/sotodlib/issues/234, by making sure that if there are channel assignments for multiple bands in a given action folder, it will make sure to add one for each band to the ChanAssignments Table in the archive. I checked that this works by using:

```
SMURF = ls.G3tSmurf('/mnt/so1/data/ucsd-k2so/timestreams',
               meta_path='/mnt/so1/data/ucsd-k2so/smurf',
               db_path='/home/jseibert/indexes/test_fix_k2so.db')

am = ls.load_file('/mnt/so1/data/ucsd-k2so/timestreams/16456/ufm_mv11/1645644498_004.g3',archive=SMURF)
```

The returned axis manager has all the band, channel info necessary in `am.ch_info`, which was not the case before, and there are no errors where information for different channels are failing to load.