### PR TITLE
Multi-slot Bugfix

### DIFF
--- a/site-scripts/update_g3tsmurf_database.py
+++ b/site-scripts/update_g3tsmurf_database.py
@@ -51,7 +51,12 @@ if __name__ == '__main__':
     new_obs = session.query(Observations).filter( Observations.start >= min_time,
                                                   Observations.stop == None).all()
     for obs in new_obs:
-        SMURF.update_observation_files(obs, session, force=True)
+        SMURF.update_observation_files(
+            obs, 
+            session, 
+            force=True,
+            max_early=90,
+        )
 
     if args.detdb_filename is not None:
         dump_DetDb(SMURF, args.detdb_filename)

--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -658,6 +658,7 @@ class G3tSmurf:
         if obs is None:
             x = session.query(Files.name)
             x = x.filter(
+                Files.stream_id == stream_id,
                 Files.start >= dt.datetime.utcfromtimestamp(action_ctime - max_early)
             )
             x = x.order_by(Files.start).first()
@@ -734,7 +735,8 @@ class G3tSmurf:
             return
 
         x = session.query(Files.name).filter(
-            Files.start >= obs.start - dt.timedelta(seconds=max_early)
+            Files.stream_id == obs.stream_id,
+            Files.start >= obs.start - dt.timedelta(seconds=max_early),
         )
         x = x.order_by(Files.start).first()
         if x is None:


### PR DESCRIPTION
A couple bug fixes found in LATR testing. Add stream-id to file queries and extend the buffering time in the updates because there are large delays between when frames are being made.