### PR TITLE
Change how channel indexing works on load.

### DIFF
--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -1759,8 +1759,10 @@ def get_channel_mask(
         if np.isscalar(ch):
             if np.issubdtype(type(ch), np.integer):
                 # this is an absolute readout INDEX (not band*512+ch)
-                if ch >= status.num_chans:
+                if not ignore_missing and ch >= status.num_chans:
                     raise ValueError(f"Requested Index {ch} > {status.num_chans}")
+                if ch >= status.num_chans:
+                    continue
                 msk[ch] = True
 
             elif np.issubdtype(type(ch), np.floating):

--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -1726,8 +1726,7 @@ def get_channel_mask(
         List of desired channels the type of each list element is used
         to determine what it is:
 
-        * int : absolute readout index (ex: if you just want to load range(X)
-                channels or range(100,200) ). Useful for batching.
+        * int : index of channel in file. Useful for batching.
         * (int, int) : band, channel
         * string : channel name (requires archive or obsfiledb)
         * float : frequency in the smurf status (or should we use channel assignment?)

--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -1726,7 +1726,8 @@ def get_channel_mask(
         List of desired channels the type of each list element is used
         to determine what it is:
 
-        * int : absolute readout channel
+        * int : absolute readout index (ex: if you just want to load range(X)
+                channels or range(100,200) ). Useful for batching.
         * (int, int) : band, channel
         * string : channel name (requires archive or obsfiledb)
         * float : frequency in the smurf status (or should we use channel assignment?)
@@ -1758,10 +1759,11 @@ def get_channel_mask(
     for ch in ch_list:
         if np.isscalar(ch):
             if np.issubdtype(type(ch), np.integer):
-                # this is an absolute readout channel
-                if not ignore_missing and ~np.any(status.mask == ch):
-                    raise ValueError(f"channel {ch} not found")
-                msk[status.mask == ch] = True
+                # this is an absolute readout INDEX (not band*512+ch)
+                #if not ignore_missing and ~np.any(status.mask == ch):
+                if ch >= status.num_chans:
+                    raise ValueError(f"Requested Index {ch} > {status.num_chans}")
+                msk[ch] = True
 
             elif np.issubdtype(type(ch), np.floating):
                 # this is a resonator frequency

--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -1759,7 +1759,6 @@ def get_channel_mask(
         if np.isscalar(ch):
             if np.issubdtype(type(ch), np.integer):
                 # this is an absolute readout INDEX (not band*512+ch)
-                #if not ignore_missing and ~np.any(status.mask == ch):
                 if ch >= status.num_chans:
                     raise ValueError(f"Requested Index {ch} > {status.num_chans}")
                 msk[ch] = True


### PR DESCRIPTION
Recently we realized that the indexing of how to build a channel mask was pretty not-useful if you just wanted to blindly load sections of channels. This updates `load_file` and `get_channel_mask` to just accept `channels= range(x,y)` and return the resonator channels at those indexes. Will be useful for batching and just limiting detector loads in general.

Solves this issue: https://github.com/simonsobs/sotodlib/issues/278 