### PR TITLE
Context changes to support on-the-fly detdb

### DIFF
--- a/sotodlib/core/context.py
+++ b/sotodlib/core/context.py
@@ -71,6 +71,7 @@ class Context(odict):
         self.obsdb = None
         self.detdb = None
         self.obsfiledb = None
+        self.obs_detdb = None
 
         for to_import in self.get('imports', []):
             importlib.import_module(to_import)
@@ -200,6 +201,18 @@ class Context(odict):
         if isinstance(obs_id, dict):
             obs_id = obs_id['obs_id']  # You passed in a dict.
 
+        # Call a hook after preparing obs_id but before loading obs
+        self._call_hook('before-load-obs', obs_id=obs_id,
+                        detsets=detsets, samples=samples)
+
+        # Identify whether we should use a detdb or an obs_detdb
+        # If there is an obs_detdb, use that.
+        # Otherwise, use whatever is in self.detdb, even if that is None.
+        if self.obs_detdb is not None:
+            detdb = self.obs_detdb
+        else:
+            detdb = self.detdb
+
         # If the obs_id is colon-coded, decode them.
         if ':' in obs_id:
             tokens = obs_id.split(':')
@@ -208,7 +221,7 @@ class Context(odict):
             # Create a map from option value to option key.
             prop_map = {}
             for f in allowed_fields[::-1]:
-                for v in self.detdb.props(props=[f]).distinct()[f]:
+                for v in detdb.props(props=[f]).distinct()[f]:
                     prop_map[v] = f
             for t in tokens[1:]:
                 prop = prop_map.get(t)
@@ -244,7 +257,7 @@ class Context(odict):
 
         # Make the final list of dets -- force resolve it to a list,
         # not a detspec.
-        if self.detdb is None:
+        if detdb is None:
             # Try to resolve this without a DetDb (if you do this
             # better, maybe make it a static method of DetDb.
             dets = None
@@ -260,8 +273,8 @@ class Context(odict):
                         dets.intersection_update(ds)
             dets = list(dets)
         else:
-            dets = self.detdb.intersect(*dets_selection,
-                                        resolve=True)
+            dets = detdb.intersect(*dets_selection,
+                                   resolve=True)
 
         # The request to the metadata loader should include obs_id and
         # the detector selection.
@@ -283,7 +296,7 @@ class Context(odict):
         if not isinstance(metadata_list, list):
             raise ValueError(f"Context metadata entry has type {type(metadata_list)} "
                             "but should be a list. Check .yaml formatting")
-        meta = self.loader.load(metadata_list, request)
+        meta = self.loader.load(metadata_list, request, detdb=detdb)
 
         # Make sure standard obsloaders are registered ...
         from ..io import load as _
@@ -307,8 +320,21 @@ class Context(odict):
         """
         if isinstance(request, str):
             request = {'obs:obs_id': request}
+
+        # Call a hook after preparing obs_id but before loading obs
+        obs_id = request['obs:obs_id']
+        self._call_hook('before-load-obs', obs_id=obs_id,
+                        detsets=detsets, samples=samples)
+        # Identify whether we should use a detdb or an obs_detdb
+        # If there is an obs_detdb, use that.
+        # Otherwise, use whatever is in self.detdb, even if that is None.
+        if self.obs_detdb is not None:
+            detdb = self.obs_detdb
+        else:
+            detdb = self.detdb
+
         metadata_list = self._get_warn_missing('metadata', [])
-        return self.loader.load(metadata_list, request)
+        return self.loader.load(metadata_list, request, detdb)
 
     def check_meta(self, request):
         """Check for existence of required metadata.
@@ -316,8 +342,21 @@ class Context(odict):
         """
         if isinstance(request, str):
             request = {'obs:obs_id': request}
+
+        # Call a hook after preparing obs_id but before loading obs
+        obs_id = request['obs:obs_id']
+        self._call_hook('before-load-obs', obs_id=obs_id,
+                        detsets=detsets, samples=samples)
+        # Identify whether we should use a detdb or an obs_detdb
+        # If there is an obs_detdb, use that.
+        # Otherwise, use whatever is in self.detdb, even if that is None.
+        if self.obs_detdb is not None:
+            detdb = self.obs_detdb
+        else:
+            detdb = self.detdb
+
         metadata_list = self._get_warn_missing('metadata', [])
-        return self.loader.check(metadata_list, request)
+        return self.loader.check(metadata_list, request, detdb)
 
 
 def _read_cfg(filename=None, envvar=None, default=None):

--- a/sotodlib/core/context.py
+++ b/sotodlib/core/context.py
@@ -202,7 +202,7 @@ class Context(odict):
             obs_id = obs_id['obs_id']  # You passed in a dict.
 
         # Call a hook after preparing obs_id but before loading obs
-        self._call_hook('before-load-obs', obs_id=obs_id,
+        self._call_hook('before-load-obs', obs_id=obs_id, dets=dets,
                         detsets=detsets, samples=samples)
 
         # Identify whether we should use a detdb or an obs_detdb

--- a/sotodlib/core/context.py
+++ b/sotodlib/core/context.py
@@ -202,7 +202,7 @@ class Context(odict):
             obs_id = obs_id['obs_id']  # You passed in a dict.
 
         # Call a hook after preparing obs_id but before loading obs
-        self._call_hook('before-load-obs', obs_id=obs_id, dets=dets,
+        self._call_hook('before-use-detdb', obs_id=obs_id, dets=dets,
                         detsets=detsets, samples=samples)
 
         # Identify whether we should use a detdb or an obs_detdb
@@ -323,7 +323,7 @@ class Context(odict):
 
         # Call a hook after preparing obs_id but before loading obs
         obs_id = request['obs:obs_id']
-        self._call_hook('before-load-obs', obs_id=obs_id,
+        self._call_hook('before-use-detdb', obs_id=obs_id,
                         detsets=detsets, samples=samples)
         # Identify whether we should use a detdb or an obs_detdb
         # If there is an obs_detdb, use that.
@@ -345,7 +345,7 @@ class Context(odict):
 
         # Call a hook after preparing obs_id but before loading obs
         obs_id = request['obs:obs_id']
-        self._call_hook('before-load-obs', obs_id=obs_id,
+        self._call_hook('before-use-detdb', obs_id=obs_id,
                         detsets=detsets, samples=samples)
         # Identify whether we should use a detdb or an obs_detdb
         # If there is an obs_detdb, use that.

--- a/sotodlib/core/metadata/loader.py
+++ b/sotodlib/core/metadata/loader.py
@@ -45,7 +45,7 @@ class SuperLoader:
         """
         REGISTRY[name] = loader_class
 
-    def load_raw(self, spec_list, request):
+    def load_raw(self, spec_list, request, detdb=None):
         """Loads metadata objects and returns them in their Natural
         containers.
 
@@ -53,6 +53,8 @@ class SuperLoader:
           spec_list (list of dict): A list of metadata specification
             dictionaries.
           request (dict): A metadata request dictionary.
+          detdb (core.metadata.DetDb): A DetDb-like object for use
+            loading metadata.
 
         Notes:
           Each entry in spec_list must be a dictionary with the
@@ -88,6 +90,8 @@ class SuperLoader:
           already applied.
 
         """
+        if detdb is None:
+            detdb = self.detdb
         items = []
         for spec_dict in spec_list:
             dbfile = spec_dict['db']
@@ -171,13 +175,13 @@ class SuperLoader:
                     loader_class = REGISTRY[loader]
                 except KeyError:
                     raise RuntimeError('No metadata loader registered under name "%s"' % loader)
-                loader_object = loader_class(detdb=self.detdb, obsdb=self.obsdb)
+                loader_object = loader_class(detdb=detdb, obsdb=self.obsdb)
                 mi1 = loader_object.from_loadspec(index_line)
                 # restrict to index_line...
-                if (self.detdb is None and
+                if (detdb is None and
                     len([k for k in index_line if k.startswith('dets:')])):
                     raise ValueError(f"Metadata not loadable without detdb: {index_line}")
-                mi2 = mi1.restrict_dets(index_line, detdb=self.detdb)
+                mi2 = mi1.restrict_dets(index_line, detdb=detdb)
                 results.append(mi2)
 
             # Check that we got results, then combine them in to single ResultSet.
@@ -194,11 +198,13 @@ class SuperLoader:
             items.append((unpackers, result))
         return items
 
-    def unpack(self, packed_items, dest=None):
+    def unpack(self, packed_items, dest=None, detdb=None):
         """Unpack items from packed_items, and return then in a single
         AxisManager.
 
         """
+        if detdb is None:
+            detdb = self.detdb
         if dest is None:
             dest = core.AxisManager()
         for unpackers, metadata_instance in packed_items:
@@ -206,7 +212,7 @@ class SuperLoader:
             if isinstance(metadata_instance, core.AxisManager):
                 child_axes = metadata_instance
             else:
-                child_axes = metadata_instance.axismanager(detdb=self.detdb)
+                child_axes = metadata_instance.axismanager(detdb=detdb)
             fields_to_delete = list(child_axes._fields.keys())
             # Unpack to requested field names.
             for unpack in unpackers:
@@ -223,7 +229,7 @@ class SuperLoader:
                 dest.merge(child_axes)
         return dest
 
-    def load(self, spec_list, request, dest=None, check=False):
+    def load(self, spec_list, request, detdb=None, dest=None, check=False):
         """Loads metadata objects and processes them into a single
         AxisManager.  This is equivalent to running load_raw and then
         unpack, though the two are intermingled.
@@ -234,11 +240,14 @@ class SuperLoader:
         or the Exception raised when trying to load that entry.
 
         """
+        if detdb is None:
+            detdb = self.detdb
+
         if check:
             errors = []
             for spec in spec_list:
                 try:
-                    item = self.load_raw([spec], request)
+                    item = self.load_raw([spec], request, detdb)
                     errors.append((spec, None))
                 except Exception as e:
                     errors.append((spec, e))
@@ -246,8 +255,8 @@ class SuperLoader:
 
         for spec in spec_list:
             try:
-                item = self.load_raw([spec], request)
-                dest = self.unpack(item, dest=dest)
+                item = self.load_raw([spec], request, detdb)
+                dest = self.unpack(item, dest=dest, detdb=detdb)
             except Exception as e:
                 e.args = e.args + (
                     "\n\nThe above exception arose while processing "

--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -2358,7 +2358,7 @@ def load_g3tsmurf_obs(db, obs_id, dets=None, samples=None, **kwargs):
         "select name from files " "where obs_id=?" + "order by start", (obs_id,)
     )
     flist = [row[0] for row in c]
-    return load_file(flist, dets, samples=samples, obsfiledb=db)
+    return load_file(flist, dets, samples=samples, obsfiledb=db, short_labels=False)
 
 
 core.OBSLOADER_REGISTRY["g3tsmurf"] = load_g3tsmurf_obs

--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -1400,7 +1400,7 @@ def obs_detdb_context_hook(ctx, obs_id, *args, **kwargs):
     return ddb
 
 core.Context.hook_sets['obs_detdb_load'] = {
-    'before-load-obs': obs_detdb_context_hook,
+    'before-use-detdb': obs_detdb_context_hook,
 }
 
 class SmurfStatus:

--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -1394,6 +1394,14 @@ def make_DetDb_single_obs(obsfiledb, obs_id):
     detdb.conn.commit()
     return detdb
 
+def obs_detdb_context_hook(ctx, obs_id, *args, **kwargs):
+    ddb = make_DetDb_single_obs(ctx.obsfiledb, obs_id)
+    ctx.obs_detdb = ddb
+    return ddb
+
+core.Context.hook_sets['obs_detdb_load'] = {
+    'before-load-obs': obs_detdb_context_hook,
+}
 
 class SmurfStatus:
     """


### PR DESCRIPTION
This PR adds functionality to Context to build the obs_detdb, a DetDb-like object that is constructed upon calling either get_obs or get_meta (or check_meta) after providing a specific obs_id. It populates the attribute `ctx.obs_detdb` and leaves `ctx.detdb` alone to make clear that the object is not the same as a traditional DetDb, though it does still belong to that class. 

Adds a hook, living in the load_smurf module, that is called with key `before-load-obs` after the obs_id is initialized. Here is an example Context file:

```
tags:
  g3tsmurf_dir: '/mnt/so1/users/kmharrin/smurf_context'

obsfiledb: '{g3tsmurf_dir}/latrt_db_v4.db'
obsdb: '{g3tsmurf_dir}/latrt_db_v4.db'

imports:
  - sotodlib.io.load_smurf

obs_loader_type: 'g3tsmurf'

context_hooks: obs_detdb_load
```
Notice that the detdb key isn't included here.

I've tested this using a few obs_ids and haven't had any issues yet. I've also checked the metadata loading which does work, but am not including that in the example Context file because there are some bugs that are related to the construction of the CalDb I'm loading, having nothing to do with the changes addressed in this PR. I made some changes to the metadata loading functions to make sure the correct DetDb is passed through to the right places, and I checked that it is working properly, so those shouldn't be an issue. (The problem emerges only when trying to merge that resultant axis manager with the loaded timestream, which is related to the way I've named detectors in the CalDb, and shouldn't require a PR to address).