### PR TITLE
Detdb transformation

### DIFF
--- a/docs/context.rst
+++ b/docs/context.rst
@@ -335,7 +335,7 @@ per detector per observation::
     for i in range(len(obs_rs)):
         aman = context.get_obs(obs_rs[i]['obs_id'])
         things = calculate_thing(aman)
-        thing_rs = metadata.ResultSet(keys=['dets:name', 'thing'])
+        thing_rs = metadata.ResultSet(keys=['dets:readout_id', 'thing'])
         for d, det in enumerate(aman.dets.vals):
             thing_rs.rows.append((det, things[d]))
         io_meta.write_dataset(thing_rs, h5_file, f'thing_for_{obs_id}')

--- a/docs/context.rst
+++ b/docs/context.rst
@@ -806,6 +806,46 @@ contain only the ``obs_id``.  For each item in the context.yaml
    field from the result, for example).
 
 
+
+Changing det_info
+-----------------
+
+Metadata entries can be used to change the active ``det_info`` table
+that is used to screen and match metadata results.  This is
+accomplished through special metadata entries with the following
+syntax::
+
+  metadata:
+  - ...
+  - db: 'more_det_info.sqlite'
+    det_info: true
+    det_key: 'dets:name'
+  - ...
+
+The boolean ``'det_info': true`` marks this as a special metadata
+entry to update ``det_info``.  The ``det_key`` entry specifies what
+column of the loaded metadata should be used as the index to add the
+information to the existing tracked ``det_info``; that key should
+exist in both the active ``det_info`` and in the result that is loaded
+here.
+
+It is expected that ``more_det_info.sqlite`` is a standard ManifestDb,
+which will be queried in the usual way except that when we get to the
+"Wrap Metadata" step, instead the following is performed:
+
+  - The index field identified by ``det_key`` is looked up in the
+    current active ``det_info`` (after removing the dets: prefix) and
+    in the new metadata object (with prefix intact).
+  - The columns from the new metadata are merged into the active
+    ``det_info``, ensuring that the index field values correspond.
+  - Only the rows for which the index field has the same value in the
+    two objects are kept.
+
+As subsequent metadata are processed, they can match against any
+fields that have been added to ``det_info`` by preceding entries in
+the metadata list.
+
+
 ------------------------------------
 DetDb: Detector Information Database
 ------------------------------------

--- a/sotodlib/core/__init__.py
+++ b/sotodlib/core/__init__.py
@@ -13,3 +13,5 @@ from .axisman import IndexAxis, OffsetAxis, LabelAxis
 from .flagman import FlagManager
 
 from .hardware import Hardware
+
+from . import util

--- a/sotodlib/core/axisman.py
+++ b/sotodlib/core/axisman.py
@@ -89,8 +89,9 @@ class AxisInterface:
 class IndexAxis(AxisInterface):
     """This class manages a simple integer-indexed axis.  When
     intersecting data, the longer one will be simply truncated to
-    match the shorter.  Selectors must be tuples compatible with
-    slice(), e.g. (2,8,2).
+    match the shorter.  Selectors must be slice objects (with stride
+    1!) or tuples to be passed into slice(), e.g. (0, 1000) or (0,
+    None, 1)..
 
     """
     def __init__(self, name, count=None):
@@ -139,6 +140,9 @@ class OffsetAxis(AxisInterface):
     reference point.  It could be a TOD name ('obs_2020-12-01') or a
     timestamp or whatever.
 
+    Selectors must be slice objects (with stride 1!) or tuples to be
+    passed into slice(), e.g. (0, 1000) or (0, None, 1).
+
     """
 
     origin_tag = None
@@ -166,7 +170,10 @@ class OffsetAxis(AxisInterface):
         return super().resolve(src, axis_index)
 
     def restriction(self, selector):
-        sl = slice(*selector)
+        if not isinstance(selector, slice):
+            sl = slice(*selector)
+        else:
+            sl = selector
         start, stop, stride = sl.indices(self.count + self.offset)
         assert stride == 1
         assert start >= self.offset

--- a/sotodlib/core/axisman.py
+++ b/sotodlib/core/axisman.py
@@ -1,6 +1,8 @@
 import numpy as np
 from collections import OrderedDict as odict
 
+from .util import get_coindices
+
 
 class AxisInterface:
     """Abstract base class for axes managed by AxisManager."""
@@ -822,47 +824,6 @@ class AxisManager:
         from .axisman_io import _load_axisman
         return _load_axisman(src, group, cls)
 
-
-def get_coindices(v0, v1):
-    """Given vectors v0 and v1, each of which contains no duplicate
-    values, determine the elements that are found in both vectors.
-    Returns (vals, i0, i1), i.e. the vector of common elements and
-    the vectors of indices into v0 and v1 where those elements are
-    found.
-
-    This routine will use np.intersect1d if it can.  The ordering of
-    the results is different from intersect1d -- vals is not sorted,
-    but rather will the elements will appear in the same order that
-    they were found in v0 (so i0 is strictly increasing).
-
-    """
-    try:
-        vals, i0, i1 = np.intersect1d(v0, v1, return_indices=True)
-        order = np.argsort(i0)
-        return vals[order], i0[order], i1[order]
-    except TypeError:  # return_indices not implemented in numpy < 1.15
-        pass
-
-    # The old fashioned way
-    v0 = np.asarray(v0)
-    w0 = sorted([(j, i) for i, j in enumerate(v0)])
-    w1 = sorted([(j, i) for i, j in enumerate(v1)])
-    i0, i1 = 0, 0
-    pairs = []
-    while i0 < len(w0) and i1 < len(w1):
-        if w0[i0][0] == w1[i1][0]:
-            pairs.append((w0[i0][1], w1[i1][1]))
-            i0 += 1
-            i1 += 1
-        elif w0[i0][0] < w1[i1][0]:
-            i0 += 1
-        else:
-            i1 += 1
-    if len(pairs) == 0:
-        return (np.zeros(0, v0.dtype), np.zeros(0, int), np.zeros(0, int))
-    pairs.sort()
-    i0, i1 = np.transpose(pairs)
-    return v0[i0], i0, i1
 
 def simplify_slice(sslice, shape):
     """Given a tuple of slices, such as what __getitem__ might produce, and the

--- a/sotodlib/core/axisman.py
+++ b/sotodlib/core/axisman.py
@@ -203,7 +203,10 @@ class LabelAxis(AxisInterface):
     def __init__(self, name, vals=None):
         super().__init__(name)
         if vals is not None:
-            vals = np.array(vals)
+            if len(vals):
+                vals = np.array(vals)
+            else:
+                vals = np.array([], dtype=np.str_)
             if vals.dtype.type is not np.str_:
                 raise TypeError(
                         'LabelAxis labels must be strings not %s' % vals.dtype)
@@ -494,7 +497,7 @@ class AxisManager:
                 keepers.append(item._fields[name])
             if len(keepers) == 0:
                 # Well we tried.
-                keepers = [items[0]]
+                keepers = [items[0]._fields[name]]
             # Call class-specific concatenation if needed.
             if isinstance(keepers[0], AxisManager):
                 new_data[name] = AxisManager.concatenate(

--- a/sotodlib/core/context.py
+++ b/sotodlib/core/context.py
@@ -323,8 +323,8 @@ class Context(odict):
 
         # Call a hook after preparing obs_id but before loading obs
         obs_id = request['obs:obs_id']
-        self._call_hook('before-use-detdb', obs_id=obs_id,
-                        detsets=detsets, samples=samples)
+        self._call_hook('before-use-detdb', obs_id=obs_id)
+
         # Identify whether we should use a detdb or an obs_detdb
         # If there is an obs_detdb, use that.
         # Otherwise, use whatever is in self.detdb, even if that is None.
@@ -345,8 +345,8 @@ class Context(odict):
 
         # Call a hook after preparing obs_id but before loading obs
         obs_id = request['obs:obs_id']
-        self._call_hook('before-use-detdb', obs_id=obs_id,
-                        detsets=detsets, samples=samples)
+        self._call_hook('before-use-detdb', obs_id=obs_id)
+
         # Identify whether we should use a detdb or an obs_detdb
         # If there is an obs_detdb, use that.
         # Otherwise, use whatever is in self.detdb, even if that is None.

--- a/sotodlib/core/context.py
+++ b/sotodlib/core/context.py
@@ -318,8 +318,15 @@ class Context(odict):
         or else a request dict like the kind passed in from get_obs.
 
         """
+        free_tags, free_tag_fields = [], []
         if isinstance(request, str):
-            request = {'obs:obs_id': request}
+            free_tag_fields = self.get('obs_colon_tags', [])
+            if len(free_tag_fields):
+                obs_id = request.split(':')[0]
+                free_tags = request.split(':')[1:]
+            else:
+                obs_id = request
+            request = {'obs:obs_id': obs_id}
 
         # Call a hook after preparing obs_id but before loading obs
         obs_id = request['obs:obs_id']
@@ -335,7 +342,8 @@ class Context(odict):
 
         metadata_list = self._get_warn_missing('metadata', [])
         det_info = detdb.props()
-        return self.loader.load(metadata_list, request, det_info=det_info, check=check)
+        return self.loader.load(metadata_list, request, det_info=det_info, check=check,
+                                free_tags=free_tags, free_tag_fields=free_tag_fields)
 
     def check_meta(self, request):
         """Check for existence of required metadata.

--- a/sotodlib/core/context.py
+++ b/sotodlib/core/context.py
@@ -166,7 +166,7 @@ class Context(odict):
         # The metadata loader.
         if load_list == 'all' or 'loader' in load_list:
             self.loader \
-                = metadata.SuperLoader(self)
+                = metadata.SuperLoader(self, obsdb=self.obsdb)
 
     def get_obs(self, obs_id=None, dets=None, detsets=None,
                 free_tags=None, samples=None, no_signal=None,
@@ -349,6 +349,7 @@ class Context(odict):
             detdb = self.detdb
 
         # Initialize det_info, starting with detdb.
+        det_info = None
         if detdb is not None:
             det_info = detdb.props()
 
@@ -360,11 +361,8 @@ class Context(odict):
 
         # Incorporate detset info from obsfiledb.
         detsets_info = self.obsfiledb.get_det_table(obs_id)
-        if det_info is None:
-            det_info = detsets_info
-        else:
-            det_info = metadata.merge_det_info(det_info, detsets_info,
-                                               ['readout_id'])
+        det_info = metadata.merge_det_info(det_info, detsets_info,
+                                           ['readout_id'])
 
         metadata_list = self._get_warn_missing('metadata', [])
         return self.loader.load(metadata_list, request, det_info=det_info, check=check,

--- a/sotodlib/core/context.py
+++ b/sotodlib/core/context.py
@@ -225,8 +225,8 @@ class Context(odict):
             used in the ObsDb and ObsFileDb.  Note however that this
             string may include "free tags" (see below).
           - a dict -- this is understood to be an ObsDb record, and
-            the value under key 'obs:obs_id' will be used as the
-            obs_id (the other items will be ignored).
+            the value under key 'obs_id' will be used as the obs_id
+            (the other items will be ignored).
           - an AxisManager -- this is a short-hand for passing an
             object through meta=... .  I.e., ``get_obs(obs_is=axisman)``
             is treated the same way as ``get_obs(obs_id=None, meta=axisman)``.
@@ -375,7 +375,7 @@ class Context(odict):
             obs_id, meta = None, obs_id
 
         elif isinstance(obs_id, dict):
-            obs_id = obs_id['obs:obs_id']  # You passed in a dict.
+            obs_id = obs_id['obs_id']  # You passed in a dict.
 
         elif isinstance(obs_id, str):
             # If the obs_id has colon-coded free tags, extract them.

--- a/sotodlib/core/context.py
+++ b/sotodlib/core/context.py
@@ -175,6 +175,7 @@ class Context(odict):
                 filename=None,
                 detsets=None,
                 meta=None,
+                ignore_missing=None,
                 free_tags=None,
                 no_signal=None,
                 loader_type=None,
@@ -207,6 +208,8 @@ class Context(odict):
             metadata fields.)
           free_tags (list): Strings to match against the
             obs_colon_tags fields for detector restrictions.
+          ignore_missing (bool): If True, don't fail when a metadata
+            item can't be loaded, just try to proceed without it.
           no_signal (bool): If True, the .signal will be set to None.
             This is a way to get the axes and pointing info without
             the (large) TOD blob.  Not all loaders may support this.
@@ -275,7 +278,7 @@ class Context(odict):
         """
         meta = self.get_meta(obs_id=obs_id, dets=dets, samples=samples,
                              filename=filename, detsets=detsets, meta=meta,
-                             free_tags=free_tags)
+                             free_tags=free_tags, ignore_missing=ignore_missing)
 
         # Use the obs_id, dets, and samples from meta.
         obs_id = meta['obs_info']['obs_id']
@@ -308,6 +311,7 @@ class Context(odict):
                  meta=None,
                  free_tags=None,
                  check=False,
+                 ignore_missing=False,
                  det_info_scan=False):
         """Load supporting metadata for an observation and return it in an
         AxisManager.
@@ -439,7 +443,7 @@ class Context(odict):
         metadata_list = self._get_warn_missing('metadata', [])
         meta = self.loader.load(metadata_list, request, det_info=det_info, check=check,
                                 free_tags=free_tags, free_tag_fields=free_tag_fields,
-                                det_info_scan=det_info_scan)
+                                det_info_scan=det_info_scan, ignore_missing=ignore_missing)
         if check:
             return meta
 

--- a/sotodlib/core/metadata/__init__.py
+++ b/sotodlib/core/metadata/__init__.py
@@ -8,7 +8,7 @@ from .detdb import DetDb
 from .obsdb import ObsDb
 from .obsfiledb import ObsFileDb
 from .manifest import ManifestDb, ManifestScheme
-from .loader import SuperLoader, LoaderInterface, Unpacker
+from .loader import SuperLoader, LoaderInterface, Unpacker, merge_det_info
 
 def get_example(db_type, *args, **kwargs):
     if db_type == 'DetDb':

--- a/sotodlib/core/metadata/loader.py
+++ b/sotodlib/core/metadata/loader.py
@@ -467,9 +467,9 @@ def merge_det_info(det_info, new_info,
     """
     new_keys = _filter_items('dets:', new_info.keys)
     if (len(new_keys) != len(new_info.keys)):
-        reraise(spec, RuntimeError(
+        raise RuntimeError(
             f'New det_info metadata has keys without prefix "dets:": '
-            f'{new_info}'))
+            f'{new_info}')
     new_info.keys = new_keys
 
     for match_key in index_columns:
@@ -490,7 +490,7 @@ def merge_det_info(det_info, new_info,
     common_keys = set(new_info.keys) & set(det_info.keys)
     for k in common_keys:
         if len(i0) and np.any(new_info[k][i0] != det_info[k][i1]):
-            reraise(spec, ValueError(f'Conflict in field "{k}"'))
+            raise ValueError(f'Conflict in field "{k}"')
 
     logger.debug(f' ... updating det_info (row count '
                  f'{len(det_info)} -> {len(i1)})')

--- a/sotodlib/core/metadata/loader.py
+++ b/sotodlib/core/metadata/loader.py
@@ -1,5 +1,4 @@
 from sotodlib import core
-from ..axisman import get_coindices
 
 import logging
 import os
@@ -219,7 +218,7 @@ class SuperLoader:
                 # index_line.
                 det_restricts = _filter_items('dets:', index_line, remove=True)
                 dets_key = 'name'
-                new_dets, i_new, i_info = get_coindices(mi1.dets.vals, det_info['name'])
+                new_dets, i_new, i_info = core.util.get_coindices(mi1.dets.vals, det_info['name'])
                 mask = np.ones(len(i_new), bool)
                 for k, v in det_restricts.items():
                     mask *= (det_info[k][i_info] == v)
@@ -315,8 +314,11 @@ class SuperLoader:
             unmatched = []
             for k, v in det_reqs.items():
                 if k in det_info.keys:
-                    mask *= (det_info[k] == v)
-                    aug_request['dets:' + k] = v
+                    if isinstance(v, list):
+                        mask *= (core.util.get_multi_index(v, det_info[k]) >= 0)
+                    else:
+                        mask *= (det_info[k] == v)
+                        aug_request['dets:' + k] = v
                 else:
                     unmatched.append('dets:' + k)
             if final and len(unmatched):
@@ -417,7 +419,7 @@ def merge_det_info(det_info, new_info,
             f'No co-index key ({index_columns}) was found in both '
             f'{det_info} and {new_info}')
 
-    both, i0, i1 = get_coindices(new_info[match_key], det_info[match_key])
+    both, i0, i1 = core.util.get_coindices(new_info[match_key], det_info[match_key])
 
     # Common fields need to be in accordance, then drop them.
     common_keys = set(new_info.keys) & set(det_info.keys)

--- a/sotodlib/core/metadata/loader.py
+++ b/sotodlib/core/metadata/loader.py
@@ -13,15 +13,6 @@ REGISTRY = {
 }
 
 
-def _filter_items(prefix, d, remove=True):
-    # Restrict d to only items that start with prefix; if d is a dict,
-    # return a dict with only the keys that satisfy that condition.
-    if isinstance(d, dict):
-        return {k: d[prefix*remove + k]
-                for k in _filter_items(prefix, list(d.keys()), remove=remove)}
-    return [k[len(prefix)*remove:] for k in d if k.startswith(prefix)]
-
-
 class SuperLoader:
     def __init__(self, context=None, detdb=None, obsdb=None, working_dir=None):
         """Metadata batch loader.
@@ -255,7 +246,7 @@ class SuperLoader:
             described in load_one.
           request (dict): A request dict.
           det_info (AxisManager): Detector info table to use for
-            reconciling 'dets:*' field restrictions.
+            reconciling 'dets:...' field restrictions.
           free_tags (list of str): Strings that restrict the detector
             to any detector that matches the string in any of the
             det_info fields listed in free_tag_fields.
@@ -397,6 +388,15 @@ class SuperLoader:
         return dest
 
 
+def _filter_items(prefix, d, remove=True):
+    # Restrict d to only items that start with prefix; if d is a dict,
+    # return a dict with only the keys that satisfy that condition.
+    if isinstance(d, dict):
+        return {k: d[prefix*remove + k]
+                for k in _filter_items(prefix, list(d.keys()), remove=remove)}
+    return [k[len(prefix)*remove:] for k in d if k.startswith(prefix)]
+
+
 def merge_det_info(det_info, new_info,
                    index_columns=['readout_id', 'det_id']):
     """Args:
@@ -415,7 +415,7 @@ def merge_det_info(det_info, new_info,
       The input arguments det_info and new_info may be modified by
       this function.  Passing in None for det_info is convenient to
       initialize a det_info from a new_info where the columns are
-      named dets:* ...
+      named dets:... .
 
     """
     new_keys = _filter_items('dets:', new_info.keys)
@@ -478,6 +478,7 @@ def convert_det_info(det_info, dets=None):
         child = convert_det_info(sub_info, dets)
         output.wrap(subtable, child)
     return output
+
 
 class Unpacker:
     """Encapsulation of instructions for what information to extract from

--- a/sotodlib/core/metadata/loader.py
+++ b/sotodlib/core/metadata/loader.py
@@ -240,7 +240,7 @@ class SuperLoader:
         return result
 
     def load(self, spec_list, request, det_info=None, free_tags=[],
-             free_tag_fields=[], dest=None, check=False):
+             free_tag_fields=[], dest=None, check=False, det_info_scan=False):
         """Loads metadata objects and processes them into a single
         AxisManager.
 
@@ -258,6 +258,8 @@ class SuperLoader:
           dest (AxisManager or None): Destination container for the
             metadata (if None, a new one is created).
           check (bool): If True, run in check mode (see Notes).
+          det_info_scan (bool): If True, *only* process entries that
+            directly update det_info.
 
         Returns:
           In normal mode, an AxisManager containing the metadata
@@ -336,8 +338,12 @@ class SuperLoader:
         # Process each item.
         items = []
         for spec in spec_list:
+            if det_info_scan and not spec.get('det_info'):
+                continue
+
             logger.debug(f'Processing metadata spec={spec} with augmented '
                          f'request={aug_request}')
+
             try:
                 item = self.load_one(spec, aug_request, det_info)
                 error = None

--- a/sotodlib/core/metadata/loader.py
+++ b/sotodlib/core/metadata/loader.py
@@ -68,7 +68,7 @@ class SuperLoader:
           request (dict): A metadata request dict (stating what
             observation and detectors are of interest).
           det_info (ResultSet): Table of detector properties to use
-            when resolving metadata that is indexed with dets:*
+            when resolving metadata that is indexed with dets:...
             fields.
 
         Notes:
@@ -112,7 +112,7 @@ class SuperLoader:
           detectors, but the metadata index, or the user request,
           expresses that the result should be limited to only a subset
           of those detectors.  This is notated in practice by
-          including dets:* fields in the index data in the ManifestDb,
+          including dets:... fields in the index data in the ManifestDb,
           or in the request dict.  Only fields already present in
           det_info may be included in the request dict.
 
@@ -313,7 +313,7 @@ class SuperLoader:
             unmatched = []
             for k, v in det_reqs.items():
                 if k in det_info.keys:
-                    if isinstance(v, list):
+                    if isinstance(v, (list, np.ndarray)):
                         mask *= (core.util.get_multi_index(v, det_info[k]) >= 0)
                     else:
                         mask *= (det_info[k] == v)
@@ -485,7 +485,7 @@ class Unpacker:
     some source container, and what to call it in the destination
     container.
 
-    The classmethod :ref:method:``decode`` is used to populate
+    The classmethod :func:`decode` is used to populate
     Unpacker objects from metadata instructions; see docstring.
 
     Attributes:

--- a/sotodlib/core/metadata/loader.py
+++ b/sotodlib/core/metadata/loader.py
@@ -278,7 +278,8 @@ class SuperLoader:
         return result
 
     def load(self, spec_list, request, det_info=None, free_tags=[],
-             free_tag_fields=[], dest=None, check=False, det_info_scan=False):
+             free_tag_fields=[], dest=None, check=False, det_info_scan=False,
+             ignore_missing=False):
         """Loads metadata objects and processes them into a single
         AxisManager.
 
@@ -298,6 +299,8 @@ class SuperLoader:
           check (bool): If True, run in check mode (see Notes).
           det_info_scan (bool): If True, *only* process entries that
             directly update det_info.
+          ignore_missing (bool): If True, don't fail when a metadata
+            item can't be loaded, just try to proceed without it.
 
         Returns:
           In normal mode, an AxisManager containing the metadata
@@ -389,6 +392,10 @@ class SuperLoader:
             except Exception as e:
                 if check:
                     error = e
+                elif ignore_missing:
+                    logger.warning(f'Failed to load metadata for spec={spec}, '
+                                   f'request={aug_request}; ignoring.')
+                    continue
                 else:
                     reraise(spec, e)
 

--- a/sotodlib/core/metadata/loader.py
+++ b/sotodlib/core/metadata/loader.py
@@ -279,7 +279,13 @@ class SuperLoader:
             if obs_info is not None:
                 obs_info.update(request)
                 request = obs_info
-
+            if dest is None:
+                dest = core.AxisManager()
+            obs_man = core.AxisManager()
+            for k, v in obs_info.items():
+                obs_man.wrap(k[len('obs:'):], v)
+            dest.wrap('obs_info', obs_man)
+            
         def reraise(e, spec):
             e.args = e.args + (
                 "\n\nThe above exception arose while processing "

--- a/sotodlib/core/metadata/loader.py
+++ b/sotodlib/core/metadata/loader.py
@@ -375,7 +375,7 @@ class SuperLoader:
 
             # Make everything an axisman.
             if not isinstance(item, core.AxisManager):
-                item = item.axismanager(det_info=det_info)
+                item = item.axismanager(det_info=det_info, axis_key='readout_id')
 
             # Unpack it.
             try:

--- a/sotodlib/core/metadata/loader.py
+++ b/sotodlib/core/metadata/loader.py
@@ -214,8 +214,8 @@ class SuperLoader:
                 # that may be used to toss things out based on
                 # index_line.
                 det_restricts = _filter_items('dets:', index_line, remove=True)
-                dets_key = 'name'
-                new_dets, i_new, i_info = core.util.get_coindices(mi1.dets.vals, det_info['name'])
+                dets_key = 'readout_id'
+                new_dets, i_new, i_info = core.util.get_coindices(mi1.dets.vals, det_info[dets_key])
                 mask = np.ones(len(i_new), bool)
                 for k, v in det_restricts.items():
                     mask *= (det_info[k][i_info] == v)

--- a/sotodlib/core/metadata/manifest.py
+++ b/sotodlib/core/metadata/manifest.py
@@ -362,7 +362,7 @@ class ManifestDb:
             return None
         return row_id[0]
 
-    def match(self, params, multi=False):
+    def match(self, params, multi=False, prefix=None):
         """Given Index Data, return Endpoint Data.
 
         Arguments:
@@ -387,6 +387,9 @@ class ManifestDb:
         rows = c.fetchall()
         rp.insert(0, 'filename')
         rows = [dict(zip(rp, r)) for r in rows]
+        if prefix is not None:
+            for r in rows:
+                r['filename'] = os.path.join(prefix, r['filename'])
         if multi:
             return rows
         if len(rows) == 0:

--- a/sotodlib/core/metadata/obsfiledb.py
+++ b/sotodlib/core/metadata/obsfiledb.py
@@ -4,7 +4,7 @@ from collections import OrderedDict
 import numpy as np
 
 from . import common
-
+from .resultset import ResultSet
 
 TABLE_DEFS = {
     'detsets': [
@@ -232,6 +232,17 @@ class ObsFileDb:
         """
         c = self.conn.execute('select det from detsets where name=?', (detset,))
         return [r[0] for r in c]
+
+    def get_det_table(self, obs_id):
+        """Get table of detectors and detsets suitable for use with Context
+        det_info.  Returns Resultset with keys=['dets:detset','dets:readout_id'].
+
+        """
+        c = self.conn.execute(
+            'select detsets.name as `dets:detset`, det as `dets:readout_id`'
+            'from detsets join files '
+            'on files.detset=detsets.name where obs_id=?', (obs_id, ))
+        return ResultSet.from_cursor(c)
 
     def get_files(self, obs_id, detsets=None, prefix=None):
         """Get the file names associated with a particular obs_id and detsets.

--- a/sotodlib/core/metadata/resultset.py
+++ b/sotodlib/core/metadata/resultset.py
@@ -216,7 +216,7 @@ class ResultSet(object):
                 assert all(d not in dets for d in dets_i)  # Not disjoint!
                 dets.extend(dets_i)
                 indices.extend([row_i] * len(dets_i))
-            indices = np.array(indices)
+            indices = np.array(indices, dtype=int)
             aman = core.AxisManager(core.LabelAxis(axis_name, dets))
             for k in self.keys:
                 if not k.startswith(prefix):

--- a/sotodlib/core/metadata/resultset.py
+++ b/sotodlib/core/metadata/resultset.py
@@ -173,68 +173,6 @@ class ResultSet(object):
                     break
         assert(len(self.keys) == len(set(self.keys)))
 
-    def axismanager(self, det_info=None, axis_name='dets',
-                    axis_key='name', prefix='dets:'):
-        """Convert self to a Context-compatible AxisManager.
-
-        Rows of this ResultSet correspond to the AxisManager axis_name
-        ("dets" by default).  The axis values are taken from field
-        prefix+axis_key, if that field exists in self; otherwise they
-        are taken from det_info (where axis_key must be a field).  In
-        the latter case, the fields in self starting with prefix are
-        joined, in the SQL sense, against the fields with the same
-        name in det_info.
-
-        The AxisManager that is returned may not have as many rows as
-        either det_info or self.
-
-        """
-        from sotodlib import core
-
-        # Determine the dets axis columns
-        dets_cols = {}
-        for k in self.keys:
-            if k.startswith(prefix):
-                dets_cols[k] = k[len(prefix):]
-        # Get the detector names for entry.
-        if axis_key in dets_cols:
-            # If axis_key is a field in this dataset, there should be
-            # one row per detector, and construction is simple.
-            dets = self[axis_key]
-            assert(len(dets) == len(set(dets)))  # unique list?
-            aman = core.AxisManager(core.LabelAxis(axis_name, dets))
-            for k in self.keys:
-                if not k.startswith(prefix):
-                    aman.wrap(k, self[k], [(0, axis_name)])
-        else:
-            # Each row in self represents more than one detector, and
-            # we want to broadcast that to one row per detector.
-            if det_info is None:
-                raise RuntimeError(
-                    'Expansion to dets axes requires det_info '
-                    'but None was not passed in.')
-
-            row_map = {}  # map from multi-key value to row in self
-            for i, row in enumerate(self):
-                key = tuple([row[k] for k in dets_cols.keys()])
-                if key in row_map:
-                    raise ValueError("Duplicate entries for combined unique key.")
-                row_map[key] = i
-
-            # Get index of self that corresponds to each row in det_info.
-            indices = np.array(
-                [row_map.get(tuple(row.values()), -1)
-                 for row in det_info.subset(keys=dets_cols.values())])
-            mask = indices >= 0
-            dets = det_info[axis_key][mask]
-            indices = indices[mask]
-
-            aman = core.AxisManager(core.LabelAxis(axis_name, dets))
-            for k in self.keys:
-                if not k.startswith(prefix):
-                    aman.wrap(k, self[k][indices], [(0, axis_name)])
-        return aman
-
     def restrict_dets(self, restriction, detdb=None):
         # There are 4 classes of keys:
         # - dets:* keys appearing only in restriction

--- a/sotodlib/core/util.py
+++ b/sotodlib/core/util.py
@@ -1,0 +1,72 @@
+import numpy as np
+
+def get_coindices(v0, v1):
+    """Given vectors v0 and v1, each of which contains no duplicate
+    values, determine the elements that are found in both vectors.
+    Returns (vals, i0, i1), i.e. the vector of common elements and
+    the vectors of indices into v0 and v1 where those elements are
+    found.
+
+    This routine will use np.intersect1d if it can.  The ordering of
+    the results is different from intersect1d -- vals is not sorted,
+    but rather the elements will appear in the same order that they
+    were found in v0 (so that i0 is strictly increasing).
+
+    """
+    try:
+        vals, i0, i1 = np.intersect1d(v0, v1, return_indices=True)
+        order = np.argsort(i0)
+        return vals[order], i0[order], i1[order]
+    except TypeError:  # return_indices not implemented in numpy < 1.15
+        pass
+
+    # The old fashioned way
+    v0 = np.asarray(v0)
+    w0 = sorted([(j, i) for i, j in enumerate(v0)])
+    w1 = sorted([(j, i) for i, j in enumerate(v1)])
+    i0, i1 = 0, 0
+    pairs = []
+    while i0 < len(w0) and i1 < len(w1):
+        if w0[i0][0] == w1[i1][0]:
+            pairs.append((w0[i0][1], w1[i1][1]))
+            i0 += 1
+            i1 += 1
+        elif w0[i0][0] < w1[i1][0]:
+            i0 += 1
+        else:
+            i1 += 1
+    if len(pairs) == 0:
+        return (np.zeros(0, v0.dtype), np.zeros(0, int), np.zeros(0, int))
+    pairs.sort()
+    i0, i1 = np.transpose(pairs)
+    return v0[i0], i0, i1
+
+
+def get_multi_index(short_list, long_list):
+    """For each item in long_list, determine the index at which it occurs
+    in short_list.  Returns the equivalent of::
+
+       np.array([short_list.index(x) if x in short_list else -1
+                 for x in long_list])
+
+    """
+    w0 = sorted([(j, i) for i, j in enumerate(short_list)])
+    w1 = sorted([(j, i) for i, j in enumerate(long_list)])
+    i0, i1 = 0, 0
+    indices = []
+    while i0 < len(w0) and i1 < len(w1):
+        if w0[i0][0] == w1[i1][0]:
+            indices.append((w1[i1][1], w0[i0][1]))
+            i1 += 1
+        elif w0[i0][0] < w1[i1][0]:
+            i0 += 1
+        else:
+            indices.append((w1[i1][1], -1))
+            i1 += 1
+    while i1 < len(w1):
+        indices.append((w1[i1][1], -1))
+        i1 += 1
+    if len(indices) == 0:
+        return np.zeros(0, int)
+    indices.sort()
+    return np.array([i0 for i1, i0 in indices])

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -8,7 +8,8 @@
 import unittest
 import tempfile
 
-from sotodlib.core import metadata, Context
+from sotodlib import core
+from sotodlib.core import metadata, Context, OBSLOADER_REGISTRY
 from sotodlib.io.metadata import ResultSetHdfLoader, write_dataset, _decode_array
 
 import os
@@ -93,6 +94,179 @@ class ContextTest(unittest.TestCase):
         self.assertEqual(len(req['dets']), 1)
         req = ctx.get_obs('obs0', logic_only=True, dets={'band': 'f090'})
         self.assertEqual(len(req['dets']), len(det_list) // 2)
+
+    def test_100_loads(self):
+        dataset_sim = DatasetSim()
+
+        # Test detector resolutions ...
+        ctx = dataset_sim.get_context()
+        n = len(dataset_sim.dets)
+        for selection, count in [
+                ({'dets:readout_id': ['det05']}, 1),
+                ({'dets:detset': 'neard'}, 4),
+                ({'dets:detset': ['neard']}, 4),
+                ({'dets:detset': ['neard', 'fard']}, 8),
+                ({'dets:detset': ['neard'], 'dets:readout_id': ['det00', 'det05']}, 1),
+                ({'dets:readout_id': ['xx']}, 0),
+                ({'dets:band': ['f090']}, 4),
+                ({'dets:band': ['f090'], 'dets:detset': ['neard']}, 2),
+        ]:
+            selection['obs:obs_id'] = dataset_sim.obss['obs_id'][1]
+            meta = ctx.get_meta(selection)
+            self.assertEqual(meta.dets.count, count, msg=f"{selection}")
+
+        # And without detdb nor metadata
+        ctx = dataset_sim.get_context(with_detdb=False)
+        for selection, count in [
+                ({'dets:detset': ['neard']}, 4),
+        ]:
+            selection['obs:obs_id'] = dataset_sim.obss['obs_id'][1]
+            meta = ctx.get_meta(selection)
+            self.assertEqual(meta.dets.count, count, msg=f"{selection}")
+
+    def test_110_more_loads(self):
+        dataset_sim = DatasetSim()
+        n_det, n_samp = dataset_sim.det_count, dataset_sim.sample_count
+        obs_id = dataset_sim.obss['obs_id'][1]
+
+        # Test some TOD loading.
+        ctx = dataset_sim.get_context()
+        tod = ctx.get_obs(obs_id)
+        self.assertEqual(tod.signal.shape, (n_det, n_samp))
+
+        tod = ctx.get_obs(obs_id + ':f090')
+        self.assertEqual(tod.signal.shape, (n_det//2, n_samp))
+
+        tod = ctx.get_obs(obs_id, free_tags=['f150'])
+        self.assertEqual(tod.signal.shape, (n_det//2, n_samp))
+
+        tod = ctx.get_obs(obs_id, samples=(10, n_samp // 2))
+        self.assertEqual(tod.signal.shape, (n_det, n_samp // 2 - 10))
+
+        # Loading via filename
+        tod = ctx.get_obs(filename='obs_number_11_neard.txt')
+        self.assertEqual(tod.signal.shape, (n_det//2, n_samp))
+
+        # Loading via prepopulated & modified meta
+        meta = ctx.get_meta(obs_id)
+        meta.restrict('dets', meta.dets.vals[:5])
+        tod = ctx.get_obs(meta)
+        self.assertEqual(tod.signal.shape, (5, n_samp))
+
+
+class DatasetSim:
+    """Provide in-RAM Context objects and tod/metadata loader functions
+    for Context behavior testing.
+
+    """
+    def __init__(self):
+        self.dets = metadata.ResultSet(
+            ['readout_id', 'band', 'pol_code', 'x', 'y'],
+            [('det00', 'f090', 'A', 0.0, 0.0),
+             ('det01', 'f090', 'B', 0.0, 0.0),
+             ('det02', 'f150', 'A', 0.0, 0.0),
+             ('det03', 'f150', 'B', 0.0, 0.0),
+             ('det04', 'f090', 'A', 1.0, 0.0),
+             ('det05', 'f090', 'B', 1.0, 0.0),
+             ('det06', 'f150', 'A', 1.0, 0.0),
+             ('det07', 'f150', 'B', 1.0, 0.0)])
+
+        self.obss = metadata.ResultSet(
+            ['obs_id', 'timestamp', 'type', 'target'],
+            [('obs_number_11', 1600010000., 'planet', 'uranus'),
+             ('obs_number_12', 1600020000., 'survey', 'the_cmb'),
+             ('obs_number_13', 1600030000., 'survey', 'the_cmb'),
+            ])
+
+        self.det_count = len(self.dets)
+        self.sample_count = 100
+
+        class _TestML(metadata.LoaderInterface):
+            def from_loadspec(_self, load_params):
+                return self.metadata_loader(load_params)
+
+        OBSLOADER_REGISTRY['unittest_loader'] = self.tod_loader
+        metadata.SuperLoader.register_metadata('unittest_loader', _TestML)
+
+    def get_context(self, with_detdb=True, with_metadata=True):
+        detdb = metadata.DetDb()
+        detdb.create_table('base', ['readout_id string',
+                                    'pol_code string',
+                                    'x float',
+                                    'y float'])
+        save_for_later = ['band']
+        for row in self.dets.subset(keys=[k for k in self.dets.keys
+                                          if k not in save_for_later]):
+            detdb.add_props('base', row['readout_id'], **row)
+
+        obsdb = metadata.ObsDb()
+        obsdb.add_obs_columns([f'{k} string' for k in self.obss.keys
+                               if k not in ['obs_id', 'timestamp']])
+        for row in self.obss:
+            obsdb.update_obs(row['obs_id'], data=row)
+
+        obsfiledb = metadata.ObsFileDb()
+        obsfiledb.add_detset('neard', self.dets['readout_id'][:len(self.dets)//2])
+        obsfiledb.add_detset('fard',  self.dets['readout_id'][len(self.dets)//2:])
+        for obs_id in self.obss['obs_id']:
+            obsfiledb.add_obsfile(f'{obs_id}_neard.txt', obs_id, 'neard',
+                                  0, self.sample_count)
+            obsfiledb.add_obsfile(f'{obs_id}_fard.txt', obs_id, 'fard',
+                                  0, self.sample_count)
+
+        ctx = Context(data=MINIMAL_CONTEXT)
+        ctx.obsdb = obsdb
+        ctx.obsfiledb = obsfiledb
+        if with_detdb:
+            ctx.detdb = detdb
+        ctx.reload(['loader'])
+        ctx.update({
+            'obs_loader_type': 'unittest_loader',
+            'obs_colon_tags': ['band'],
+        })
+
+        # metadata: bands.h5
+        _scheme = metadata.ManifestScheme() \
+                  .add_data_field('loader') \
+                  .add_range_match('obs:timestamp')
+        bands_db = metadata.ManifestDb(scheme=_scheme)
+        bands_db.add_entry({'obs:timestamp': [0, 2e9], 'loader': 'unittest_loader'}, 'bands.h5')
+
+        if with_metadata:
+            ctx['metadata'] = [
+                {'db': bands_db,
+                 'det_info': True,
+                 'dets_key': 'readout_id'},
+            ]
+
+        return ctx
+
+    def metadata_loader(self, kw):
+        # For Superloader.
+        filename = os.path.split(kw['filename'])[1]
+        if filename == 'bands.h5':
+            rs = self.dets.subset(keys=['readout_id', 'band'])
+            rs.keys = ['dets:' + k for k in rs.keys]
+            return rs
+        else:
+            raise ValueError(f'metadata request for "{filename}"')
+
+    def tod_loader(self, obsfiledb, obs_id, dets=None, prefix=None,
+                   samples=None, no_signal=None,
+                   **kwargs):
+        # For Context.get_obs
+        if samples is None:
+            samples = 0, None
+        samples = list(samples)
+        if samples[1] is None:
+            samples[1] = self.sample_count
+        samples = [s if s >= 0 else self.sample_count + s
+                   for s in samples]
+
+        tod = core.AxisManager(core.LabelAxis('dets', dets),
+                               core.OffsetAxis('samps', samples[1] - samples[0], samples[0]))
+        tod.wrap_new('signal', ('dets', 'samps'))
+        return tod
 
 
 if __name__ == '__main__':

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,0 +1,99 @@
+# Copyright (c) 2022 Simons Observatory.
+# Full license can be found in the top level "LICENSE" file.
+
+"""Test Context class, including metadata and TOD loading.
+
+"""
+
+import unittest
+import tempfile
+
+from sotodlib.core import metadata, Context
+from sotodlib.io.metadata import ResultSetHdfLoader, write_dataset, _decode_array
+
+import os
+import h5py
+import sqlite3
+import yaml
+
+from ._helpers import mpi_multi
+
+MINIMAL_CONTEXT = {
+    'tags': {},
+    'imports': [],
+    'metadata': [],
+    }
+
+
+@unittest.skipIf(mpi_multi(), "Running with multiple MPI processes")
+class ContextTest(unittest.TestCase):
+
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+
+    def tearDown(self):
+        self.tempdir.cleanup()
+
+    def _open_new(self, name, mode='w'):
+        full = os.path.join(self.tempdir.name, name)
+        if mode == 'create':
+            open(full, 'w').close()
+            fout = None
+        else:
+            fout = open(full, mode)
+        return full, fout
+
+    def _write_context(self, d):
+        name, fout = self._open_new('context.yaml')
+        fout.write(yaml.dump(d))
+        fout.close()
+        return name
+
+    def test_000_smoke(self):
+        ctx_file = self._write_context(MINIMAL_CONTEXT)
+        ctx = Context(ctx_file)
+
+    def test_001_dbs(self):
+        # Does context populate obsdb, detdb, obsfiledb from file?
+        for key, cls in [
+                ('obsdb', metadata.ObsDb),
+                ('detdb', metadata.DetDb),
+                ('obsfiledb', metadata.ObsFileDb),
+        ]:
+            cd = MINIMAL_CONTEXT.copy()
+            db = cls()
+            name, _ = self._open_new('db.sqlite', 'create')
+            db.to_file(name)
+            cd[key] = name
+            ctx = Context(self._write_context(cd))
+            self.assertIsInstance(getattr(ctx, key), cls)
+
+    def test_010_metadata(self):
+        obs_list = ['obs%i' % i for i in range(2)]
+        det_list = ['det%i' % i for i in range(4)]
+        ctx = Context(self._write_context(MINIMAL_CONTEXT))
+
+        ctx.obsdb = metadata.ObsDb()
+        for i, obs_id in enumerate(obs_list):
+            ctx.obsdb.update_obs(obs_id, data={'timestamp': 1680000000 + i*600})
+
+        ctx.detdb = metadata.DetDb()
+        ctx.detdb.create_table('base', [
+            "`index` integer",
+            "`band` string",
+        ])
+        for i, d in enumerate(det_list):
+            ctx.detdb.add_props('base', d,
+                                index=i,
+                                band={0: 'f090', 1: 'f150'}[i % 2])
+
+        req = ctx.get_obs('obs0', logic_only=True)
+        self.assertEqual(len(req['dets']), len(det_list))
+        req = ctx.get_obs('obs0', logic_only=True, dets=['det0'])
+        self.assertEqual(len(req['dets']), 1)
+        req = ctx.get_obs('obs0', logic_only=True, dets={'band': 'f090'})
+        self.assertEqual(len(req['dets']), len(det_list) // 2)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -116,6 +116,11 @@ class ContextTest(unittest.TestCase):
         checks = ctx.get_meta(obs_id, check=True)
         self.assertIsInstance(checks, list)
 
+        # Check det_info mode
+        det_info = ctx.get_det_info(obs_id)
+        self.assertIsInstance(det_info, metadata.ResultSet)
+        self.assertEqual(len(det_info), n)
+
     def test_110_more_loads(self):
         dataset_sim = DatasetSim()
         n_det, n_samp = dataset_sim.det_count, dataset_sim.sample_count
@@ -127,17 +132,17 @@ class ContextTest(unittest.TestCase):
         self.assertEqual(tod.signal.shape, (n_det, n_samp))
 
         tod = ctx.get_obs(obs_id + ':f090')
-        self.assertEqual(tod.signal.shape, (n_det//2, n_samp))
+        self.assertEqual(tod.signal.shape, (n_det // 2, n_samp))
 
         tod = ctx.get_obs(obs_id, free_tags=['f150'])
-        self.assertEqual(tod.signal.shape, (n_det//2, n_samp))
+        self.assertEqual(tod.signal.shape, (n_det // 2, n_samp))
 
         tod = ctx.get_obs(obs_id, samples=(10, n_samp // 2))
         self.assertEqual(tod.signal.shape, (n_det, n_samp // 2 - 10))
 
         # Loading via filename
         tod = ctx.get_obs(filename='obs_number_11_neard.txt')
-        self.assertEqual(tod.signal.shape, (n_det//2, n_samp))
+        self.assertEqual(tod.signal.shape, (n_det // 2, n_samp))
 
         # Loading via prepopulated & modified meta
         meta = ctx.get_meta(obs_id)
@@ -151,6 +156,11 @@ class ContextTest(unittest.TestCase):
         meta.restrict('dets', meta.dets.vals[:5])
         tod = ctx.get_obs(meta)
         self.assertEqual(tod.signal.shape, (5, 80))
+
+        det_info = ctx.get_det_info(obs_id)
+        det_info = det_info.subset(rows=det_info['band'] == 'f090')
+        tod = ctx.get_obs(obs_id, dets=det_info)
+        self.assertEqual(tod.signal.shape, (n_det // 2, n_samp))
 
 
 class DatasetSim:

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -127,6 +127,12 @@ class ContextTest(unittest.TestCase):
         self.assertIsInstance(det_info, metadata.ResultSet)
         self.assertEqual(len(det_info), n)
 
+        # Check tolerant mode
+        ctx = dataset_sim.get_context(with_bad_metadata=True)
+        with self.assertRaises(Exception):
+            ctx.get_meta(obs_id)
+        ctx.get_meta(obs_id, ignore_missing=True)
+
     def test_110_more_loads(self):
         dataset_sim = DatasetSim()
         n_det, n_samp = dataset_sim.det_count, dataset_sim.sample_count
@@ -209,7 +215,8 @@ class DatasetSim:
         OBSLOADER_REGISTRY['unittest_loader'] = self.tod_loader
         metadata.SuperLoader.register_metadata('unittest_loader', _TestML)
 
-    def get_context(self, with_detdb=True, with_metadata=True):
+    def get_context(self, with_detdb=True, with_metadata=True,
+                    with_bad_metadata=False):
         detdb = metadata.DetDb()
         detdb.create_table('base', ['readout_id string',
                                     'pol_code string',
@@ -313,6 +320,13 @@ class DatasetSim:
             {'db': info_db,
              'name': 'focal_plane'},
         ]
+
+        if with_bad_metadata:
+            # This entry is intended to cause a lookup failure.
+            ctx['metadata'].insert(0, {
+                'db': 'not-a-file.sqlite',
+                'name': 'important_info&',
+            })
 
         return ctx
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -109,7 +109,11 @@ class ContextTest(unittest.TestCase):
             self.assertEqual(meta.dets.count, count, msg=f"{selection}")
 
         # And with obs_id as a dict.
-        meta = ctx.get_meta({'obs:obs_id': obs_id})
+        meta = ctx.get_meta({'obs_id': obs_id})
+        self.assertEqual(meta.dets.count, 8)
+
+        # You know, the kind of dict you get from obsdb.
+        meta = ctx.get_meta(ctx.obsdb.get()[0])
         self.assertEqual(meta.dets.count, 8)
 
         # Check check mode

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -69,32 +69,6 @@ class ContextTest(unittest.TestCase):
             ctx = Context(self._write_context(cd))
             self.assertIsInstance(getattr(ctx, key), cls)
 
-    def test_010_metadata(self):
-        obs_list = ['obs%i' % i for i in range(2)]
-        det_list = ['det%i' % i for i in range(4)]
-        ctx = Context(self._write_context(MINIMAL_CONTEXT))
-
-        ctx.obsdb = metadata.ObsDb()
-        for i, obs_id in enumerate(obs_list):
-            ctx.obsdb.update_obs(obs_id, data={'timestamp': 1680000000 + i*600})
-
-        ctx.detdb = metadata.DetDb()
-        ctx.detdb.create_table('base', [
-            "`index` integer",
-            "`band` string",
-        ])
-        for i, d in enumerate(det_list):
-            ctx.detdb.add_props('base', d,
-                                index=i,
-                                band={0: 'f090', 1: 'f150'}[i % 2])
-
-        req = ctx.get_obs('obs0', logic_only=True)
-        self.assertEqual(len(req['dets']), len(det_list))
-        req = ctx.get_obs('obs0', logic_only=True, dets=['det0'])
-        self.assertEqual(len(req['dets']), 1)
-        req = ctx.get_obs('obs0', logic_only=True, dets={'band': 'f090'})
-        self.assertEqual(len(req['dets']), len(det_list) // 2)
-
     def test_100_loads(self):
         dataset_sim = DatasetSim()
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -382,5 +382,25 @@ class TestFlagManager(unittest.TestCase):
         tod.wrap('flags', flags)
         self.assertTrue( type(tod.flags) == core.FlagManager )
 
+
+class TestUtil(unittest.TestCase):
+    def test_coindices(self):
+        x = ['d', 'a', 'g', 'e', 'b']
+        y = ['x', 'b', 'o', 'd', 'q']
+        z, i0, i1 = core.util.get_coindices(x, y)
+        the_answers = (['d', 'b'], [0, 4], [3, 1])
+        self.assertEqual(list(z),  the_answers[0])
+        self.assertEqual(list(i0), the_answers[1])
+        self.assertEqual(list(i1), the_answers[2])
+
+    def test_multi_index(self):
+        x = ['x', 'y', 'c', 'a']
+        y = ['a', 'a', 'b', 'c', 'a', 'u']
+        ix = core.util.get_multi_index(x, y)
+        the_answer = np.array([x.index(_y) if _y in x else -1
+                               for _y in y])
+        self.assertEqual(list(ix), list(the_answer))
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -157,6 +157,17 @@ class TestAxisManager(unittest.TestCase):
         aman = core.AxisManager.concatenate([amanA, amanB], axis='dets')
         self.assertEqual(aman.signal.shape[0], len(detsA) + len(detsB))
 
+        # Even if one is empty?
+        amanX = amanA.restrict('dets', [])
+        amanY = amanB.copy()
+        aman = core.AxisManager.concatenate([amanX, amanY])
+        self.assertEqual(aman.signal.shape[0], amanY.signal.shape[0])
+
+        # or both are empty?
+        amanY = amanB.restrict('dets', [])
+        aman = core.AxisManager.concatenate([amanX, amanY])
+        self.assertEqual(aman.signal.shape[0], 0)
+
         # Handling of array that does not share the axis?
         amanA.wrap_new('azimuth', shape=('samps',))[:] = 1.
         amanB.wrap_new('azimuth', shape=('samps',))[:] = 2.

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -99,7 +99,6 @@ class MetadataTest(unittest.TestCase):
             'c.h5', mandb.match({'obs:timestamp': 100})['filename'])
 
     def test_020_db_resolution(self):
-
         """Test metadata detdb/obsdb resolution system
 
         This tests one of the more complicated cases:
@@ -133,11 +132,11 @@ class MetadataTest(unittest.TestCase):
 
         # To match the early/late example we need DetDb and ObsDb.
         detdb = metadata.DetDb()
-        detdb.create_table('base', ["`name` str", "`band` str", "`polcode` str"])
-        detdb.add_props('base', 'det1', name='det1', band='f090', polcode='A')
-        detdb.add_props('base', 'det2', name='det2', band='f090', polcode='B')
-        detdb.add_props('base', 'det3', name='det3', band='f150', polcode='A')
-        detdb.add_props('base', 'det4', name='det4', band='f150', polcode='B')
+        detdb.create_table('base', ["`readout_id` str", "`band` str", "`polcode` str"])
+        detdb.add_props('base', 'det1', readout_id='det1', band='f090', polcode='A')
+        detdb.add_props('base', 'det2', readout_id='det2', band='f090', polcode='B')
+        detdb.add_props('base', 'det3', readout_id='det3', band='f150', polcode='A')
+        detdb.add_props('base', 'det4', readout_id='det4', band='f150', polcode='B')
 
         obsdb = metadata.ObsDb()
         t_pivot = 2000010000

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -133,11 +133,11 @@ class MetadataTest(unittest.TestCase):
 
         # To match the early/late example we need DetDb and ObsDb.
         detdb = metadata.DetDb()
-        detdb.create_table('base', ["`band` str", "`polcode` str"])
-        detdb.add_props('base', 'det1', band='f090', polcode='A')
-        detdb.add_props('base', 'det2', band='f090', polcode='B')
-        detdb.add_props('base', 'det3', band='f150', polcode='A')
-        detdb.add_props('base', 'det4', band='f150', polcode='B')
+        detdb.create_table('base', ["`name` str", "`band` str", "`polcode` str"])
+        detdb.add_props('base', 'det1', name='det1', band='f090', polcode='A')
+        detdb.add_props('base', 'det2', name='det2', band='f090', polcode='B')
+        detdb.add_props('base', 'det3', name='det3', band='f150', polcode='A')
+        detdb.add_props('base', 'det4', name='det4', band='f150', polcode='B')
 
         obsdb = metadata.ObsDb()
         t_pivot = 2000010000
@@ -171,7 +171,7 @@ class MetadataTest(unittest.TestCase):
             {'db': mandb_fn,
              'name': 'tau&timeconst'}
         ]
-        mtod = loader.load(spec_list, {'obs:obs_id': 'obs_00'})
+        mtod = loader.load(spec_list, {'obs:obs_id': 'obs_00'}, detdb.props())
         self.assertCountEqual(mtod['tau'], [T090, T090, T150, T150])
 
         # Test 2: ManifestDb specifies polcode, which crosses with
@@ -196,7 +196,7 @@ class MetadataTest(unittest.TestCase):
         # Now we expect only f090 A and f150 B to resolve to non-bad vals.
         # Make sure you reinit the loader, to avoid cached dbs.
         loader = metadata.SuperLoader(obsdb=obsdb, detdb=detdb)
-        mtod = loader.load(spec_list, {'obs:obs_id': 'obs_00'})
+        mtod = loader.load(spec_list, {'obs:obs_id': 'obs_00'}, detdb.props())
         self.assertCountEqual(mtod['tau'], [T090, TBAD, TBAD, T150])
 
 


### PR DESCRIPTION
Addresses everything listed in #261 .  (Supersedes #264 as the comments below reflect major interface changes.)

I am still interested in feedback on the context.get_obs/get_meta interface, but I think it's much better now.  You can do any of the following for get_obs:
```
   ctx.get_obs(obs_id)
   ctx.get_obs(obs_id, dets=['det_01', 'det_02'])
   ctx.get_obs(obs_id, detsets=['w29'])
   ctx.get_obs(obs_id, dets={'readout_id': ['det_01', 'det_02']})
   ctx.get_obs(obs_id, dets={'detset': ['w29']})
   ctx.get_obs(obs_id, dets={'band': 'f090'})
```

Also, filename= still works. And you can throw in samples=(start, stop). And you can still use "obs_colon_tags" (internal nomenclature is now "free tags"). Another example, with 'band' as a free tag:
```
   ctx.get_obs(obs_id+':f090', samples=(0, 1000))
```
For get_meta, the interface is basically the same:
```
   meta = ctx.get_meta(obs_id)  # a string
   meta = ctx.get_meta(obs_id, dets={'band': 'f090'})
```
With that meta result you can do:
```
   tod = ctx.get_obs(meta)
```
and it will magically work, even if you manipulate the meta .dets and/or .samps axes. So that's cool.

Couple other notes:

- The way to add new det_info fields is through a special metadata entry. The loader in that case should return a ResultSet with columns dets:readout_id and dets:new stuff. We can make this more general but it would be nice to limit the options here. This is highly compatible with simple HDF5 tables.
- The AxisManager .dets axis always just contains the readout_id. We can add a promotion step that flips it over to some other field, at the end. If we're loading other 2-d metadata, along the way, that happen to be indexed by det_id (this seems unlikely...) then we can add a metadata setting that indicates what det_info field to reconcile against (i.e. to translate .dets from dets:whatever to dets:readout_id before trying to combine the AxisManagers)
- The DetDb is not used except to turn it into the first iteration of det_info. The hook Joe added might still work... it will probably only need to be called from one place. We don't need to store obs_detdb.  We should consider redefining the hook to act on det_info (the ResultSet) instead of a DetDb.
