### PR TITLE
Expand H5 Default Loading for CalDbs

### DIFF
--- a/sotodlib/core/metadata/loader.py
+++ b/sotodlib/core/metadata/loader.py
@@ -2,7 +2,7 @@ from sotodlib import core
 import os
 
 REGISTRY = {
-    '_default': 'ResultSetHdf'
+    '_default': 'DefaultHdf'
 }
 
 


### PR DESCRIPTION
This PR adds 2 new metadata loaders, one that loads `AxisManagers` and another that determines the type of data being loaded. 

`DefaultHdfLoader` assumes the file is an hdf5 file and will look for the `_axisman` attribute in the dataset, if it's there it will load through the new `AxisManagerHdfLoader` and if it is not it will assume it is a `ResultSet`. I've also updated the default loader to be this new one. 