### PR TITLE
Gen det db detmap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# pychram
+.idea

--- a/sotodlib/site_pipeline/make_det_info_wafer.py
+++ b/sotodlib/site_pipeline/make_det_info_wafer.py
@@ -31,9 +31,7 @@ def main(args=None):
     scheme = core.metadata.ManifestScheme()
     scheme.add_range_match('obs:timestamp')
     scheme.add_data_field('dataset')
-    db = core.metadata.ManifestDb(configs["det_db"], scheme=scheme)  
-    
-    out_dir, out_file = os.path.split(configs["det_info"])
+    db = core.metadata.ManifestDb(configs["det_db"], scheme=scheme)
     
     w = "dets:wafer."
     keys = [
@@ -59,20 +57,13 @@ def main(args=None):
     det_rs = core.metadata.ResultSet(keys=keys)
     
     for array_name in array_names:
-        # Generate the OperateTuneData for the Array
-        map_maker = MapMaker( north_is_highband=False, ## should not matter for this
-                              array_name=array_name,
-                              dark_bias_lines=None,
-                              output_parent_dir=out_dir,
-                              verbose=False)
-        otd, layout = map_maker.load_metadata()
-        otd.map_layout_data(layout)
-
-        ## we CANNOT use otd.tune_data for the for loop.
-        ## probably need docs/change control on the IDs in DetMap if that
-        ## the source of the IDs
-        for tune in otd: 
-            #print(tune.detector_id, tune.is_optical)
+        # Initialize a detmap.makemap.MapMaker() instance that will have ideal/design metadata for this array.
+        map_maker = MapMaker(north_is_highband=False,  # used to set smurf_band in metadata
+                             array_name=array_name,
+                             verbose=False)
+        # iterate over the ideal/design metadata for this array
+        for tune in map_maker.grab_metadata():
+            # print(tune.detector_id, tune.is_optical)
             # add detector name to database
             det_rs.append({
                 "dets:det_id": tune.detector_id,

--- a/sotodlib/site_pipeline/make_det_info_wafer.py
+++ b/sotodlib/site_pipeline/make_det_info_wafer.py
@@ -9,53 +9,53 @@ from detmap.makemap import MapMaker
 from sotodlib import core
 from sotodlib.io.metadata import write_dataset
 
-
 logger = logging.getLogger(__name__)
+
 
 def parse_args():
     parser = ArgumentParser()
-    parser.add_argument('-c', '--config-file',help=
-                        "Configuration File for running DetMap")
+    parser.add_argument('-c', '--config-file', help="Configuration File for running DetMap")
     args = parser.parse_args()
     return args
+
 
 def main(args=None):
     if args is None:
         args = parse_args()
-        
+
     configs = yaml.safe_load(open(args.config_file, "r"))
 
     array_names = [array["name"] for array in configs["arrays"]]
     logger.info(f"Creating Det Info for UFMs-{','.join([array for array in array_names])}")
-    
+
     scheme = core.metadata.ManifestScheme()
     scheme.add_range_match('obs:timestamp')
     scheme.add_data_field('dataset')
     db = core.metadata.ManifestDb(configs["det_db"], scheme=scheme)
-    
+
     w = "dets:wafer."
     keys = [
         "dets:det_id",
-        w+"array",
-        w+"bond_pad",
-        w+"mux_band",
-        w+"mux_channel",
-        w+"mux_subband",
-        w+"mux_position",
-        w+"design_freq_mhz",
-        w+"bias_line",
-        w+"pol",
-        w+"bandpass",
-        w+"det_row",
-        w+"det_col",
-        w+"rhombus",
-        w+"type",
-        w+"det_x",
-        w+"det_y",
-        w+"angle",
+        w + "array",
+        w + "bond_pad",
+        w + "mux_band",
+        w + "mux_channel",
+        w + "mux_subband",
+        w + "mux_position",
+        w + "design_freq_mhz",
+        w + "bias_line",
+        w + "pol",
+        w + "bandpass",
+        w + "det_row",
+        w + "det_col",
+        w + "rhombus",
+        w + "type",
+        w + "det_x",
+        w + "det_y",
+        w + "angle",
     ]
     det_rs = core.metadata.ResultSet(keys=keys)
-    
+
     for array_name in array_names:
         # Initialize a detmap.makemap.MapMaker() instance that will have ideal/design metadata for this array.
         map_maker = MapMaker(north_is_highband=False,  # used to set smurf_band in metadata
@@ -67,25 +67,25 @@ def main(args=None):
             # add detector name to database
             det_rs.append({
                 "dets:det_id": tune.detector_id,
-                w+"array": array_name,
-                w+"bond_pad": tune.bond_pad,
-                w+"mux_band": str(tune.mux_band),
-                w+"mux_channel": none_to_nan(tune.mux_channel),
-                w+"mux_subband": none_to_nan(tune.mux_subband),
-                w+"mux_position": none_to_nan(tune.mux_layout_position),
-                w+"design_freq_mhz": none_to_nan(tune.design_freq_mhz),
-                w+"bias_line": none_to_nan(tune.bias_line),
-                w+"pol": str(tune.pol),
-                w+"bandpass": f"f{tune.bandpass}" if tune.bandpass is not None else "NC",
-                w+"det_row": none_to_nan(tune.det_row),
-                w+"det_col": none_to_nan(tune.det_col),
-                w+"rhombus": str(tune.rhomb),
-                w+"type": str(tune.det_type),
-                w+"det_x": none_to_nan(tune.det_x),
-                w+"det_y": none_to_nan(tune.det_y),
-                w+"angle": np.radians(none_to_nan(tune.angle_actual_deg)),
+                w + "array": array_name,
+                w + "bond_pad": tune.bond_pad,
+                w + "mux_band": str(tune.mux_band),
+                w + "mux_channel": none_to_nan(tune.mux_channel),
+                w + "mux_subband": none_to_nan(tune.mux_subband),
+                w + "mux_position": none_to_nan(tune.mux_layout_position),
+                w + "design_freq_mhz": none_to_nan(tune.design_freq_mhz),
+                w + "bias_line": none_to_nan(tune.bias_line),
+                w + "pol": str(tune.pol),
+                w + "bandpass": f"f{tune.bandpass}" if tune.bandpass is not None else "NC",
+                w + "det_row": none_to_nan(tune.det_row),
+                w + "det_col": none_to_nan(tune.det_col),
+                w + "rhombus": str(tune.rhomb),
+                w + "type": str(tune.det_type),
+                w + "det_x": none_to_nan(tune.det_x),
+                w + "det_y": none_to_nan(tune.det_y),
+                w + "angle": np.radians(none_to_nan(tune.angle_actual_deg)),
             })
-    
+
     dest_dataset = ",".join(array_names)
     write_dataset(det_rs, configs["det_info"], dest_dataset)
     # Update the index.
@@ -93,14 +93,17 @@ def main(args=None):
                'dataset': dest_dataset}
     db.add_entry(db_data, configs["det_info"])
 
-    #aman = det_rs.to_axismanager(axis_key="dets:det_id")
-    #aman.save(out_path)
-    #return aman
+    # aman = det_rs.to_axismanager(axis_key="dets:det_id")
+    # aman.save(out_path)
+    # return aman
+    return None
+
 
 def none_to_nan(val):
     if val is None:
         return np.nan
     return val
 
-if __name__=='__main__':
-    aman = main() 
+
+if __name__ == '__main__':
+    aman = main()

--- a/sotodlib/site_pipeline/make_read_det_match.py
+++ b/sotodlib/site_pipeline/make_read_det_match.py
@@ -85,6 +85,7 @@ def main(args=None):
         
         ## Run mapping on each TuneSet.
         for ts in tunesets:
+            bgmap_path = None
             mapping = array["mapping"]      
             dest_dataset = f"{ts.stream_id}_{ts.name}_mapping_v{mapping['version']}"
             
@@ -104,7 +105,8 @@ def main(args=None):
             array_map=None
             logger.info(f"Making Map for {ts.path}")
             try:
-                array_map = map_maker.make_map_smurf(tunefile=ts.path)
+                array_map = map_maker.make_map_smurf(tunefile=ts.path,
+                                                     bgmap_path=bgmap_path)
             except:
                 logger.warning(f"Map Maker Failed on {ts.path}")
                 continue
@@ -119,13 +121,12 @@ def main(args=None):
                 keys=["dets:det_id", 
                       "dets:readout_id"]
             )
-
-            ## loop through detector IDs and find readout ID matches
-            for tune in array_map:
+            # loop through detector IDs and find readout ID matches
+            for tune in array_map.get_mux_output(add_back_null=False):
                 det_id = tune.detector_id
                 if det_id is None:
-                    ## resonators smurf found that array map doesn't think 
-                    ## should exist (artifacts?)
+                    logger.warning('The DetMap issued "det_id" is should not allowed to be None in the return from ' +
+                                   'detmap.data_io.channel_assignment.OperateTuneData.get_mux_output()')
                     continue
                 i_did = np.where(det_info.dets.vals == det_id)[0]
                 if len(i_did) != 1:

--- a/sotodlib/site_pipeline/make_read_det_match.py
+++ b/sotodlib/site_pipeline/make_read_det_match.py
@@ -17,60 +17,56 @@ from sotodlib.io.metadata import write_dataset, read_dataset
 
 logger = logging.getLogger(__name__)
 
+
 def parse_args():
     parser = ArgumentParser()
-    parser.add_argument('-c', '--config-file',help=
-                        "Configuration File for running DetMap")
+    parser.add_argument('-c', '--config-file', help=
+    "Configuration File for running DetMap")
     parser.add_argument('--min-ctime', type=float, help=
-                        "Minimum ctime to search for TuneSets")
+    "Minimum ctime to search for TuneSets")
     parser.add_argument('--max-ctime', type=float, help=
-                        "Maximum ctime to search for TuneSets")
+    "Maximum ctime to search for TuneSets")
     parser.add_argument('--override', action='store_true')
     args = parser.parse_args()
     return args
 
+
 def main(args=None):
     if args is None:
         args = parse_args()
-
     configs = yaml.safe_load(open(args.config_file, "r"))
-
-    #SMURF = G3tSmurf(os.path.join(configs["data_prefix"], "timestreams"),
-    #                 configs["g3tsmurf_db"],
-    #                 meta_path=os.path.join(configs["data_prefix"], "smurf"))
+    # SMURF = G3tSmurf(os.path.join(configs["data_prefix"], "timestreams"),
+    #                  configs["g3tsmurf_db"],
+    #                  meta_path=os.path.join(configs["data_prefix"], "smurf"))
     SMURF = G3tSmurf.from_configs(configs)
     session = SMURF.Session()
-
     if os.path.exists(configs["read_db"]):
         logger.info(f'Mapping {configs["read_db"]} for the archive index.')
         db = core.metadata.ManifestDb(configs["read_db"])
-        
     else:
         logger.info(f'Creating {configs["read_db"]} for the archive index.')
         scheme = core.metadata.ManifestScheme()
         scheme.add_exact_match('dets:detset')
         scheme.add_data_field('dataset')
-        db = core.metadata.ManifestDb(configs["read_db"], scheme=scheme)      
-    
-    array_names = [array["name"] for array in configs["arrays"]]
-    det_info_group = ",".join(array_names)     
+        db = core.metadata.ManifestDb(configs["read_db"], scheme=scheme)
 
+    array_names = [array["name"] for array in configs["arrays"]]
+    det_info_group = ",".join(array_names)
     for array in configs["arrays"]:
-        ## Load Det Info
+        # Load Detector Information
         rs = read_dataset(configs["det_info"], det_info_group)
         det_rs = core.metadata.merge_det_info(None, rs)
         det_info = core.metadata.loader.convert_det_info(det_rs, dets=det_rs["det_id"])
-        det_info.restrict( 
-            "dets", 
-            det_info.dets.vals[det_info.wafer.array==array["name"]],
+        det_info.restrict(
+            "dets",
+            det_info.dets.vals[det_info.wafer.array == array["name"]],
         )
         logger.info(
             f"Found {det_info.dets.count} detector_ids for Array {array['name']}"
         )
-
-        ## Find TuneSets for Each Array
+        # Find TuneSets for Each Array
         tunesets = session.query(TuneSets).filter(
-            TuneSets.stream_id==array["stream_id"]
+            TuneSets.stream_id == array["stream_id"]
         )
         if args.min_ctime is not None:
             tunesets.filter(
@@ -79,30 +75,23 @@ def main(args=None):
         if args.max_ctime is not None:
             tunesets.filter(
                 TuneSets.start <= dt.datetime.utcfromtimestamp(args.max_ctime)
-             )
+            )
         tunesets = tunesets.all()
         logger.info(f"Found {len(tunesets)} TuneSets for Array {array['name']}")
-        
-        ## Run mapping on each TuneSet.
+        # Run mapping on each TuneSet.
         for ts in tunesets:
             bgmap_path = None
-            mapping = array["mapping"]      
+            mapping = array["mapping"]
             dest_dataset = f"{ts.stream_id}_{ts.name}_mapping_v{mapping['version']}"
-            
             if dest_dataset in db.get_entries() and not args.override:
                 logger.debug(f"Dataset {dest_dataset} already exists")
                 continue
-            
-            ## Setup Mapping for Each Mapping Type
-            map_maker = MapMaker(
-                north_is_highband=array["north_is_highband"],
-                array_name = array["name"],
-                mapping_strategy = mapping["strategy"],
-                dark_bias_lines=array["dark_bias_lines"],
-                **mapping["params"]
-            )
-
-            array_map=None
+            # Setup Mapping for Each Mapping Type
+            map_maker = MapMaker(north_is_highband=array["north_is_highband"],
+                                 array_name=array["name"],
+                                 mapping_strategy=mapping["strategy"],
+                                 dark_bias_lines=array["dark_bias_lines"],
+                                 **mapping["params"])
             logger.info(f"Making Map for {ts.path}")
             try:
                 array_map = map_maker.make_map_smurf(tunefile=ts.path,
@@ -112,13 +101,13 @@ def main(args=None):
                 continue
 
             readout_ids, bands, channels = zip(*[
-                    (ch.name, ch.band, ch.channel) for ch in ts.channels
-                    ])
+                (ch.name, ch.band, ch.channel) for ch in ts.channels
+            ])
             bands = np.array(bands)
             channels = np.array(channels)
 
             rs_list = core.metadata.ResultSet(
-                keys=["dets:det_id", 
+                keys=["dets:det_id",
                       "dets:readout_id"]
             )
             # loop through detector IDs and find readout ID matches
@@ -131,40 +120,36 @@ def main(args=None):
                 i_did = np.where(det_info.dets.vals == det_id)[0]
                 if len(i_did) != 1:
                     logger.warning(f"Map returned detector_id, {det_id}, "
-                                "not in database, what happened?")
+                                   "not in database, what happened?")
                     continue
-                i_did = i_did[0]
                 i_rid = np.where(np.all([
-                        bands == tune.smurf_band,
-                        channels == tune.smurf_channel], axis=0))[0]
+                    bands == tune.smurf_band,
+                    channels == tune.smurf_channel], axis=0))[0]
                 if len(i_rid) != 1:
                     logger.debug(f"Detector {det_id} not found in Tuneset {ts.name}")
-                    ## If we want to track which detectors do not have readout_ids it
-                    ## would go here, but has trouble with dets:readout_id loading in 
-                    ## the current framework
+                    """ If we want to track which detectors do not have readout_ids it
+                        would go here, but has trouble with dets:readout_id loading in 
+                        the current framework."""
                     continue
                 i_rid = i_rid[0]
-                #ch_info.readout_id[i_did] = readout_ids[i_rid]
-                rs_list.append( {"dets:det_id": det_id,
-                                 "dets:readout_id": readout_ids[i_rid]})
+                # ch_info.readout_id[i_did] = readout_ids[i_rid]
+                rs_list.append({"dets:det_id": det_id,
+                                "dets:readout_id": readout_ids[i_rid]})
 
             for rid in readout_ids:
                 if rid in rs_list["dets:readout_id"]:
                     continue
-                rs_list.append( {"dets:det_id": "NO_MATCH",
-                                 "dets:readout_id": rid})
-        
-            
+                rs_list.append({"dets:det_id": "NO_MATCH",
+                                "dets:readout_id": rid})
+
             write_dataset(rs_list, configs["read_info"], dest_dataset, args.override)
-            
-            if not dest_dataset in db.get_entries():
+
+            if dest_dataset not in db.get_entries():
                 # Update the index.
                 db_data = {'dets:detset': ts.name,
                            'dataset': dest_dataset}
                 db.add_entry(db_data, configs["read_info"])
 
 
-
 if __name__ == "__main__":
     main()
-


### PR DESCRIPTION
Streamlined the usage of DetMap functions in sotodlib.

What sodetlib was doing with DetMap was something that was valuable to all DetMap users. The processes that were in sodetlib have been folded into DetMap so that they are tested and maintained for all users of DetMap.

Specifically, for sotodlib these upgrades added methods for iteration of over the metadata for an array, as well as the iteration over mapped data. This pull request corresponds to upgrades in DetMap that are now available on the main branch. The new iteration and data access is best shown in the demonstration notebook [detmap/example/demo_iter.ipynb](https://github.com/simonsobs/DetMap/blob/main/detmap/example/demo_iter.ipynb).

The old version of the sotodlib branch `get-det-db` will still work with the with the upgraded DetMap if this pull request is ignored. 