### PR TITLE
tod_ops: cleanup iir_filter

### DIFF
--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -2298,6 +2298,14 @@ def load_file(
     aman.wrap("timestamps", _get_timestamps(streams), ([(0, "samps")]))
     aman.wrap("status", status.aman)
 
+    # If readout filter in enabled build iir_params AxisManager
+    if status.filter_enabled:
+        iir_params = core.AxisManager()
+        iir_params.wrap("a", status.filter_a)
+        iir_params.wrap("b", status.filter_b)
+        iir_params.wrap("fscale", 1/status.flux_ramp_rate_hz)
+        aman.wrap("iir_params", iir_params)
+
     # Conversion from DAC counts to squid phase
     aman.wrap("signal", np.zeros((aman[det_axis].count, aman["samps"].count), "float32"), [(0, det_axis), (1, "samps")])
     for idx in range(aman[det_axis].count):


### PR DESCRIPTION
I would like to revisit the interface for iir_params -- see amendments in this PR.

The good news is that the options and logic are greatly simplified.  The bad news is that this doesn't defualt to looking in "status" anymore.

@skhrg @kmharrington  This will break the integration with 'status' in g3tsmurf.  Can you have the g3tsmurf loader instead populate "iir_params" directly?  I think that's more general.  Also you will need to compute the original sampling frequency and use that to set fscale (it is not simply the decimation factor, it turns out).  Feel free to add that to this PR if convenient.

In the proposed system here, parameters "a", "b", and "fscale" are loaded from an AxisManager called "iir_params".  I am open to other names for these things (especially "iir" and "fscale"), but I want them to remain somewhat general rather than being tied to Smurf and Smurf status.
