### PR TITLE
Update smurf caldbs

### DIFF
--- a/docs/site_pipeline.rst
+++ b/docs/site_pipeline.rst
@@ -135,19 +135,31 @@ Here's an annotated example:
 Inputs
 ``````
 
-The formal inputs should all be made available through the Context.
-They are:
+The Context should cause the TOD to be loaded with all supporting
+metadata loaded into the AxisManager.  Here are key members that will
+be processed:
 
-- Obs Book
-- HWP Angle
-- Chanmap
-- Basecal - store in 'cal_base'
-- RelCal model - store in 'cal_flat'
-- Timeconst model
-- Focal plane
-- Glitch flags - store in 'glitch_flags'
-- Noise cuts - store in 'noise_cuts'
-- HWP Spinsync
+- Deconvolution step:
+
+  - ``'timeconst'``
+  - ``'iir_params'``
+
+- Calibration:
+
+  - Whatever is listed in preprocessing.cal_keys
+
+- Pointing correction:
+
+  - ``'boresight_offset'``
+
+- Demodulation and downsampling:
+
+  - not implemented
+
+- Planet mapmaking:
+
+  - ``'source_flags'``
+  - ``'glitch_flags'`` - optional
 
 
 Support

--- a/docs/site_pipeline.rst
+++ b/docs/site_pipeline.rst
@@ -69,6 +69,87 @@ Here's an annotated example:
     default: {'xyr': [0., 0., 0.1]}
 
 
+make-uncal-beam-map
+-------------------
+
+.. automodule:: sotodlib.site_pipeline.make_uncal_beam_map
+   :members:
+   :undoc-members:
+
+
+Command line arguments
+``````````````````````
+
+.. argparse::
+   :module: sotodlib.site_pipeline.make_uncal_beam_map
+   :func: _get_parser
+   :prog: make-uncal-beam-map
+
+Config file format
+``````````````````
+
+Here's an annotated example:
+
+.. code-block:: yaml
+
+  # Data source
+  context_file: ./act_uranus/context.yaml
+
+  # Sub-observation data grouping
+  subobs:
+    use: detset
+    label: wafer_slot
+
+  # Database of results
+  archive:
+    index: 'archive.sqlite'
+    policy:
+      type: 'directory'
+      root_dir: './'
+      pattern: 'maps/{product_id}'
+
+  # Output selection and naming
+  output:
+    map_codes: ['solved', 'weights']
+    pattern: '{product_id}_{split}_{map_code}.fits'
+
+  # Plot generation
+  plotting:
+    zoom:
+      f090: [10, arcmin]
+      f150: [10, arcmin]
+
+  # Preprocessing
+  preprocessing:
+    cal_keys: ['abscal', 'relcal']
+    pointing_keys: ['boresight_offset']
+
+  # Mapmaking parameters
+  mapmaking:
+    force_source: Uranus
+    res:
+      f090: [15, arcsec]
+      f150: [15, arcsec]
+
+
+Inputs
+``````
+
+The formal inputs should all be made available through the Context.
+They are:
+
+- Obs Book
+- HWP Angle
+- Chanmap
+- Basecal - store in 'cal_base'
+- RelCal model - store in 'cal_flat'
+- Timeconst model
+- Focal plane
+- Glitch flags - store in 'glitch_flags'
+- Noise cuts - store in 'noise_cuts'
+- HWP Spinsync
+
+
 Support
 =======
 

--- a/docs/site_pipeline.rst
+++ b/docs/site_pipeline.rst
@@ -66,6 +66,7 @@ Here's an annotated example:
 
   # Mask parameters
   mask_params:
+    mask_res: [2, 'arcmin']
     default: {'xyr': [0., 0., 0.1]}
 
 

--- a/sotodlib/coords/__init__.py
+++ b/sotodlib/coords/__init__.py
@@ -4,3 +4,4 @@ from .helpers import (
     Timer, DEG, ScalarLastQuat
 )
 from . import planets
+from .plotting import *

--- a/sotodlib/coords/planets.py
+++ b/sotodlib/coords/planets.py
@@ -212,20 +212,17 @@ def filter_for_sources(tod=None, signal=None, source_flags=None,
         signal -= signal_pca
 
     else:
+        # Make sure PCA decomposition targets (signal_pca) are mean 0.
+        # It's convenient to remove the same levels from signal now,
+        # too.
         levels = signal_pca.mean(axis=1)
+        signal_pca -= levels[:,None]
         signal -= levels[:,None]
-        signal_pca -= level[:,None]
 
-        # Clean the means, get PCA model, restore means.
-        #signal -= levels[:,None]
+        # Get PCA model and discard the source vectors.
         pca = tod_ops.pca.get_pca_model(tod, signal=signal_pca, n_modes=n_modes)
-        #signal += levels[:,None]
-
-        # Swap original data back into the TOD, remove means.
-        #gaps.swap(tod, signal=signal)
-        #signal -= levels[:,None]
-
         del signal_pca
+
         # Remove the PCA model.
         tod_ops.pca.add_model(tod, pca, -1, signal=signal)
 

--- a/sotodlib/coords/planets.py
+++ b/sotodlib/coords/planets.py
@@ -434,7 +434,8 @@ def _add_to_mask(req, mask_map):
         raise ValueError(f'Requested mask is None.  For no mask, pass [].')
     if isinstance(req, (list, tuple)):
         for _r in req:
-            _generate_mask(_r, mask_map)
+            # Also, maybe test this somehow?
+            _add_to_mask(_r, mask_map)
     elif isinstance(req, dict):
         shape = req.get('shape', 'circle')
         if shape == 'circle':

--- a/sotodlib/coords/planets.py
+++ b/sotodlib/coords/planets.py
@@ -491,9 +491,11 @@ def load_detector_splits(tod=None, filename=None, dataset=None,
     if source is None:
         if dataset is None:
             filename, dataset = filename.split(':')
-        source = metadata.read_dataset(filename, dataset).axismanager()
-    elif isinstance(source, metadata.ResultSet):
-        source = source.axismanager()
+        source = metadata.read_dataset(filename, dataset)
+    if isinstance(source, metadata.ResultSet):
+        di = core.metadata.loader.unconvert_det_info(tod.det_info)
+        source = core.metadata.loader.broadcast_resultset(
+            source, di, axis_key='name')
     else:
         source = source.copy()
     source.restrict_axes([tod.dets])

--- a/sotodlib/coords/planets.py
+++ b/sotodlib/coords/planets.py
@@ -630,10 +630,12 @@ def make_map(tod, center_on=None, scan_coords=True, thread_algo=False,
             logger.info(f'Mapping split "{group_label}"')
             if base_cuts is not None:
                 group_cuts = group_cuts + base_cuts
-            w = P.to_weights(cuts=group_cuts, det_weights=det_weights)
-            m = P.remove_weights(
-                tod=tod, signal=signal, weights_map=w, cuts=group_cuts,
-                det_weights=det_weights, eigentol=eigentol)
+            with MmTimer('getting weights'):
+                w = P.to_weights(cuts=group_cuts, det_weights=det_weights)
+            with MmTimer('getting map and applying inverse weights'):
+                m = P.remove_weights(
+                    tod=tod, signal=signal, weights_map=w, cuts=group_cuts,
+                    det_weights=det_weights, eigentol=eigentol)
             output['splits'][group_label] = {
                 'binned': None,
                 'weights': w.astype('float32'),

--- a/sotodlib/coords/plotting.py
+++ b/sotodlib/coords/plotting.py
@@ -1,0 +1,175 @@
+from matplotlib.axes import Axes
+from matplotlib.ticker import Formatter, MultipleLocator
+from matplotlib.projections import register_projection
+
+import numpy as np
+from pixell import enmap
+
+__all__ = ['BeamMapAxes']
+
+
+class _RescaleFormatter(Formatter):
+    """Tick formatter that divides the tick positions by some unit, and
+    rounds the result to some number of decimal places for display.
+
+    """
+    def __init__(self, unit=1., precision=0):
+        self.unit = unit
+        self.precision = precision
+    def __call__(self, x, pos=None):
+        label = x / self.unit
+        if self.precision == 0:
+            return str(int(np.round(label)))
+        return str(np.round(label, self.precision))
+
+
+class BeamMapAxes(Axes):
+    """Axes sub-class adapted for displaying beam maps.  This extends
+    standard Axes in two ways:
+
+    - Arrays passed to imshow for rendering must in fact be
+      enmap.ndarrays; the wcs will be inspected to set the image
+      extent (in degrees).
+    - The X and Y scales and axis labels will be automatically
+      rescaled, depending on the current viewport, to show
+      degrees/arcminutes/arcseconds as appropriate.
+
+    Args:
+      unit (str): Force the axis & label units to one of 'deg',
+        'arcmin', 'arcsec'.  If this is not set, the units will adapt
+        to the viewport.
+      n_major (int or (int, int)): The maximum number of major ticks
+        to permit on the x and y axes.
+
+    Notes:
+
+      This class isn't used directly but rather is registered in
+      matplotlib's projection system under the name "so-beammap",
+      which can then be used as a projection argument to pyplot.axes
+      or pyplot.subplot.  E.g.::
+
+        ax = plt.subplot(221, projection='so-beammap')
+
+      You can also use the .factor classmethod to achieve the same thing::
+
+        ax = plt.subplot(221, projection=BeamMapAxes.factory())
+
+      This latter form allows for defaults to be overridden::
+
+        ax = plt.subplot(221, projection=BeamMapAxes.factory(units='arcmin', max_n=12))
+
+      You might also find it useful to set the same projection on a
+      set of subplots; that's done like this:
+
+          fig, axs = plt.subplots(1, 3, subplot_kwargs={'projection': BeamMapAxes()})
+
+    """
+    name = 'so-beammap'
+
+    rules = [
+        # min_extent, unitstr
+        (    2,  'deg'  ),
+        ( 2/60, 'arcmin'),
+        (    0, 'arcsec')
+    ]
+
+    def __init__(self, fig, rect, unit=None, n_major=None, **kw):
+        self._force_unit = unit
+        try:
+            n_major = tuple(n_major)
+        except TypeError:
+            n_major = (n_major, n_major)
+        self.n_major = n_major
+        super().__init__(fig, rect, **kw)
+
+    def _set_lim_helper(self, axis, ex, n):
+        if n is None:
+            n = 8
+
+        # Extent and upper bound tick spacing
+        extent = abs(ex[1] - ex[0])
+        step = extent / n
+
+        label = self._force_unit
+        if label is None:
+            for min_size, label in self.rules:
+                if extent > min_size:
+                    break
+        unit = {'deg': 1., 'arcmin': 1/60, 'arcsec': 1/3600}[label]
+
+        if step < unit:
+            # If ticks will be smaller than 1 unit, start at some
+            # 10**-n.
+            base = 10
+            zooms = []
+        else:
+            # But for ticks that look to be integer multiples of a
+            # unit; start at 60**n, and go up in nice factors of 60.
+            base = 60
+            zooms = [2, 2.5, 2, 1.5, 2, 2]
+
+        step = unit * base**np.floor(np.log(step/unit) / np.log(base))
+        while round(abs(extent) / step) > n:
+            if not zooms:
+                zooms = [2, 2.5, 2]  # 10s.
+            step *= zooms.pop(0)
+
+        precision = max(int(np.ceil(np.log10(unit / step))),0)
+        axis.set_major_locator(MultipleLocator(step))
+        axis.set_major_formatter(_RescaleFormatter(unit, precision))
+
+        return label
+
+    def set_xlim(self, *args, **kw):
+        super().set_xlim(*args, **kw)
+        label = self._set_lim_helper(self.xaxis, self.get_xlim(), self.n_major[0])
+        self.set_xlabel(f'$\\xi$ ({label})')
+
+    def set_ylim(self, *args, **kw):
+        super().set_ylim(*args, **kw)
+        label = self._set_lim_helper(self.yaxis, self.get_ylim(), self.n_major[1])
+        self.set_ylabel(f'$\\eta$ ({label})')
+
+    def imshow(self, *args, **kwargs):
+        """Wrapper for Axes.imshow with the following adjustments:
+
+        - The image you pass in must be a 2d enmap.ndarray, i.e. it
+          should have a ``wcs`` attribute.
+        - kwarg 'origin' must be 'lower' (or omitted)
+        - kwarg 'extent' must be None (or omitted); the boundary of
+          the map, in degrees, will be used to set the "extent".  (As
+          a result, means that any viewport adjustments should be
+          passed in degrees, rather than pixel index coords or
+          whatever units are being shown on the axis labels.)
+        - kwarg 'aspect' will be set to match the pixel aspect ratio,
+          unless it is explicitly passed in.
+
+        """
+        assert(kwargs.pop('origin', 'lower') == 'lower')
+        assert(kwargs.pop('extent', None) is None)
+
+        # just make extent be degrees!
+        img = args[0]
+        assert(isinstance(img, enmap.ndmap))
+        wcs = img.wcs.wcs
+        if kwargs.get('aspect') is None:
+            # H / W of the pixel
+            kwargs['aspect'] = abs(wcs.cdelt[1] / wcs.cdelt[0])
+        extent = []
+        for n, ax, sgn in [(img.shape[1], 0, -1), (img.shape[0], 1, 1)]:
+            lohi = ((np.array([0, n]) - 0.5) + 1 - wcs.crpix[ax]) * wcs.cdelt[ax] + wcs.crval[ax]
+            extent.extend(list(lohi * sgn))
+        return super().imshow(*args, origin='lower', extent=extent, **kwargs)
+
+    @classmethod
+    def factory(cls, **kw):
+        class _AxesFactory:
+            def __init__(self, **kw):
+                self.kw = kw
+            def _as_mpl_axes(self):
+                return cls, self.kw
+        return _AxesFactory(**kw)
+
+
+# Register 'so-beammap' with matplotlib
+register_projection(BeamMapAxes)

--- a/sotodlib/coords/pmat.py
+++ b/sotodlib/coords/pmat.py
@@ -196,7 +196,7 @@ class P:
         return self._enmapify(proj.zeros(super_shape))
 
     def to_map(self, tod=None, dest=None, comps=None, signal=None,
-               det_weights=None, cuts=None):
+               det_weights=None, cuts=None, eigentol=None):
         """Project time-ordered signal into a map.  This performs the operation
 
             m += P d
@@ -214,6 +214,7 @@ class P:
             uniform weights of 1 are applied.
           cuts: Sample cuts to exclude from processing.  If None,
             self.cuts is used.
+          eigentol: This is ignored.
 
         """
         signal = _valid_arg(signal, 'signal', src=tod)

--- a/sotodlib/coords/pmat.py
+++ b/sotodlib/coords/pmat.py
@@ -392,7 +392,7 @@ class P:
         if cuts is None:
             cuts = self.cuts
         if self.threads is False:
-            return proj, cuts
+            return proj, ~cuts
         if self.threads is None:
             self.threads = 'simple'
         if isinstance(self.threads, str):

--- a/sotodlib/core/metadata/loader.py
+++ b/sotodlib/core/metadata/loader.py
@@ -170,7 +170,11 @@ class SuperLoader:
 
         index_lines = []
         for subreq in subreqs:
+            # Reject any subreq that explicitly contradicts request on any key.
+            if any([subreq.get(k, v) != v for k, v in request.items()]):
+                continue
             subreq.update(request)
+
             try:
                 _lines = man.match(subreq, multi=True, prefix=dbpath)
             except Exception as e:
@@ -182,6 +186,9 @@ class SuperLoader:
                     + '  ' + str(subreq) + '\n'
                     + 'The exception is:\n  %s' % text)
             for _line in _lines:
+                # Now reject any _line if they contradict subreq.
+                if any([subreq.get(k, v) != v for k, v in _line.items()]):
+                    continue
                 _line.update(subreq)
                 index_lines.append(_line)
 
@@ -273,6 +280,7 @@ class SuperLoader:
             results.append(mi2)
 
         # Check that we got results, then combine them in to single ResultSet.
+        logger.debug(f'Concatenating {len(results)} results: {results}')
         assert(len(results) > 0)
         result = results[0].concatenate(results)
         return result

--- a/sotodlib/io/load.py
+++ b/sotodlib/io/load.py
@@ -472,10 +472,7 @@ def load_observation(db, obs_id, dets=None, samples=None, prefix=None,
     aman = None
 
     for detset, dets in dets_by_detset.items():
-        c = db.conn.execute('select name, sample_start, sample_stop '
-                            'from files '
-                            'where obs_id=? and detset=? ' +
-                            'order by sample_start', (obs_id, detset))
+        detset_files = db.get_files(obs_id, detsets=[detset], prefix=prefix)[detset]
         subreq = []
         if no_signal:
             if aman is None:
@@ -511,14 +508,14 @@ def load_observation(db, obs_id, dets=None, samples=None, prefix=None,
         stop = sample_stop
 
         streams = None
-        for row in c:
-            f, file_start, file_stop = row
+        for row in detset_files:
+            filename, file_start, file_stop = row
             assert(file_start is not None)
             start = max(0, sample_start - file_start)
             if sample_stop is not None:
                 stop = sample_stop - file_start
             streams = unpack_frames(
-                prefix+f, request, streams, samples=(start, stop))
+                filename, request, streams, samples=(start, stop))
 
         if aman is None:
             # Create AxisManager now that we know the sample count.

--- a/sotodlib/site_pipeline/make_source_flags.py
+++ b/sotodlib/site_pipeline/make_source_flags.py
@@ -72,12 +72,8 @@ def main(args=None):
         tod = ctx.get_obs(config['obs_id'], detsets=[detset],
                           no_signal=True)
 
-        # Boost detdb into array_data.
-        if 'array_data' not in tod:
-            util.promote_array_data(ctx, tod)
-
         # Figure out the indexing info for this.
-        this_index = tod.array_data[group_by]
+        this_index = tod.det_info[group_by]
         assert([x == this_index[0] for x in this_index])
         this_index = this_index[0]
         if this_index in index_map:

--- a/sotodlib/site_pipeline/make_source_flags.py
+++ b/sotodlib/site_pipeline/make_source_flags.py
@@ -7,6 +7,7 @@ import yaml
 
 import sotodlib
 from sotodlib import core, coords, site_pipeline
+from . import util
 
 logger = logging.getLogger(__name__)
 
@@ -41,12 +42,11 @@ def main(args=None):
 
     ctx = core.Context(config['context_file'])
 
-    group_by = config['subobs'].get('use', 'detset')
-    if group_by == 'detset':
-        groups = ctx.obsfiledb.get_detsets(config['obs_id'])
-    elif group_by.startswith('dets:'):
+    # This will process data by detset, but will insist that this maps
+    # one-to-one with some detdb field.
+    group_by = config['subobs'].get('group_by', 'dets:detset')
+    if group_by.startswith('dets:'):
         group_by = group_by.split(':',1)[1]
-        groups = ctx.detdb.props(props=group_by).distinct()[group_by]
     else:
         raise ValueError("Can't group by '{group_by}'")
 
@@ -57,26 +57,39 @@ def main(args=None):
         logger.info(f'Creating {config["archive"]["index"]} for the archive index.')
         scheme = core.metadata.ManifestScheme()
         scheme.add_exact_match('obs:obs_id')
-        if group_by != 'detset':
-            scheme.add_exact_match('dets:' + group_by)
+        scheme.add_data_field('dets:' + group_by)
         scheme.add_data_field('dataset')
         db = core.metadata.ManifestDb(config['archive']['index'], scheme=scheme)
 
-    for group in groups:
-        logger.info(f'Loading {config["obs_id"]}:{group_by}={group}')
-        if group_by == 'detset':
-            # Load pointing and dets axis; we don't need signal though.
-            tod = ctx.get_obs(config['obs_id'], detsets=[group],
-                              no_signal=True)
-        else:
-            tod = ctx.get_obs(config['obs_id'], dets={group_by: group},
-                              no_signal=True)
+    # We will loop over detsets here, but insist on a simple
+    # correspondence to the output index values.
+    index_map = {}
+
+    detsets = ctx.obsfiledb.get_detsets(config['obs_id'])
+    for detset in detsets:
+        logger.info(f'Loading {config["obs_id"]}:detset={detset}')
+        # Load pointing and dets axis; we don't need signal though.
+        tod = ctx.get_obs(config['obs_id'], detsets=[detset],
+                          no_signal=True)
+
+        # Boost detdb into array_data.
+        if 'array_data' not in tod:
+            util.promote_array_data(ctx, tod)
+
+        # Figure out the indexing info for this.
+        this_index = tod.array_data[group_by]
+        assert([x == this_index[0] for x in this_index])
+        this_index = this_index[0]
+        if this_index in index_map:
+            raise RuntimeError(f"Some detset already mapped to {this_index}: "
+                               f"{index_map[this_index]}")
+        index_map[this_index] = detset
+        logger.info(f'detset "{detset}" corresponds to {group_by}="{this_index}"')
 
         # Load / compute mask parameters.
         mask_params = config['mask_params']['default']
-        mask_res = site_pipeline.util.parse_angle(
-            site_pipeline.util.lookup_conditional(config['mask_params'], 'res',
-                                                  default=[1, 'arcmin']))
+        mask_res = util.parse_angle(util.lookup_conditional(
+            config['mask_params'], 'res', default=[1, 'arcmin']))
 
         sources = coords.planets.get_nearby_sources(tod)
         flags = None
@@ -102,21 +115,18 @@ def main(args=None):
         logger.info(f'Total mask weight is {weight*100:.2}%.')
 
         # Wrap result into AxisManager for HDF5 off-load.
-        aman = core.AxisManager(tod.dets)
-        aman.wrap('source_flags', flags, [(0, 'dets')])
+        aman = core.AxisManager(tod.dets, tod.samps)
+        aman.wrap('source_flags', flags, [(0, 'dets'), (1, 'samps')])
 
         # Get file + dataset from policy.
-        policy = site_pipeline.util.ArchivePolicy.from_params(config['archive']['policy'])
+        policy = util.ArchivePolicy.from_params(config['archive']['policy'])
         dest_file, dest_dataset = policy.get_dest(config['obs_id'])
-        if group_by == 'detset':
-            dest_dataset += '_' + group
         aman.save(dest_file, dest_dataset, overwrite=True)
 
         # Update the index.
         db_data = {'obs:obs_id': config['obs_id'],
-                   'dataset': dest_dataset}
-        if group_by != 'detset':
-            db_data['dets:'+group_by] = group
+                   'dataset': dest_dataset,
+                   f'dets:{group_by}': this_index}
         db.add_entry(db_data, dest_file, replace=True)
 
     # Return something?

--- a/sotodlib/site_pipeline/make_source_flags.py
+++ b/sotodlib/site_pipeline/make_source_flags.py
@@ -74,13 +74,16 @@ def main(args=None):
 
         # Load / compute mask parameters.
         mask_params = config['mask_params']['default']
+        mask_res = site_pipeline.util.parse_angle(
+            site_pipeline.util.lookup_conditional(config['mask_params'], 'res',
+                                                  default=[1, 'arcmin']))
 
         sources = coords.planets.get_nearby_sources(tod)
         flags = None
         for source_name, eph_object in sources:
             logger.info(f'Flagging for {source_name} ...')
             _flags = coords.planets.compute_source_flags(
-                tod, center_on=source_name, res=0.01*coords.DEG,
+                tod, center_on=source_name, res=mask_res*coords.DEG,
                 mask=mask_params)
             weight = np.mean(_flags.get_stats()['samples']) / _flags.shape[1]
             logger.info(f' ... weight for {source_name} was {weight*100:.2}%.')
@@ -114,7 +117,7 @@ def main(args=None):
                    'dataset': dest_dataset}
         if group_by != 'detset':
             db_data['dets:'+group_by] = group
-        db.add_entry(db_data, dest_file)
+        db.add_entry(db_data, dest_file, replace=True)
 
     # Return something?
     return tod, aman

--- a/sotodlib/site_pipeline/make_uncal_beam_map.py
+++ b/sotodlib/site_pipeline/make_uncal_beam_map.py
@@ -1,0 +1,257 @@
+"""This module produces maps for a single observation of a bright
+point source.  The observation is identifed by an obs_id.  The data
+for the observation may be divided into different detector groups; and
+each 'group' will be loaded and mapped independently (this will
+normally be associated with a "detset").  The data for each
+observation in each group may be further subdivided into 'data
+splits'; this normally corresponds to frequency "band".
+
+"""
+
+from argparse import ArgumentParser
+import logging
+import numpy as np
+import os
+import sys
+import yaml
+import matplotlib.pyplot as plt
+
+import sotodlib
+import so3g
+from sotodlib import core, coords, site_pipeline, tod_ops
+
+from . import util
+
+logger = logging.getLogger(__name__)
+
+def _get_parser():
+    parser = ArgumentParser()
+    parser.add_argument('-c', '--config-file', help=
+                        "Configuration file.")
+    parser.add_argument('-v', '--verbose', action='count',
+                        default=0, help="Pass multiple times to increase.")
+    parser.add_argument('obs_id',help=
+                        "Observation for which to make source map.")
+    parser.add_argument('--test', action='store_true', help=
+                        "Reduce detector count for quick tests.")
+
+    return parser
+
+def _get_config(args):
+    cfg = yaml.safe_load(open(args.config_file, 'r'))
+    for k in ['obs_id', 'verbose']:
+        cfg[k] = getattr(args, k)
+    cfg['_args'] = args
+    return cfg
+
+def _plot_map(bundle, filename=None, **kwargs):
+    # To-do for the plot:
+    # - T map and weights map (full footprint)
+    # - T, Q, and U zoomed in on source
+    # - labeled array diagram showing participating detectors and
+    #  their weights
+    src_map = bundle['solved']
+    fig, axs = plt.subplots(3, 1, subplot_kw={'projection': src_map.wcs},
+                            figsize=(5, 8))
+    mask = bundle['weights'][0,0] != 0
+    for _m, ax in zip(src_map, axs):
+        _m1 = np.ma.masked_where(~mask, _m)
+        ax.imshow(_m1, origin='lower')
+    if filename is not None:
+        fig.savefig(filename)
+    return fig
+
+def _adjust_focal_plane(tod, focal_plane=None, boresight_offset=None):
+    """Apply pointing correction to focal plane.  These are assumed to be
+    boresight corrections, even though there is one per detector.
+
+    """
+    if focal_plane is None:
+        focal_plane = tod.focal_plane
+    if boresight_offset is None:
+        boresight_offset = tod.boresight_offset
+
+    # Get detector the boresight pointing quaternions
+    fp = focal_plane
+    fp_q = so3g.proj.quat.rotation_xieta(fp.xi, fp.eta, fp.gamma)
+
+    # Get the adjustments
+    bc = boresight_offset
+    fp_adjust = so3g.proj.quat.rotation_xieta(bc.dx, bc.dy, bc.gamma)
+
+    # Apply focal plane adjust.
+    fp_new = fp_adjust * fp_q
+
+    # Get modified xi, eta, gamma.
+    xi, eta, gamma = so3g.proj.quat.decompose_xieta(fp_new)
+    fp.xi[:] = xi
+    fp.eta[:] = eta
+    fp.gamma[:] = gamma
+
+
+def main(args=None):
+    """Entry point."""
+    if args is None:
+        args = sys.argv[1:]
+    parser = _get_parser()
+    config = _get_config(parser.parse_args(args))
+
+    if config['verbose'] >= 1:
+        logger.setLevel('INFO')
+    if config['verbose'] >= 2:
+        sotodlib.logger.setLevel('INFO')
+    if config['verbose'] >= 3:
+        sotodlib.logger.setLevel('DEBUG')
+
+    ctx = core.Context(config['context_file'])
+
+    group_by = config['subobs'].get('use', 'detset')
+    if group_by == 'detset':
+        groups = ctx.obsfiledb.get_detsets(config['obs_id'])
+    elif group_by.startswith('dets:'):
+        group_by = group_by.split(':',1)[1]
+        groups = ctx.detdb.props(props=group_by).distinct()[group_by]
+    else:
+        raise ValueError("Can't group by '{group_by}'")
+
+    if len(groups) == 0:
+        logger.warning(f'No map groups found for obs_id={config["obs_id"]}')
+
+    if os.path.exists(config['archive']['index']):
+        logger.info(f'Mapping {config["archive"]["index"]} for the archive index.')
+        db = core.metadata.ManifestDb(config['archive']['index'])
+    else:
+        logger.info(f'Creating {config["archive"]["index"]} for the archive index.')
+        scheme = core.metadata.ManifestScheme()
+        scheme.add_exact_match('obs:obs_id')
+        scheme.add_data_field('group')
+        scheme.add_data_field('split')
+        db = core.metadata.ManifestDb(config['archive']['index'], scheme=scheme)
+
+    for group in groups:
+        logger.info(f'Loading {config["obs_id"]}:{group_by}={group}')
+        map_info = {'obs_id': config['obs_id'],
+                    'group': group,
+                    group_by: group,
+        }
+        map_info['product_id'] = '{obs_id}-{group}'.format(**map_info)
+
+        if group_by == 'detset':
+            tod = ctx.get_obs(config['obs_id'], detsets=[group])
+        else:
+            tod = ctx.get_obs(config['obs_id'], dets={group_by: group})
+
+        # Modify dets axis for testing
+        if config['_args'].test:
+            dets = tod.dets.vals[::10]
+            tod.restrict('dets', dets)
+
+        # Modify samps axis for FFTs.
+        tod_ops.fft_trim(tod)
+
+        # Determine what source to map.
+        ## To-do: have a mode where it maps all sources it finds.
+        source_name = config['mapmaking'].get('force_source')
+        if source_name is None:
+            sources = coords.planets.get_nearby_sources(tod)
+            if len(sources) == 1:
+                source_name = sources[0][0]
+            elif len(sources) == 0:
+                logger.error("No mappable sources in footprint.")
+                sys.exit(1)
+            else:
+                logger.error("Multiple sources in footprint: %s" %
+                             ([n for n, s in sources],))
+                sys.exit(1)
+        map_info['source_name'] = source_name
+        
+        # Plan to split on frequency band
+        band_splits = core.metadata.ResultSet(['dets:name', 'group'])
+        band_splits.rows = list(zip(tod.dets.vals, tod.array_data['fcode']))
+        band_splits = coords.planets.load_detector_splits(tod, source=band_splits)
+
+        # Deconvolve readout filter and detector time constants.
+        tod_ops.fft_trim(tod)
+        tod_ops.detrend_tod(tod)
+        filt = (tod_ops.filters.iir_filter(invert=True)
+                * tod_ops.filters.timeconst_filter(invert=True))
+        tod.signal[:] = tod_ops.fourier_filter(tod, filt, resize=None, detrend=None)
+
+        # Demodulation & downsampling.
+        # ...
+
+        # Fix pointing.
+        logger.info('Applying pointing corrections.')
+        if 'boresight_offset' in tod:
+            logger.info(' ... applying "boresight_offset".')
+            _adjust_focal_plane(tod)
+
+        # Apply calibration
+        cal = None
+        for k in config['preprocessing']['cal_keys']:
+            if k in tod:
+                if cal is None:
+                    cal = 1.
+                cal *= tod[k]
+        if cal is not None:
+            tod.signal *= cal[:,None]
+
+        # Figure out the resolution
+        reses = [
+            util.lookup_conditional(config['mapmaking'], 'res', tags=[b])
+            for b in band_splits.keys()]
+        assert(all([r == reses[0] for r in reses]))  # Resolution conflict
+        res_deg = util.parse_angle(reses[0])
+        
+        # Where to put things.
+        policy = util.ArchivePolicy.from_params(
+            config['archive']['policy'])
+        
+        dest_dir = policy.get_dest(**map_info)
+        if os.path.exists(dest_dir):
+            logger.info(f' ... destination already exists ({dest_dir})')
+        else:
+            logger.info(f' ... creating destination dir ({dest_dir})')
+            os.makedirs(dest_dir)
+
+        # Make the maps.
+        logger.info(f'Calling mapmaker.')
+        output = coords.planets.make_map(tod, center_on=source_name,
+                                         res=res_deg*coords.DEG,
+                                         data_splits=band_splits,
+                                         info=map_info)
+
+        # Save and plot
+        ocfg = config['output']
+        pcfg = config['plotting']
+        opattern = ocfg['pattern']
+        ppattern = pcfg.get('pattern', opattern + '.png')
+
+        used_names = []  # watch for accidental self-overwrites
+        db_code = ocfg['map_codes'][0]
+        
+        for key, bundle in output['splits'].items():
+            # Save
+            for code in ocfg['map_codes']:
+                filename = os.path.join(
+                    dest_dir, opattern.format(map_code=code, split=key, **map_info))
+                bundle[code].write(filename)
+                if filename in used_names:
+                    logger.warning(f'Wrote this file more than once: {filename}; '
+                                   f'using {key}, {code}')
+                used_names.append(filename)
+                if code == db_code:
+                    # Index
+                    db_data = {'obs:obs_id': config['obs_id'],
+                               'group': group,
+                               'split': key}
+                    db.add_entry(db_data, filename, replace=True)
+
+            # Plot
+            plot_filename = os.path.join(
+                dest_dir, ppattern.format(map_code=code, split=key, **map_info))
+            _plot_map(bundle, plot_filename)
+
+
+    # Return something?
+    return True

--- a/sotodlib/site_pipeline/make_uncal_beam_map.py
+++ b/sotodlib/site_pipeline/make_uncal_beam_map.py
@@ -145,10 +145,6 @@ def main(args=None):
             dets = tod.dets.vals[::10]
             tod.restrict('dets', dets)
 
-        # Boost detdb into array_data.
-        if 'array_data' not in tod:
-            util.promote_array_data(ctx, tod)
-
         # Modify samps axis for FFTs.
         tod_ops.fft_trim(tod)
 
@@ -170,7 +166,7 @@ def main(args=None):
         
         # Plan to split on frequency band
         band_splits = core.metadata.ResultSet(['dets:name', 'group'])
-        band_splits.rows = list(zip(tod.dets.vals, tod.array_data['fcode']))
+        band_splits.rows = list(zip(tod.dets.vals, tod.det_info['band']))
         band_splits = coords.planets.load_detector_splits(tod, source=band_splits)
 
         # Deconvolve readout filter and detector time constants.

--- a/sotodlib/site_pipeline/make_uncal_beam_map.py
+++ b/sotodlib/site_pipeline/make_uncal_beam_map.py
@@ -88,18 +88,6 @@ def _adjust_focal_plane(tod, focal_plane=None, boresight_offset=None):
     fp.eta[:] = eta
     fp.gamma[:] = gamma
 
-def _promote_array_data(ctx, tod):
-    # Wrap detdb properties into tod.array_data.  This makes SO sim
-    # TOD AxisManagers look like ACT TOD AxisManagers ... we'll get an
-    # SO solution in place.
-    props = ctx.detdb.props()
-    array_data = core.AxisManager(
-        core.LabelAxis('dets', props['name']))
-    for k in props.keys:
-        array_data.wrap(k, props[k], [(0, 'dets')])
-    tod.wrap('array_data', array_data)
-    return array_data
-
 def main(args=None):
     """Entry point."""
     if args is None:
@@ -159,7 +147,7 @@ def main(args=None):
 
         # Boost detdb into array_data.
         if 'array_data' not in tod:
-            _promote_array_data(ctx, tod)
+            util.promote_array_data(ctx, tod)
 
         # Modify samps axis for FFTs.
         tod_ops.fft_trim(tod)

--- a/sotodlib/site_pipeline/update_smurf_caldbs.py
+++ b/sotodlib/site_pipeline/update_smurf_caldbs.py
@@ -1,0 +1,258 @@
+"""This module updates the produced CalDbs from smurf metadata output.
+Command line arguments can be used to select which CalDbs are updated,
+and depending on the type of CalDb will either do so based on an obs_id or 
+a time range. In addition, this will update the Metadata Indexes that 
+describe how to load the proper dataset when loading observations or metadata
+with the Context system.
+
+"""
+
+from argparse import ArgumentParser
+import numpy as np
+import os
+import sys
+import yaml
+import matplotlib.pyplot as plt
+
+import sotodlib
+from sotodlib.site_pipeline import util
+from sotodlib.core import metadata
+
+from sotodlib.io.metadata import write_dataset
+from sotodlib.io.load_smurf import G3tSmurf, Tunes, Observations
+
+logger = util.init_logger(__name__, 'update-smurf-caldbs: ')
+
+def _get_parser():
+    parser = ArgumentParser()
+    parser.add_argument('-c', '--config-file', help=
+                        "Configuration File")
+    parser.add_argument('-v', '--verbose', action='count',
+                        default=0, help="Pass multiple times to increase.")
+    parser.add_argument('obs_id',help=
+                        "Observation ID if necessary for updating a particular CalDb")
+    parser.add_argument('-iv', '--iv', action='store_true',help=
+                        "If present, update the IV CalDbs")
+    parser.add_argument('-bgm', '--bias-group-map', action='store_true',help=
+                        "If present, update the bias group map CalDbs")
+    parser.add_argument('-bs', '--bias-steps', action='store_true',help=
+                        "If present, update the bias step CalDbs")
+    
+    return parser
+
+def _get_config(args):
+    cfg = yaml.safe_load(open(args.config_file,'r'))
+    for k in ['obs_id', 'verbose']:
+        cfg[k] = getattr(args, k, None)
+    cfg['_args'] = args
+    return cfg
+
+def _make_iv_caldb(cfg):
+    # initialize SQLAlchemy Session from G3tSmurf Db
+    SMURF = G3tSmurf(archive_path=cfg['g3tsmurf']['archive_path'],
+                     meta_path=cfg['g3tsmurf']['meta_path'],
+                     db_path=cfg['g3tsmurf']['db_path'])
+    session = SMURF.Session()
+   
+    # load ManifestDb
+    if os.path.exists(cfg['archive']['iv']['index']):
+        db = metadata.ManifestDb(map_file=cfg['archive']['iv']['index'])
+    else:
+        scheme = metadata.ManifestScheme()
+        scheme.add_exact_match('obs:obs_id')
+        scheme.add_data_field('dataset')
+
+        db = metadata.ManifestDb(scheme=scheme)
+        db.to_file(cfg['archive']['iv']['index'])
+
+    # initialize a ResultSet to hold the IV CalDb
+    iv_caldb = metadata.ResultSet(keys=['dets:readout_id', 'band', 'channel', 'R_n', 'p_sat', 'polarity'])
+
+    o = session.query(Observations).filter(Observations.obs_id == cfg['obs_id']).one_or_none()
+
+    for fname, stream_id, ctime, path in SMURF.search_metadata_files(max_ctime=o.timestamp,reverse=True):
+        if 'iv' in fname:
+            iva_fp = path
+            break
+
+    iva = np.load(iva_fp, allow_pickle=True).item()        
+            
+    # use G3tSmurf index to extract correct detector names
+    t = iva['meta']['tunefile'].split('/')[-1]
+    tun = session.query(Tunes).filter(Tunes.name == t).one_or_none()
+    channels = [(c.name, c.band, c.channel) for c in tun.tuneset.channels]
+
+    for cname in channels:
+        name, band, channel = cname
+
+        try:
+            idx = np.where((iva['bands']==band)*(iva['channels']==channel))[0][0]
+            R_n = iva['R_n'][idx]
+            p_sat = iva['p_sat'][idx]
+            polarity = iva['polarity'][idx]
+        except IndexError:
+            R_n = np.nan
+            p_sat = np.nan
+            polarity = np.nan
+
+        iv_caldb.rows.append((name, band, channel, R_n, p_sat, polarity))
+        
+    # Get file and dataset from policy
+    policy = util.ArchivePolicy.from_params(cfg['archive']['iv']['policy'])
+    dest_file, dest_dataset = policy.get_dest(cfg['obs_id']+'_iv')
+    db_data = {'obs:obs_id': cfg['obs_id'], 'dataset': dest_dataset}
+    
+    logger.info(f'Writing IV CalDb to {dest_file}.')
+    write_dataset(iv_caldb, dest_file, dest_dataset, overwrite=True)
+    
+    # add an entry to the ManifestDb at the current obs_id
+    logger.info(f'Updating Metadata Index {cfg["archive"]["iv"]["index"]}')
+    db.add_entry(db_data,filename=dest_file,replace=True)
+
+def _make_bgmap_caldb(cfg):
+    # initialize SQLAlchemy Session from G3tSmurf Db
+    SMURF = G3tSmurf(archive_path=cfg['g3tsmurf']['archive_path'],
+                     meta_path=cfg['g3tsmurf']['meta_path'],
+                     db_path=cfg['g3tsmurf']['db_path'])
+    session = SMURF.Session()
+   
+    # load ManifestDb
+    if os.path.exists(cfg['archive']['bgmap']['index']):
+        db = metadata.ManifestDb(map_file=cfg['archive']['bgmap']['index'])
+    else:
+        scheme = metadata.ManifestScheme()
+        scheme.add_exact_match('obs:obs_id')
+        scheme.add_data_field('dataset')
+
+        db = metadata.ManifestDb(scheme=scheme)
+        db.to_file(cfg['archive']['bgmap']['index'])
+
+    # initialize a ResultSet to hold the bgmap CalDb
+    bgmap_caldb = metadata.ResultSet(keys=['dets:readout_id', 'band', 'channel', 'bias_group'])
+
+    o = session.query(Observations).filter(Observations.obs_id == cfg['obs_id']).one_or_none()
+
+    for fname, stream_id, ctime, path in SMURF.search_metadata_files(max_ctime=o.timestamp,reverse=True):
+        if 'bg_map' in fname:
+            bgm_fp = path
+            break
+
+    bgm = np.load(bgm_fp, allow_pickle=True).item()        
+            
+    # use G3tSmurf index to extract correct detector names
+    t = bgm['meta']['tunefile'].split('/')[-1]
+    tun = session.query(Tunes).filter(Tunes.name == t).one_or_none()
+    channels = [(c.name, c.band, c.channel) for c in tun.tuneset.channels]
+
+    for cname in channels:
+        name, band, channel = cname
+
+        try:
+            idx = np.where((bgm['bands']==band)*(bgm['channels']==channel))[0][0]
+            bg_assign = bgm['bgmap'][idx]
+        except IndexError:
+            bg_assign = -1
+
+        bgmap_caldb.rows.append((name, band, channel, bg_assign))
+        
+    # Get file and dataset from policy
+    policy = util.ArchivePolicy.from_params(cfg['archive']['bgmap']['policy'])
+    dest_file, dest_dataset = policy.get_dest(cfg['obs_id']+'_bgmap')
+    db_data = {'obs:obs_id': cfg['obs_id'], 'dataset': dest_dataset}
+    
+    logger.info(f'Writing bias group map CalDb to {dest_file}.')
+    write_dataset(bgmap_caldb, dest_file, dest_dataset, overwrite=True)
+    
+    # add an entry to the ManifestDb at the current obs_id
+    logger.info(f'Updating Metadata Index {cfg["archive"]["bgmap"]["index"]}')
+    db.add_entry(db_data,filename=dest_file,replace=True)
+
+def _make_bias_step_caldb(cfg):
+    # initialize SQLAlchemy Session from G3tSmurf Db
+    SMURF = G3tSmurf(archive_path=cfg['g3tsmurf']['archive_path'],
+                     meta_path=cfg['g3tsmurf']['meta_path'],
+                     db_path=cfg['g3tsmurf']['db_path'])
+    session = SMURF.Session()
+   
+    # load ManifestDb
+    if os.path.exists(cfg['archive']['bias_steps']['index']):
+        db = metadata.ManifestDb(map_file=cfg['archive']['bias_steps']['index'])
+    else:
+        scheme = metadata.ManifestScheme()
+        scheme.add_exact_match('obs:obs_id')
+        scheme.add_data_field('dataset')
+
+        db = metadata.ManifestDb(scheme=scheme)
+        db.to_file(cfg['archive']['bias_steps']['index'])
+
+    # initialize a ResultSet to hold the IV CalDb
+    bs_caldb = metadata.ResultSet(keys=['dets:readout_id', 'band', 'channel', 'tau_eff', 'Si', 'R0'])
+
+    o = session.query(Observations).filter(Observations.obs_id == cfg['obs_id']).one_or_none()
+
+    for fname, stream_id, ctime, path in SMURF.search_metadata_files(max_ctime=o.timestamp,reverse=True):
+        if 'bias_step' in fname:
+            bsa_fp = path
+            break
+
+    bsa = np.load(bsa_fp, allow_pickle=True).item()        
+            
+    # use G3tSmurf index to extract correct detector names
+    t = bsa['meta']['tunefile'].split('/')[-1]
+    tun = session.query(Tunes).filter(Tunes.name == t).one_or_none()
+    channels = [(c.name, c.band, c.channel) for c in tun.tuneset.channels]
+
+    for cname in channels:
+        name, band, channel = cname
+
+        try:
+            idx = np.where((bsa['bands']==band)*(bsa['channels']==channel))[0][0]
+            R0 = bsa['R0'][idx]
+            Si = bsa['Si'][idx]
+            tau = bsa['tau_eff'][idx]
+        except IndexError:
+            R0 = np.nan
+            Si = np.nan
+            tau = np.nan
+
+        bs_caldb.rows.append((name, band, channel, tau, Si, R0))
+        
+    # Get file and dataset from policy
+    policy = util.ArchivePolicy.from_params(cfg['archive']['bias_steps']['policy'])
+    dest_file, dest_dataset = policy.get_dest(cfg['obs_id']+'_bias_steps')
+    db_data = {'obs:obs_id': cfg['obs_id'], 'dataset': dest_dataset}
+    
+    logger.info(f'Writing bias step CalDb to {dest_file}.')
+    write_dataset(bs_caldb, dest_file, dest_dataset, overwrite=True)
+    
+    # add an entry to the ManifestDb at the current obs_id
+    logger.info(f'Updating Metadata Index {cfg["archive"]["bias_steps"]["index"]}')
+    db.add_entry(db_data,filename=dest_file,replace=True)
+
+def main(args=None):
+    if args is None:
+        args = sys.argv[1:]
+    parser = _get_parser()
+    config = _get_config(parser.parse_args(args))
+    print(config['_args'].iv, config['_args'].bias_group_map)
+
+    if config['verbose'] >= 1:
+        logger.setLevel('INFO')
+    if config['verbose'] >= 2:
+        sotodlib.logger.setLevel('INFO')
+    if config['verbose'] >= 3:
+        sotodlib.logger.setLevel('DEBUG')
+    
+    if config['_args'].iv:
+        logger.info(f'Creating IV CalDb for obs_id: {config["obs_id"]}')
+        _make_iv_caldb(config)
+    if config['_args'].bias_group_map:
+        logger.info(f'Creating bias group map CalDb for obs_id: {config["obs_id"]}')
+        _make_bgmap_caldb(config)
+    if config['_args'].bias_steps:
+        logger.info(f'Creating bias step CalDb for obs_id: {config["obs_id"]}')
+        _make_bias_step_caldb(config)
+
+    # Return something?
+    return True
+    

--- a/sotodlib/site_pipeline/util.py
+++ b/sotodlib/site_pipeline/util.py
@@ -2,6 +2,8 @@ import math
 import os
 import inspect
 
+from .. import core
+
 class ArchivePolicy:
     """Storage policy assistance.  Helps to determine the HDF5
     filename and dataset name for a result.
@@ -197,3 +199,16 @@ def lookup_conditional(source, key, tags=None, default=KeyError):
             if t in source:
                 return lookup_conditional(source[t], None, tags=tags, default=default)
         return default
+
+
+def promote_array_data(ctx, tod):
+    # Wrap detdb properties into tod.array_data.  This makes SO sim
+    # TOD AxisManagers look like ACT TOD AxisManagers ... we'll get an
+    # SO solution in place.
+    props = ctx.detdb.props()
+    array_data = core.AxisManager(
+        core.LabelAxis('dets', props['name']))
+    for k in props.keys:
+        array_data.wrap(k, props[k], [(0, 'dets')])
+    tod.wrap('array_data', array_data)
+    return array_data

--- a/sotodlib/site_pipeline/util.py
+++ b/sotodlib/site_pipeline/util.py
@@ -1,3 +1,7 @@
+import math
+import os
+import inspect
+
 class ArchivePolicy:
     """Storage policy assistance.  Helps to determine the HDF5
     filename and dataset name for a result.
@@ -9,9 +13,187 @@ class ArchivePolicy:
     def from_params(params):
         if params['type'] == 'simple':
             return ArchivePolicy(**params)
+        if params['type'] == 'directory':
+            return DirectoryArchivePolicy(**params)
+        raise ValueError('No handler for "type"="%s"' % params['type'])
 
     def __init__(self, **kwargs):
         self.filename = kwargs['filename']
 
     def get_dest(self, product_id):
+        """Returns (hdf_filename, dataset_addr).
+
+        """
         return self.filename, product_id
+
+
+class DirectoryArchivePolicy:
+    """Storage policy for stuff organized directly on the filesystem.
+
+    """
+    def __init__(self, **kwargs):
+        self.root_dir = kwargs['root_dir']
+        self.pattern = kwargs['pattern']
+
+    def get_dest(self, **kw):
+        """Returns full path to destination directory.
+
+        """
+        return os.path.join(self.root_dir, self.pattern.format(**kw))
+
+
+def parse_angle(angle, default_units='deg', desired_units='deg'):
+    """Convert an expression for an angle into a float in the desired
+    angle units.  This accepts floats or tuples that also state the
+    unit.  For example:
+
+      parse_angle(123.)
+        => 123.
+
+      parse_angle((60, 'arcmin'))
+        => 1.
+
+      parse_angle(1, desired_units='rad')
+        => 0.017453292519943295
+
+      parse_angle(1, default_units='rad')
+        => 57.29577951308232
+
+    The units must be one of ['rad', 'deg', 'arcmin', 'arcsec'].
+
+    """
+    units = {
+        'rad': 1.,
+        'deg': math.pi/180,
+        'arcmin': math.pi/180/60,
+        'arcsec': math.pi/180/60/60,
+    }
+    try:
+        angle = float(angle)
+    except TypeError:
+        angle, default_units = angle  # e.g. (12, 'arcmin')
+    return angle * units[default_units] / units[desired_units]
+
+
+def _filter_dict(d, bad_keys=['_stop_here']):
+    if not isinstance(d, dict):
+        return d
+    # Support for lookup_conditional
+    return {k: v for k, v in d.items()
+            if k not in bad_keys}
+
+
+def lookup_conditional(source, key, tags=None, default=KeyError):
+    """Lookup a value in a dict, with the possibility of descending
+    through nested dictionaries using tags provided by the user.
+
+    This function returns the returns source[key] unless source[key]
+    is a dict, in which case the tags (a list of strings) are each
+    tested in the dict to see if they lead to a sub-setting.
+
+    For example, if the source dictionary is {'number': {'a': 1, 'b':
+    2}} and the user requests key 'number', with tags=['a'], then the
+    returned value will be 1.
+
+    If you want a dict to be returned literally, and not crawled
+    further, include a dummy key '_stop_here', with arbitrary value
+    (this key will be removed from the result before returning to the
+    user).
+
+    The key '_default' will always cause a match, even if none of the
+    other tags match.  (This _default value also becomes the default
+    if further recursion fails to yield an exact match.)
+
+    Args:
+      source (dict): The parameter tree to search.
+      key (str): The key to terminate the search on.
+      tags (list of str or None): tags that may be auto-descended.
+      default: Value to return if the search does not resolve.  The
+        special value KeyError will instead cause a KeyError to be
+        raised if the search is not resolved.
+
+    Examples::
+
+      source = {
+        'my_param': {
+          '_default': 100.,
+          'f150': 90.
+        }
+      }
+
+      lookup_conditional(source, 'my_param')
+        => 100.
+
+      lookup_conditional(source, 'my_param', tags=['f090'])
+        => 100.
+
+      lookup_conditional(source, 'my_param', tags=['f150'])
+        => 90.
+
+      lookup_conditional(source, 'my_other_param')
+        KeyError!
+
+      lookup_conditional(source, 'my_other_param', default=0)
+        => 0
+
+      # Note _default takes precedence over default argument.
+      lookup_conditional(source, 'my_param', default=0)
+        => 100.
+
+      # Nested example:
+      source = {
+        'fit_params': {
+          '_default': {
+            'a': 12,
+            'b': 100,
+            '_stop_here': None,  # don't descend any further.
+          },
+          'f150': {
+            'SAT': {
+              'a': 1000,
+              'b': 1200,
+              '_stop_here': None,
+            },
+            'LAT': {
+              'a': 1,
+              'b': 2,
+              '_stop_here': None,
+            },
+          },
+        },
+      }
+
+      lookup_conditional(source, 'fit_params', tags=['f150', 'LAT'])
+        => {'a': 1, 'b': 2}
+
+      lookup_conditional(source, 'fit_params', tags=['LAT'])
+        => {'a': 12, 'b': 100}
+
+      lookup_conditional(source, 'fit_params', tags=['f150'])
+        => {'a': 12, 'b': 100}
+
+    """
+    if tags is None:
+        tags = []
+    if key is not None:
+        # On entry, key is not None.
+        result = default
+        if key in source:
+            result = lookup_conditional(source[key], None, tags=tags, default=default)
+        if inspect.isclass(result) and issubclass(result, Exception):
+            raise result(f"Failed to find key '{key}' in {source}")
+        return result
+    else:
+        # This block is entered on recursion.
+        if not isinstance(source, dict):
+            return source
+        if '_stop_here' in source:
+            return _filter_dict(source)
+        # Update default?
+        if '_default' in source:
+            default = _filter_dict(source['_default'])
+        # Find a tag.
+        for t in tags:
+            if t in source:
+                return lookup_conditional(source[t], None, tags=tags, default=default)
+        return default

--- a/sotodlib/site_pipeline/util.py
+++ b/sotodlib/site_pipeline/util.py
@@ -199,16 +199,3 @@ def lookup_conditional(source, key, tags=None, default=KeyError):
             if t in source:
                 return lookup_conditional(source[t], None, tags=tags, default=default)
         return default
-
-
-def promote_array_data(ctx, tod):
-    # Wrap detdb properties into tod.array_data.  This makes SO sim
-    # TOD AxisManagers look like ACT TOD AxisManagers ... we'll get an
-    # SO solution in place.
-    props = ctx.detdb.props()
-    array_data = core.AxisManager(
-        core.LabelAxis('dets', props['name']))
-    for k in props.keys:
-        array_data.wrap(k, props[k], [(0, 'dets')])
-    tod.wrap('array_data', array_data)
-    return array_data

--- a/sotodlib/tod_ops/__init__.py
+++ b/sotodlib/tod_ops/__init__.py
@@ -1,6 +1,6 @@
 from .detrend import detrend_data, detrend_tod
 from .fft_ops import rfft
-from .filters import fourier_filter
+from .filters import fourier_filter, fft_trim
 from .gapfill import \
     get_gap_fill, get_gap_fill_single, \
     get_gap_model, get_gap_model_single

--- a/sotodlib/tod_ops/detrend.py
+++ b/sotodlib/tod_ops/detrend.py
@@ -32,6 +32,8 @@ def detrend_data(tod, method='linear', axis_name='samps',
 
     """
     signal = tod[signal_name]
+    dtype_in = signal.dtype
+
     axis_idx = list(tod._assignments[signal_name]).index(axis_name)
     n_samps = signal.shape[axis_idx]
     
@@ -57,7 +59,7 @@ def detrend_data(tod, method='linear', axis_name='samps',
 
     if axis_idx != signal.ndim - 1:
         signal = signal.transpose(tuple(axis_reorder))
-    return signal
+    return signal.astype(dtype_in)
 
 def detrend_tod(tod, method='linear', signal_name='signal', axis_name='samps', count=10, out_name=None):
     """simple wrapper: to be more verbose"""

--- a/sotodlib/tod_ops/filters.py
+++ b/sotodlib/tod_ops/filters.py
@@ -26,7 +26,7 @@ def fourier_filter(tod, filt_function,
         
         filt_function: function( freqs, tod ) function that takes a set of 
             frequencies and the axis manager and returns the filter in 
-            fouier space
+            fourier space
         
         detrend: Method of detrending to be done before ffting. Can
             be 'linear', 'mean', or None.
@@ -82,8 +82,6 @@ def fourier_filter(tod, filt_function,
     else:
         raise ValueError('resize must be "zero_pad", "trim", or None')
 
-    a, b, t_1, t_2 = fft_ops.build_rfft_object(n_det, n, 'BOTH')
-
     if detrend is not None:
         signal = detrend_data(tod, detrend, axis_name=axis_name,
                              signal_name=signal_name)
@@ -91,31 +89,39 @@ def fourier_filter(tod, filt_function,
         signal = tod[signal_name]
     signal = np.atleast_2d(signal)
 
-    if other_idx is not None and other_idx != 0:
-        ## so that code can be written always along axis 1
-        signal = signal.transpose()
+    if isinstance(filt_function, identity_filter):
+        logger.info('fourier_filter: filt_function is identity; skipping FFT.')
+        signal = signal.copy()
 
-    # This copy is valid for all modes of "resize"
-    a[:,:min(n, axis.count)] = signal[:,:min(n, axis.count)]
-    a[:,min(n, axis.count):] = 0
-    
-    ## FFT Signal
-    t_1();
-    
-    ## Get Filter
-    freqs = np.fft.rfftfreq(n, delta_t)
-    filt_function.apply(freqs, tod, b, **kwargs)
+    else:
+        a, b, t_1, t_2 = fft_ops.build_rfft_object(n_det, n, 'BOTH')
 
-    ## FFT Back
-    t_2();
-    
-    # Un-pad?
-    signal = a[:,:min(n, axis.count)]
-        
+        if other_idx is not None and other_idx != 0:
+            ## so that code can be written always along axis 1
+            signal = signal.transpose()
+
+        # This copy is valid for all modes of "resize"
+        a[:,:min(n, axis.count)] = signal[:,:min(n, axis.count)]
+        a[:,min(n, axis.count):] = 0
+
+        ## FFT Signal
+        t_1()
+
+        ## Get Filter
+        freqs = np.fft.rfftfreq(n, delta_t)
+        filt_function.apply(freqs, tod, b, **kwargs)
+
+        ## FFT Back
+        t_2()
+
+        # Un-pad?
+        signal = a[:,:min(n, axis.count)]
+
+        if other_idx is not None and other_idx != 0:
+            return signal.transpose()
+
     if other_idx is None:
         return signal[0]
-    if other_idx != 0:
-        return signal.transpose()
     
     return signal
 
@@ -167,6 +173,10 @@ class _chainable:
     def _preference(f):
         return getattr(f, 'preference', 'compose')
     def __mul__(self, other):
+        if isinstance(other, identity_filter):
+            return self
+        if isinstance(self, identity_filter):
+            return other
         return FilterChain([self, other])
 
 class FilterFunc(_chainable):
@@ -272,6 +282,18 @@ fft_apply_filter = FilterApplyFunc.deco
 
 # Filtering Functions
 #################
+@fft_filter
+def identity_filter(freqs, tod, invert=False):
+    """Identity filter (gain=1 at all frequencies).
+
+    This filter has some special handling -- the FFT will not take
+    place if your only intention is to apply an identify filter; also
+    identity_filter() * other_filter() will simply return the
+    other_filter().
+
+    """
+    return np.ones(len(freqs))
+
 @fft_filter
 def low_pass_butter4(freqs, tod, fc):
     """4th-order low-pass filter with f3db at fc (Hz).

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -44,7 +44,7 @@ class MetadataTest(unittest.TestCase):
             'a_bad_string': None,
             'a_bad_float': None,
             })
-        self.assertCountEqual(arx.dtype.names, ['another_string', 'another_float'])
+        self.assertEqual(list(arx.dtype.names), ['another_string', 'another_float'])
         self.assertEqual(arx['another_string'].dtype.char, 'U')
 
     def test_001_hdf(self):
@@ -74,7 +74,7 @@ class MetadataTest(unittest.TestCase):
                'obs:obs_id': test_obs_id,
                'dataset': 'timeconst_1ms'}
         data = loader.from_loadspec(req)
-        self.assertCountEqual(data['timeconst'], [TGOOD])
+        self.assertEqual(list(data['timeconst']), [TGOOD])
 
     def test_010_manifest_basics(self):
         """Test that you can create a ManifestScheme and ManifestDb and add
@@ -171,7 +171,15 @@ class MetadataTest(unittest.TestCase):
              'name': 'tau&timeconst'}
         ]
         mtod = loader.load(spec_list, {'obs:obs_id': 'obs_00'}, detdb.props())
-        self.assertCountEqual(mtod['tau'], [T090, T090, T150, T150])
+        self.assertEqual(list(mtod['tau']), [T090, T090, T150, T150])
+
+        # Make sure that also plays well with det specs.
+        mtod = loader.load(spec_list, {'obs:obs_id': 'obs_00', 'dets:band': 'f090'},
+                           detdb.props())
+        self.assertEqual(list(mtod['tau']), [T090, T090])
+        mtod = loader.load(spec_list, {'obs:obs_id': 'obs_00', 'dets:band': 'f150'},
+                           detdb.props())
+        self.assertEqual(list(mtod['tau']), [T150, T150])
 
         # Test 2: ManifestDb specifies polcode, which crosses with
         # dataset band.
@@ -196,8 +204,15 @@ class MetadataTest(unittest.TestCase):
         # Make sure you reinit the loader, to avoid cached dbs.
         loader = metadata.SuperLoader(obsdb=obsdb, detdb=detdb)
         mtod = loader.load(spec_list, {'obs:obs_id': 'obs_00'}, detdb.props())
-        self.assertCountEqual(mtod['tau'], [T090, TBAD, TBAD, T150])
+        self.assertEqual(list(mtod['tau']), [T090, TBAD, TBAD, T150])
 
+        # Make sure that also plays well with det specs.
+        mtod = loader.load(spec_list, {'obs:obs_id': 'obs_00', 'dets:band': 'f090'},
+                           detdb.props())
+        self.assertEqual(list(mtod['tau']), [T090, TBAD])
+        mtod = loader.load(spec_list, {'obs:obs_id': 'obs_00', 'dets:band': 'f150'},
+                           detdb.props())
+        self.assertEqual(list(mtod['tau']), [TBAD, T150])
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_tod_ops.py
+++ b/tests/test_tod_ops.py
@@ -139,13 +139,15 @@ class FilterTest(unittest.TestCase):
                 tod_ops.filters.iir_filter(iir_params=iir_params),
                 tod_ops.filters.iir_filter(
                     a=iir_params.a, b=iir_params.b, fscale=iir_params.fscale),
+                tod_ops.filters.identity_filter(),
         ]:
             f = np.fft.fftfreq(tod.samps.count) * f0
             y = filt(f, tod)
             sig_filt = tod_ops.fourier_filter(tod, filt)
             sigma1 = sig_filt.std(axis=1)
             print(f'Filter takes sigma from {sigma0} to {sigma1}')
-            self.assertTrue(np.all(sigma1 < sigma0))
+            if not isinstance(filt, tod_ops.filters.identity_filter):
+                self.assertTrue(np.all(sigma1 < sigma0))
 
         # Check 1d
         sig1f = tod_ops.fourier_filter(tod, filt, signal_name='sig1d',


### PR DESCRIPTION
site_pipeline.update_smurf_caldbs

This module will generate CalDbs from various detector outputs from sodetlib and smurf. At the time of posting as draft, has the ability to add IVs, bias group maps, and bias steps. Depending on command line arguments at the time of running the script, one can update any subset of those three, in an implementation that makes it easy to add more detector metadata if things come up. 

I generated and tested everything on Katie's dataset described here https://github.com/simonsobs/pwg-scripts/tree/master/pwg-tds/real-data-coadd/noise-data, and with a config file that can be found on simons1 at `/home/jseibert/pipeline-dev/update-smurf-caldbs/config.yaml` if anyone wants to try running it themselves with a similar setup. 

A few main questions for discussion, though I'm happy to get any comments and can change things as necessary, just wanted to put a first version up for people to glance over. Lot of words below, though most of it is a brain dump so feel free to pick and choose what to read over...

1. The way this functions is that for a given obs_id, we will locate the most recent calibration and associate it with that particular obs. If a more elegant way of doing that is required, I'm happy to switch it up but this seemed easy to put in place. At some point, I had convinced myself that a time range was the more valid way to implement the CalDbs for different products (especially bias group maps) instead of just tying them to an individual obs_id, but I talked myself out of that. Happy to be reconvinced if anyone has strong feelings...
2. The IV in particular contains pieces of information that could be included for a particular obs that are a function of chosen bias point. The most obvious of these things is the responsivity estimate from the IV curve for a chosen bias point. I didn't include that here, though again I'm happy to change that if we want. The main reason for not including in this first pass is that the bias point for a given observation is currently only made available by loading the entire TOD, which is time consuming when updating the records. I built and tested this with data that was taken before a change was made in sodetlib to register the action whenever detectors are biased using those functions, but I'm not sure that action actually reports usable information. Happy to expand on this if people want to discuss it further, but for now I left it out in the interest of efficiency.
3. Should we include the Level 2 (I think this is the right level?) filename produced by sodetlib that is used to generate the CalDb somehow in metadata to make it clear what file was used in case someone wants to backtrack?

