### PR TITLE
Updates to get things working for End-to-end Testing

### DIFF
--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -2367,18 +2367,19 @@ def load_file(
         iir_params.wrap("b", status.filter_b)
         iir_params.wrap("fscale", 1/status.flux_ramp_rate_hz)
         aman.wrap("iir_params", iir_params)
+    
+    if not no_signal:
+        aman.wrap(
+            "signal", 
+            np.zeros((aman[det_axis].count, aman["samps"].count), "float32"), 
+                     [(0, det_axis), (1, "samps")]
+        )
+        for idx in range(aman[det_axis].count):
+            io_load.hstack_into(aman.signal[idx], streams["data"][ch_info.rchannel[idx]])
 
-    # Conversion from DAC counts to squid phase
-    aman.wrap(
-        "signal", 
-        np.zeros((aman[det_axis].count, aman["samps"].count), "float32"), 
-                 [(0, det_axis), (1, "samps")]
-    )
-    for idx in range(aman[det_axis].count):
-        io_load.hstack_into(aman.signal[idx], streams["data"][ch_info.rchannel[idx]])
-
-    rad_per_count = np.pi / 2 ** 15
-    aman.signal *= rad_per_count
+        # Conversion from DAC counts to squid phase
+        rad_per_count = np.pi / 2 ** 15
+        aman.signal *= rad_per_count
     
     temp = core.AxisManager(aman.samps.copy())
     if load_primary:
@@ -2412,7 +2413,7 @@ def load_g3tsmurf_obs(
     obs_id, 
     dets=None, 
     samples=None, 
-    no_signal=None
+    no_signal=None,
     **kwargs
     ):
     """Obsloader function for g3tsmurf data archives.

--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -128,7 +128,7 @@ def _file_has_end_frames(filename):
             break
         frame = frames[0]
         if frame.type == spt3g_core.G3FrameType.Observation:
-            if frame["stream_placement"]=="end":
+            if frame.get("stream_placement")=="end":
                 ended = True
                 break
         if frame.type == spt3g_core.G3FrameType.Wiring:

--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -1471,6 +1471,7 @@ class SmurfStatus:
         self.status = status
         self.start = self.status.get("start")
         self.stop = self.status.get("stop")
+        self.stream_id = self.status.get("stream_id")
 
         self.aman = core.AxisManager()
 
@@ -1599,6 +1600,7 @@ class SmurfStatus:
                     break
                 frame = frames[0]
                 if str(frame.type) == "Wiring":
+                    status["stream_id"] = frame["sostream_id"]
                     if status.get("start") is None:
                         status["start"] = frame["time"].time / spt3g_core.G3Units.s
                         status["stop"] = frame["time"].time / spt3g_core.G3Units.s
@@ -1688,6 +1690,7 @@ class SmurfStatus:
         status = {
             "start": status_frames[0].time.timestamp(),
             "stop": status_frames[-1].time.timestamp(),
+            "stream_id": stream_id,
         }
         cur_file = None
         for frame_info in tqdm(status_frames, disable=(not show_pb)):
@@ -1884,7 +1887,7 @@ def _get_tuneset_channel_names(status, ch_map, archive):
     else:
         logger.info("Tune information not in SmurfStatus, using most recent Tune")
         tune = session.query(Tunes).filter(
-            Tunes.start <= dt.datetime.utcfromtimestamp(status.start)
+            Tunes.start <= dt.datetime.utcfromtimestamp(status.start),
             Tunes.stream_id == status.stream_id,
         )
         tune = tune.order_by(db.desc(Tunes.start)).first()


### PR DESCRIPTION
Various things we needed to update just in general or for end-to-end tests.

* use observation frames to determine if an observation. Technically completely closes #224 even though I apparently decided to close the issue before doing this. 
* add stream_id to the SmurfStatus object because we need a way to pass that around and that makes the most sense
* Add the `no_signal=True/False` option to the g3tsmurf loader. closes #269  even though it's not actually needed for this I just felt like finally doing that. 