### PR TITLE
Make Glitch Flagging and White Noise CalDbs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -100,7 +100,7 @@ autodoc_default_options = {
 autodoc_mock_imports = []
 for missing in ('numpy', 'matplotlib', 'healpy', 'astropy','sqlalchemy',
                 'quaternionarray', 'yaml', 'toml', 'sqlite3','tqdm',
-                'skyfield', 'h5py', 'pyfftw', 'scipy',
+                'skyfield', 'h5py', 'pyfftw', 'scipy', 'scipy.sparse',
                 'toast', 'spt3g', 'so3g', 'pixell'):
     try:
         foo = import_module(missing)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -101,7 +101,7 @@ autodoc_mock_imports = []
 for missing in ('numpy', 'matplotlib', 'healpy', 'astropy','sqlalchemy',
                 'quaternionarray', 'yaml', 'toml', 'sqlite3','tqdm',
                 'skyfield', 'h5py', 'pyfftw', 'scipy', 'scipy.sparse',
-                'toast', 'spt3g', 'so3g', 'pixell'):
+                'toast', 'spt3g', 'so3g', 'pixell', 'so3g.proj'):
     try:
         foo = import_module(missing)
     except ImportError:

--- a/docs/site_pipeline.rst
+++ b/docs/site_pipeline.rst
@@ -17,7 +17,6 @@ quick-turnaround data processing at the observatory.
 Pipeline Elements
 =================
 
-
 make-source-flags
 -----------------
 
@@ -54,6 +53,53 @@ Here's an annotated example:
   mask_params:
     default: {'xyr': [0., 0., 0.1]}
 
+
+make-glitch-flags
+-----------------
+
+The glitch flags script saves two types of data in the glitch AxisManager,
+`glitch_flags` is a RangesMatrix containing the masks for the default parameters
+and `glitch_detection` which contains the significance of the glitch detection
+(for all points over the `n_sig` threshold). The glitch detection information
+ignores the buffer parameter.
+
+Command line arguments
+``````````````````````
+
+.. argparse::
+   :module: sotodlib.site_pipeline.make_glitch_flags
+   :func: get_parser
+
+Config file format
+``````````````````
+
+Here's an annotated example:
+
+.. code-block:: yaml
+  
+  # Context for <whatever>
+  context_file: ./context4_b.yaml
+
+  # How to subdivide observations (by detset)
+  subobs:
+    use: detset
+    label: detset
+
+  # Metadata index & archive filenaming
+  archive:
+    index: 'archive.sqlite'
+    policy:
+      type: 'simple'
+      filename: 'archive.h5'
+
+  # Flag parameters
+  flag_params:
+    default: {
+      't_glitch': 0.002,
+      'hp_fc': 0.5,
+      'n_sig': 10,
+      'buffer': 200,
+    }
 
 Support
 =======

--- a/docs/site_pipeline.rst
+++ b/docs/site_pipeline.rst
@@ -101,6 +101,59 @@ Here's an annotated example:
       'buffer': 200,
     }
 
+make-white-noise
+-----------------
+
+This script calculates the median "white noise" between two specified
+frequencies (5 Hz and 10 Hz are the default for now). The configuration file can
+be used to pass parameters to the PSD calculation function and the binning
+function.
+
+Command line arguments
+``````````````````````
+
+.. argparse::
+   :module: sotodlib.site_pipeline.make_white_noise
+   :func: get_parser
+
+Config file format
+``````````````````
+
+Here's an annotated example:
+
+.. code-block:: yaml
+  
+  # Context for <whatever>
+  context_file: ./context4_b.yaml
+
+  # How to subdivide observations (by detset)
+  subobs:
+    use: detset
+    label: detset
+
+  # Metadata index & archive filenaming
+  archive:
+    index: 'archive.sqlite'
+    policy:
+      type: 'simple'
+      filename: 'archive.h5'
+
+  # PSD parameters
+  psd_params:
+    default: {
+      'detrend': 'linear',
+      'window': 'hann',
+    }
+
+  # Noise parameters
+  noise_params:
+    default: {
+      'low_f': 5,
+      'high_f': 10,
+    }
+
+
+
 Support
 =======
 

--- a/sotodlib/flags.py
+++ b/sotodlib/flags.py
@@ -1,5 +1,5 @@
 import numpy as np
-import scipy.stats as stats
+from scipy import stats
 
 ## "temporary" fix to deal with scipy>1.8 changing the sparse setup
 try:

--- a/sotodlib/site_pipeline/make_glitch_flags.py
+++ b/sotodlib/site_pipeline/make_glitch_flags.py
@@ -1,0 +1,102 @@
+from argparse import ArgumentParser
+import logging
+import numpy as np
+import os
+import sys
+import yaml
+
+import sotodlib
+from sotodlib import core, flags, site_pipeline
+
+logger = logging.getLogger(__name__)
+
+def get_parser():
+    parser = ArgumentParser()
+    parser.add_argument('obs_id',help=
+                        "Observation for which to generate flags.")
+    parser.add_argument('-c', '--config-file', help=
+                        "Configuration file.")
+    parser.add_argument('-v', '--verbose', action='count',
+                        default=0, help="Pass multiple times to increase.")
+    return parser
+
+def get_config(args):
+    cfg = yaml.safe_load(open(args.config_file, 'r'))
+    for k in ['obs_id', 'verbose']:
+        cfg[k] = getattr(args, k)
+    return cfg
+
+def main(args=None):
+    if args is None:
+        args = sys.argv[1:]
+    parser = get_parser()
+    config = get_config(parser.parse_args(args))
+
+    if config['verbose'] >= 1:
+        logger.setLevel('INFO')
+    if config['verbose'] >= 2:
+        sotodlib.logger.setLevel('INFO')
+    if config['verbose'] >= 3:
+        sotodlib.logger.setLevel('DEBUG')
+
+    ctx = core.Context(config['context_file'])
+
+    group_by = config['subobs'].get('use', 'detset')
+    if group_by == 'detset':
+        groups = ctx.obsfiledb.get_detsets(config['obs_id'])
+    elif group_by.startswith('dets:'):
+        group_by = group_by.split(':',1)[1]
+        groups = ctx.detdb.props(props=group_by).distinct()[group_by]
+    else:
+        raise ValueError("Can't group by '{group_by}'")
+
+    if os.path.exists(config['archive']['index']):
+        logger.info(f'Mapping {config["archive"]["index"]} for the archive index.')
+        db = core.metadata.ManifestDb(config['archive']['index'])
+    else:
+        logger.info(f'Creating {config["archive"]["index"]} for the archive index.')
+        scheme = core.metadata.ManifestScheme()
+        scheme.add_exact_match('obs:obs_id')
+        if group_by != 'detset':
+            scheme.add_exact_match('dets:' + group_by)
+        scheme.add_data_field('dataset')
+        db = core.metadata.ManifestDb(config['archive']['index'], scheme=scheme)
+
+    for group in groups:
+        logger.info(f'Loading {config["obs_id"]}:{group_by}={group}')
+        if group_by == 'detset':
+            # Load pointing and dets axis; we do
+            tod = ctx.get_obs(config['obs_id'], detsets=[group])
+        else:
+            tod = ctx.get_obs(config['obs_id'], dets={group_by: group})
+
+        # Load / compute mask parameters.
+        flag_params = config['flag_params']['default']
+
+        tod_flags, csr = flags.get_glitch_flags(tod, full_output=True, 
+                                            **flag_params)
+
+        # Compute fraction of samples
+        weight = np.mean(tod_flags.get_stats()['samples']) / tod_flags.shape[1]
+        logger.info(f'Total mask weight is {weight*100:.2}%.')
+
+        # Wrap result into AxisManager for HDF5 off-load.
+        aman = core.AxisManager(tod.dets)
+        aman.wrap('glitch_flags', tod_flags, [(0, 'dets')])
+
+        # Get file + dataset from policy.
+        policy = site_pipeline.util.ArchivePolicy.from_params(config['archive']['policy'])
+        dest_file, dest_dataset = policy.get_dest(config['obs_id'])
+        if group_by == 'detset':
+            dest_dataset += '_' + group
+        aman.save(dest_file, dest_dataset, overwrite=True)
+
+        # Update the index.
+        db_data = {'obs:obs_id': config['obs_id'],
+                   'dataset': dest_dataset}
+        if group_by != 'detset':
+            db_data['dets:'+group_by] = group
+        db.add_entry(db_data, dest_file)
+
+    # Return something?
+    return tod, aman

--- a/sotodlib/site_pipeline/make_glitch_flags.py
+++ b/sotodlib/site_pipeline/make_glitch_flags.py
@@ -83,6 +83,7 @@ def main(args=None):
         # Wrap result into AxisManager for HDF5 off-load.
         aman = core.AxisManager(tod.dets)
         aman.wrap('glitch_flags', tod_flags, [(0, 'dets')])
+        aman.wrap('glitch_detections', csr, [(0, 'dets'), (1,'samps')])
 
         # Get file + dataset from policy.
         policy = site_pipeline.util.ArchivePolicy.from_params(config['archive']['policy'])

--- a/sotodlib/site_pipeline/make_glitch_flags.py
+++ b/sotodlib/site_pipeline/make_glitch_flags.py
@@ -81,8 +81,8 @@ def main(args=None):
         logger.info(f'Total mask weight is {weight*100:.2}%.')
 
         # Wrap result into AxisManager for HDF5 off-load.
-        aman = core.AxisManager(tod.dets)
-        aman.wrap('glitch_flags', tod_flags, [(0, 'dets')])
+        aman = core.AxisManager(tod.dets, tod.samps)
+        aman.wrap('glitch_flags', tod_flags, [(0, 'dets'), (1,'samps')])
         aman.wrap('glitch_detections', csr, [(0, 'dets'), (1,'samps')])
 
         # Get file + dataset from policy.

--- a/sotodlib/site_pipeline/make_white_noise.py
+++ b/sotodlib/site_pipeline/make_white_noise.py
@@ -1,0 +1,100 @@
+from argparse import ArgumentParser
+import logging
+import numpy as np
+import os
+import sys
+import yaml
+
+import sotodlib
+from sotodlib import core, site_pipeline
+from sotodlib.tod_ops import fft_ops
+
+logger = logging.getLogger(__name__)
+
+def get_parser():
+    parser = ArgumentParser()
+    parser.add_argument('obs_id',help=
+                        "Observation for which to calculate noise numbers.")
+    parser.add_argument('-c', '--config-file', help=
+                        "Configuration file.")
+    parser.add_argument('-v', '--verbose', action='count',
+                        default=0, help="Pass multiple times to increase.")
+    return parser
+
+def get_config(args):
+    cfg = yaml.safe_load(open(args.config_file, 'r'))
+    for k in ['obs_id', 'verbose']:
+        cfg[k] = getattr(args, k)
+    return cfg
+
+def main(args=None):
+    if args is None:
+        args = sys.argv[1:]
+    parser = get_parser()
+    config = get_config(parser.parse_args(args))
+
+    if config['verbose'] >= 1:
+        logger.setLevel('INFO')
+    if config['verbose'] >= 2:
+        sotodlib.logger.setLevel('INFO')
+    if config['verbose'] >= 3:
+        sotodlib.logger.setLevel('DEBUG')
+
+    ctx = core.Context(config['context_file'])
+
+    group_by = config['subobs'].get('use', 'detset')
+    if group_by == 'detset':
+        groups = ctx.obsfiledb.get_detsets(config['obs_id'])
+    elif group_by.startswith('dets:'):
+        group_by = group_by.split(':',1)[1]
+        groups = ctx.detdb.props(props=group_by).distinct()[group_by]
+    else:
+        raise ValueError("Can't group by '{group_by}'")
+
+    if os.path.exists(config['archive']['index']):
+        logger.info(f'Mapping {config["archive"]["index"]} for the archive index.')
+        db = core.metadata.ManifestDb(config['archive']['index'])
+    else:
+        logger.info(f'Creating {config["archive"]["index"]} for the archive index.')
+        scheme = core.metadata.ManifestScheme()
+        scheme.add_exact_match('obs:obs_id')
+        if group_by != 'detset':
+            scheme.add_exact_match('dets:' + group_by)
+        scheme.add_data_field('dataset')
+        db = core.metadata.ManifestDb(config['archive']['index'], scheme=scheme)
+
+    for group in groups:
+        logger.info(f'Loading {config["obs_id"]}:{group_by}={group}')
+        if group_by == 'detset':
+            # Load pointing and dets axis; we do
+            tod = ctx.get_obs(config['obs_id'], detsets=[group])
+        else:
+            tod = ctx.get_obs(config['obs_id'], dets={group_by: group})
+
+        # Load / compute parameters.
+        psd_params = config['psd_params']['default']
+        noise_params = config['noise_params']['default']
+
+        freqs, pxx = fft_ops.calc_psd(tod, **psd_params)
+        noise = fft_ops.calc_wn(tod, freqs=freqs, pxx=pxx, **noise_params)
+        
+        # Wrap result into AxisManager for HDF5 off-load.
+        aman = core.AxisManager(tod.dets)
+        aman.wrap('white_noise', noise, [(0, 'dets')])
+
+        # Get file + dataset from policy.
+        policy = site_pipeline.util.ArchivePolicy.from_params(config['archive']['policy'])
+        dest_file, dest_dataset = policy.get_dest(config['obs_id'])
+        if group_by == 'detset':
+            dest_dataset += '_' + group
+        aman.save(dest_file, dest_dataset, overwrite=True)
+
+        # Update the index.
+        db_data = {'obs:obs_id': config['obs_id'],
+                   'dataset': dest_dataset}
+        if group_by != 'detset':
+            db_data['dets:'+group_by] = group
+        db.add_entry(db_data, dest_file)
+
+    # Return something?
+    return tod, aman

--- a/sotodlib/tod_ops/fft_ops.py
+++ b/sotodlib/tod_ops/fft_ops.py
@@ -190,7 +190,7 @@ def calc_psd(aman, signal=None, timestamps=None, **kwargs):
     """Calculates the power spectrum density of an input signal using signal.welch()
     Data defaults to aman.signal and times defaults to aman.timestamps
         Arguments:
-            aman: AxisManager with (dets, samps) OR (channels, samps)axes.
+            aman: AxisManager with (dets, samps) OR (channels, samps) axes.
 
             signal: data signal to pass to scipy.signal.welch()
             


### PR DESCRIPTION
Here's my unambitious first pass at making the pipeline scripts to calculate the glitch flags and white noise (really it's "white" noise) for different observations. 

Considering the shear amount of things I just straight copied from the "make-source-flags" scripts there's a lot of low-hanging fruit for normalization and generalization between these different pipeline objects. But I expect that will be the next PR. 