### PR TITLE
Return jump sizes as float not int

### DIFF
--- a/sotodlib/tod_ops/jumps.py
+++ b/sotodlib/tod_ops/jumps.py
@@ -146,7 +146,7 @@ def get_jump_sizes(x, jumps, win_size):
         left_height = np.median(x[left : int((j + left) / 2)])
 
         sizes[i] = right_height - left_height
-    return sizes.astype(int)
+    return sizes.astype(float)
 
 
 def jumpfinder_tv(


### PR DESCRIPTION
Dumb typo that got through on my last PR that I caught when working on jumpfixing stuff. It's something that is a simple enough fix but causes annoying enough problems that I would rather merge it now that wait for a bigger jump related PR.