### PR TITLE
Add IO interfaces for sparse arrays

### DIFF
--- a/sotodlib/core/axisman_io.py
+++ b/sotodlib/core/axisman_io.py
@@ -68,21 +68,21 @@ def expand_RangesMatrix(flat_rm):
 
 ## Flatten and Expand sparse arrays
 def flatten_csr_array(arr):
-    """Extract information from scipy.sparse.csr_array for saving in 
+    """Extract information from scipy.sparse.csr_array for saving in
     hdf5 files"""
     return {
-        'data' : arr.data,
-        'indices' : arr.indices,
-        'indptr' : arr.indptr,
-        'shape' : arr.shape,
+        'data': arr.data,
+        'indices': arr.indices,
+        'indptr': arr.indptr,
+        'shape': arr.shape,
     }
 
 
 def expand_csr_array(flat_arr):
-    """Reconstruct csr arrays from flattened versions
+    """Reconstruct csr_array from flattened versions
     """
-    return csr_array( (flat_arr['data'], flat_arr['indices'], 
-                       flat_arr['indptr']), 
+    return csr_array( (flat_arr['data'], flat_arr['indices'],
+                       flat_arr['indptr']),
                      shape=flat_arr['shape'])
 
 # Helper functions for numpy arrays containing unicode strings; must

--- a/sotodlib/core/axisman_io.py
+++ b/sotodlib/core/axisman_io.py
@@ -3,6 +3,12 @@ import numpy as np
 import json
 import h5py
 
+## "temporary" fix to deal with scipy>1.8 changing the sparse setup
+try:
+    from scipy.sparse import csr_array
+except ImportError:
+    from scipy.sparse import csr_matrix as csr_array
+
 from .axisman import *
 from .flagman import FlagManager
 
@@ -60,6 +66,24 @@ def expand_RangesMatrix(flat_rm):
         start = ends[i+stride-1]
     return so3g.proj.RangesMatrix(ranges, child_shape=shape[1:])
 
+## Flatten and Expand sparse arrays
+def flatten_csr_array(arr):
+    """Extract information from scipy.sparse.csr_array for saving in 
+    hdf5 files"""
+    return {
+        'data' : arr.data,
+        'indices' : arr.indices,
+        'indptr' : arr.indptr,
+        'shape' : arr.shape,
+    }
+
+
+def expand_csr_array(flat_arr):
+    """Reconstruct csr arrays from flattened versions
+    """
+    return csr_array( (flat_arr['data'], flat_arr['indices'], 
+                       flat_arr['indptr']), 
+                     shape=flat_arr['shape'])
 
 # Helper functions for numpy arrays containing unicode strings; must
 # be written to HDF5 as "S" type arrays.
@@ -127,6 +151,8 @@ def _save_axisman(axisman, dest, group=None):
                 raise ValueError(f"No encoder system for {k}={v.__class__}")
         elif isinstance(v, so3g.proj.RangesMatrix):
             item['encoding'] = 'rangesmatrix'
+        elif isinstance(v, csr_array):
+            item['encoding'] = 'csrarray'
         else:
             print(v.__class__)
         schema.append(item)
@@ -176,6 +202,10 @@ def _save_axisman(axisman, dest, group=None):
         elif item['encoding'] == 'rangesmatrix':
             g = dest.create_group(item['name'])
             for k, v in flatten_RangesMatrix(data).items():
+                g.create_dataset(k, data=v)
+        elif item['encoding'] == 'csrarray':
+            g = dest.create_group(item['name'])
+            for k, v in flatten_csr_array(data).items():
                 g.create_dataset(k, data=v)
         elif item['encoding'] == 'axisman':
             g = dest.create_group(item['name'])
@@ -243,6 +273,10 @@ def _load_axisman(src, group=None, cls=None):
             x = src[item['name']]
             rm_flat = {k: x[k][:] for k in ['shape', 'intervals', 'ends']}
             axisman.wrap(item['name'], expand_RangesMatrix(rm_flat), assign)
+        elif item['encoding'] == 'csrarray':
+            x = src[item['name']]
+            csr_flat = {k: x[k][:] for k in ['shape', 'data', 'indices', 'indptr']}
+            axisman.wrap(item['name'], expand_csr_array(csr_flat), assign)
         else:
             print('No decoder for:', item)
 

--- a/sotodlib/flags.py
+++ b/sotodlib/flags.py
@@ -1,6 +1,12 @@
 import numpy as np
 import scipy.stats as stats
 
+## "temporary" fix to deal with scipy>1.8 changing the sparse setup
+try:
+    from scipy.sparse import csr_array
+except ImportError:
+    from scipy.sparse import csr_matrix as csr_array
+    
 from so3g.proj import Ranges, RangesMatrix
 
 from .tod_ops import filters
@@ -40,9 +46,10 @@ def get_turnaround_flags(tod, qlim=1, az=None, merge=True,
     return flag
 
 
-def get_glitch_flags(tod, t_glitch=0.002, hp_fc=0.5, n_sig=10, buffer=200, 
-                     signal=None, merge=True, 
-                     overwrite=False, name='glitches'):
+def get_glitch_flags(aman, t_glitch=0.002, hp_fc=0.5, n_sig=10, buffer=200, 
+                     signal=None, merge=True,
+                     overwrite=False, name='glitches',
+                     full_output=True):
     """ Find glitches with fourier filtering
     Translation from moby2 as starting point
     
@@ -55,7 +62,9 @@ def get_glitch_flags(tod, t_glitch=0.002, hp_fc=0.5, n_sig=10, buffer=200,
         signal (str): if None, defaults to 'signal'
         merge (bool): if true, add to tod.flags
         name (string): name of flag to add to tod.flags
-        overwrite (bool): if true, write over flag. if false, don't
+        overwrite (bool): if true, write over flag. if false, don't    
+        full_output (bool): if true, return sparse matrix with the significance of 
+            the detected glitches
     
     Returns:
         flag: RangesMatrix object of glitches
@@ -65,24 +74,36 @@ def get_glitch_flags(tod, t_glitch=0.002, hp_fc=0.5, n_sig=10, buffer=200,
         signal = 'signal'
     # f-space filtering
     filt = filters.high_pass_sine2(cutoff=hp_fc) * filters.gaussian_filter(t_sigma=0.002)
-    fvec = fourier_filter(tod, filt, detrend='linear', 
+    fvec = fourier_filter(aman, filt, detrend='linear', 
                           signal_name=signal, resize='zero_pad')
     # get the threshods based on n_sig x nlev = n_sig x iqu x 0.741
     fvec = np.abs(fvec)
-    thres = 0.741 * stats.iqr(fvec, axis=1) * n_sig
+    iqr_range = 0.741 * stats.iqr(fvec, axis=1) 
     # get flags
-    msk = fvec > thres[:,None]
+    msk = fvec > iqr_range[:,None]*n_sig
     flag = RangesMatrix( [Ranges.from_bitmask(m) for m in msk])
     flag.buffer(buffer)
     
     if merge:
-        if name in tod.flags and not overwrite:
+        if name in aman.flags and not overwrite:
             raise ValueError('Flag name {} already exists in tod.flags'.format(name))
-        elif name in tod.flags:
-            tod.flags[name] = flag
+        elif name in aman.flags:
+            aman.flags[name] = flag
         else:
-            tod.flags.wrap(name, flag)
-        
+            aman.flags.wrap(name, flag)
+    
+    if full_output:
+        indptr = np.append( 0, 
+                           np.cumsum( [np.sum(msk[i]) 
+                                       for i in range(aman.dets.count)]))
+        indices = np.concatenate( [np.where(msk[i])[0] 
+                                   for i in range(aman.dets.count) ])
+        data = np.concatenate( [ fvec[i][msk[i]]/iqr_range[i] 
+                                for i in range(aman.dets.count)  ])
+        smat = csr_array( (data, indices, indptr), 
+                         shape=( aman.dets.count, aman.samps.count))
+        return flag, smat
+    
     return flag
 
 def get_trending_flags(aman, max_trend=5*np.pi, n_pieces=1, signal=None,

--- a/sotodlib/flags.py
+++ b/sotodlib/flags.py
@@ -6,13 +6,13 @@ try:
     from scipy.sparse import csr_array
 except ImportError:
     from scipy.sparse import csr_matrix as csr_array
-    
+
 from so3g.proj import Ranges, RangesMatrix
 
 from .tod_ops import filters
 from .tod_ops import fourier_filter
 
-def get_turnaround_flags(tod, qlim=1, az=None, merge=True, 
+def get_turnaround_flags(tod, qlim=1, az=None, merge=True,
                          overwrite=False,name='turnarounds'):
     """Flag the scan turnaround times.
 
@@ -26,16 +26,16 @@ def get_turnaround_flags(tod, qlim=1, az=None, merge=True,
         name: name of flag when merged into tod.flags
 
     Returns:
-        flag: Ranges object of turn-arounds 
+        flag: Ranges object of turn-arounds
 
     """
     if az is None:
         az = tod.boresight.az
     lo, hi = np.percentile(az, [qlim,100-qlim])
     m = np.logical_or(az < lo, az > hi)
-    
+
     flag = Ranges.from_bitmask(m)
-    
+
     if merge:
         if name in tod.flags and not overwrite:
             raise ValueError('Flag name {} already exists in tod.flags'.format(name))
@@ -46,44 +46,45 @@ def get_turnaround_flags(tod, qlim=1, az=None, merge=True,
     return flag
 
 
-def get_glitch_flags(aman, t_glitch=0.002, hp_fc=0.5, n_sig=10, buffer=200, 
+def get_glitch_flags(aman, t_glitch=0.002, hp_fc=0.5, n_sig=10, buffer=200,
                      signal=None, merge=True,
                      overwrite=False, name='glitches',
                      full_output=True):
     """ Find glitches with fourier filtering
     Translation from moby2 as starting point
-    
+
     Args:
-        tod (AxisManager): the tod 
+        aman (AxisManager): the tod
         t_glitch (float): Gaussian filter width
         hp_fc: high pass filter cutoff
         n_sig (int or float): significance of detection
         buffer (int): amount to buffer flags around found location
         signal (str): if None, defaults to 'signal'
-        merge (bool): if true, add to tod.flags
-        name (string): name of flag to add to tod.flags
-        overwrite (bool): if true, write over flag. if false, don't    
-        full_output (bool): if true, return sparse matrix with the significance of 
+        merge (bool): if true, add to aman.flags
+        name (string): name of flag to add to aman.flags
+        overwrite (bool): if true, write over flag. if false, raise ValueError
+            if name already exists in AxisManager
+        full_output (bool): if true, return sparse matrix with the significance of
             the detected glitches
-    
+
     Returns:
         flag: RangesMatrix object of glitches
     """
-    
+
     if signal is None:
         signal = 'signal'
     # f-space filtering
     filt = filters.high_pass_sine2(cutoff=hp_fc) * filters.gaussian_filter(t_sigma=0.002)
-    fvec = fourier_filter(aman, filt, detrend='linear', 
+    fvec = fourier_filter(aman, filt, detrend='linear',
                           signal_name=signal, resize='zero_pad')
     # get the threshods based on n_sig x nlev = n_sig x iqu x 0.741
     fvec = np.abs(fvec)
-    iqr_range = 0.741 * stats.iqr(fvec, axis=1) 
+    iqr_range = 0.741 * stats.iqr(fvec, axis=1)
     # get flags
     msk = fvec > iqr_range[:,None]*n_sig
     flag = RangesMatrix( [Ranges.from_bitmask(m) for m in msk])
     flag.buffer(buffer)
-    
+
     if merge:
         if name in aman.flags and not overwrite:
             raise ValueError('Flag name {} already exists in tod.flags'.format(name))
@@ -91,45 +92,45 @@ def get_glitch_flags(aman, t_glitch=0.002, hp_fc=0.5, n_sig=10, buffer=200,
             aman.flags[name] = flag
         else:
             aman.flags.wrap(name, flag)
-    
+
     if full_output:
-        indptr = np.append( 0, 
-                           np.cumsum( [np.sum(msk[i]) 
+        indptr = np.append( 0,
+                           np.cumsum( [np.sum(msk[i])
                                        for i in range(aman.dets.count)]))
-        indices = np.concatenate( [np.where(msk[i])[0] 
+        indices = np.concatenate( [np.where(msk[i])[0]
                                    for i in range(aman.dets.count) ])
-        data = np.concatenate( [ fvec[i][msk[i]]/iqr_range[i] 
+        data = np.concatenate( [ fvec[i][msk[i]]/iqr_range[i]
                                 for i in range(aman.dets.count)  ])
-        smat = csr_array( (data, indices, indptr), 
+        smat = csr_array( (data, indices, indptr),
                          shape=( aman.dets.count, aman.samps.count))
         return flag, smat
-    
+
     return flag
 
 def get_trending_flags(aman, max_trend=5*np.pi, n_pieces=1, signal=None,
                  merge=True, overwrite=True, name='trends'):
     """ Flag Detectors with trends larger than max_trend.
-    
+
     Args:
-        aman (AxisManager): the tod 
-        max_trend: maxmimum amount to always the detectors to change by. 
+        aman (AxisManager): the tod
+        max_trend: maxmimum amount to always the detectors to change by.
             The default is pi for use in phase units.
-        n_pieces: number of pieces to cut the timestream in to to look for 
+        n_pieces: number of pieces to cut the timestream in to to look for
                     trends
         signal: Signal to use to generate flags, default is aman.signal.
         merge (bool): if true, merges the generated flag into aman
         overwrite (bool): if true, write over flag. if false, don't
         name (string): name of flag to add to aman.flags if merge is True
-    
+
     Returns:
         flag: RangesMatrix object of glitches
     """
     if overwrite and name in aman.flags:
         aman.flags.move(name, None)
-    
+
     if signal is None:
         signal = aman.signal
-        
+
     signal = np.atleast_2d( signal )
     signal = signal[:,:aman.samps.count//n_pieces*n_pieces].reshape((signal.shape[0], n_pieces,-1))
 
@@ -138,7 +139,7 @@ def get_trending_flags(aman, max_trend=5*np.pi, n_pieces=1, signal=None,
 
     bad_slopes = np.abs(slopes)>max_trend
 
-    
+
     if n_pieces == 1:
         cut = bad_slopes[:,0]
     else:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7,6 +7,11 @@ import numpy as np
 from sotodlib import core
 import so3g
 
+## "temporary" fix to deal with scipy>1.8 changing the sparse setup
+try:
+    from scipy.sparse import csr_array
+except ImportError:
+    from scipy.sparse import csr_matrix as csr_array
 
 class TestAxisManager(unittest.TestCase):
 
@@ -253,6 +258,9 @@ class TestAxisManager(unittest.TestCase):
         aman.wrap('c', np.str_('twelve'))
         aman.wrap('d', np.bool_(False))
 
+        aman.wrap('sparse', csr_array( ((8,3), ([0,1], [20,54])), 
+                                      shape=(aman.dets.count, aman.samps.count)))
+                  
         with tempfile.TemporaryDirectory() as tempdir:
             filename = os.path.join(tempdir, 'test.h5')
             aman.save(filename, 'my_axisman')


### PR DESCRIPTION
This is part of a larger project I'm working on for creating descriptive caldbs off of observations but I'm breaking this out for easier review. Sparse arrays look like they're going to be super useful for saving the values behind calculated flags without need to create ndets x nsamps boolean masks. They go directly into AxisManagers and expanding the IO for saving them is straightforward. 

I'm not very excited about the try-catch import statement I've put in everywhere, but the scipy docs say they're actively moving away from the old matrix versions of the sparse arrays. All the functionalities I've been using are interchangeable between the two versions so I figured I'd make it so later down the line we can just change the import statement.