### PR TITLE
Adding calibration observations to the G3tSmurf Observations table

### DIFF
--- a/sotodlib/io/g3tsmurf_db.py
+++ b/sotodlib/io/g3tsmurf_db.py
@@ -59,7 +59,10 @@ class Observations(Base):
         The end of the observation as a datetime object
     tag : string
         Tags for this observation in a single comma delimited string. These are populated 
-        through tags set while running sodetlib's stream data functions. 
+        through tags set while running sodetlib's stream data functions.
+    calibration : bool
+        Boolean that stores whether or not the observation is a calibration-type observation
+        i.e. an IV curve, a bias step, etc. 
     files : list of SQLAlchemy instances of Files
         The list of .g3 files in this observation built through a relationship
         to the Files table. [f.name for f in Observation.files] will return
@@ -85,6 +88,8 @@ class Observations(Base):
     stop = db.Column(db.DateTime)
     
     tag = db.Column(db.String)
+
+    calibration = db.Column(db.Boolean)
     ## one to many
     files = relationship("Files", back_populates='observation') 
     

--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -697,9 +697,9 @@ class G3tSmurf:
                     break
 
             if calibration:
-                obs_id=f"cal_{stream_id}_{session_id}",
+                obs_id=f"cal_{stream_id}_{session_id}"
             else:
-                obs_id=f"{stream_id}_{session_id}",
+                obs_id=f"{stream_id}_{session_id}"
             
             # Build Observation
             obs = Observations(
@@ -1061,24 +1061,19 @@ class G3tSmurf:
         for action, stream_id, ctime, path in self.search_metadata_actions(
             min_ctime=min_ctime, max_ctime=max_ctime
         ):
-            if action in SMURF_ACTIONS["observations"]:
+            if action in SMURF_ACTIONS["observations"] or action in SMURF_ACTIONS["calibrations"]:
                 try:
                     obs_path = os.listdir(os.path.join(path, "outputs"))
                     logger.debug(
                         f"Add new Observation: {stream_id}, {ctime}, {obs_path}"
                     )
-                    self.add_new_observation(stream_id, action, ctime, session, calibration=False)
-                except Exception as e:
-                    self._process_index_error(
-                        session, e, stream_id, ctime, path, stop_at_error
+                    self.add_new_observation(
+                        stream_id, 
+                        action, 
+                        ctime, 
+                        session, 
+                        calibration=(action in SMURF_ACTIONS["calibrations"])
                     )
-            if action in SMURF_ACTIONS["calibrations"]:
-                try:
-                    obs_path = os.listdir(os.path.join(path, "outputs"))
-                    logger.debug(
-                        f"Add new Observation: {stream_id}, {ctime}, {obs_path}"
-                    )
-                    self.add_new_observation(stream_id, action, ctime, session, calibration=True)
                 except Exception as e:
                     self._process_index_error(
                         session, e, stream_id, ctime, path, stop_at_error


### PR DESCRIPTION
This PR adds calibration observations to the G3tSmurf observations table. In particular, it adds `take_iv`, `take_bias_steps`, `take_bgmap`, and `take_noise`, gives any observations an obs_id that looks something like `cal_<stream_id>_<session_id>`. It also adds a `calibration` column to the Observations table, which will require a database update script before we can merge this into master, which @kmharrington said she would help provide at least an outline for. 