### PR TITLE
Clean Up for the g3tsmurf update script

### DIFF
--- a/docs/g3tsmurf.rst
+++ b/docs/g3tsmurf.rst
@@ -190,6 +190,7 @@ timestreams.
 
 
 .. _g3tsmurf-update-section:
+
 Database Creation and Update Script
 ====================================
 

--- a/docs/g3tsmurf.rst
+++ b/docs/g3tsmurf.rst
@@ -188,68 +188,25 @@ the "_" will be assumed to be in the same observation/streaming session. The
 metadata searches are done through the action folders and their produced
 timestreams.
 
-    
-Database Creation
-==================
 
-To build a database from scratch, we create a G3tSmurf instance using a database
-path that does not already exist, index the timestream folder, and then index 
-the metadata folder::
-
-    SMURF = G3tSmurf(archive_path='/path/to/data/timestreams/',
-                     meta_path='/path/to/data/smurf/,
-                     db_path='/path/to/database.db')
-
-    SMURF.index_archive()
-    SMURF.index_metadata()
-
-There are options for inputting a minimum ctime if desired.
-
-
-
-G3tSmurf Update Script
-======================
+.. _g3tsmurf-update-section:
+Database Creation and Update Script
+====================================
 
 Keeping the databases updated requires a little care when we are building
 databases while data is actively being taken. To assist with this there is
-an **update_g3tsmurf_database.py** script saved within the **pipelines** folder.
-This
-script takes the *data_prefix* which is the path to the main save folders and
-expects to find the *timestreams* and *smurf* folders at that path. The
-*db_path* is the path to the database to be created or updated. The user running
-this script must have read, write, and execute permissions to that file.
+an **update_g3tsmurf_database.py** script saved within the
+**sotodlib.site_pipeline** folder. This script takes the *data_prefix* which is 
+the path to the main save folders and expects to find the *timestreams* and
+*smurf* folders at that path. The *db_path* is the path to the database to be
+created or updated. The user running this script must have read, write, and 
+execute permissions to that file.
 
-Here is the help for this script:: 
+Here is the information for this script:
 
-    prompt>> python3 update_g3tsmurf_database.py --help
-
-    usage: update_g3tsmurf_database.py [-h]
-                                   [--timestream-folder TIMESTREAM_FOLDER]
-                                   [--smurf-folder SMURF_FOLDER]
-                                   [--detdb-filename DETDB_FILENAME]
-                                   [--update-delay UPDATE_DELAY]
-                                   [--from-scratch]
-                                   data_prefix db_path
-    
-    positional arguments:
-    data_prefix           The prefix to data locations, use individual locations
-                          flags if data is stored in non-standard folders
-    db_path               Path to Database to update
-    
-    optional arguments:
-    -h, --help           show this help message and exit
-    --timestream-folder TIMESTREAM_FOLDER
-                         Absolute path to folder with .g3 timestreams.
-                         Overrides data_prefix
-    --smurf-folder SMURF_FOLDER
-                         Absolute path to folder with pysmurf archived data.
-                         Overrides data_prefix
-    --detdb-filename DETDB_FILENAME
-                         File for dumping the context detector database
-    --update-delay UPDATE_DELAY
-                         Days to subtract from now to set as minimum ctime
-    --from-scratch       Builds or updates database from scratch
-    
+.. argparse::
+    :module: sotodlib.site_pipeline.update_g3tsmurf_database
+    :func: get_parser
 
 Building off G3tSmurf
 =====================

--- a/docs/site_pipeline.rst
+++ b/docs/site_pipeline.rst
@@ -17,6 +17,12 @@ quick-turnaround data processing at the observatory.
 Pipeline Elements
 =================
 
+update-g3tsmurf-db
+-------------------
+
+This script set up to create and maintain g3tsmurf databases. :ref:`See details
+here<g3tsmurf-update-section>`.
+
 imprinter
 ----------
 

--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -180,7 +180,7 @@ class G3tSmurf:
     def _create_frame_types(self):
         session = self.Session()
         if not session.query(FrameType).all():
-            print("Creating FrameType table...")
+            logger.info("Creating FrameType table...")
             for k in type_key:
                 ft = FrameType(type_name=k)
                 session.add(ft)
@@ -349,11 +349,11 @@ class G3tSmurf:
 
     def index_archive(
         self,
-        verbose=False,
         stop_at_error=False,
         skip_old_format=True,
         min_ctime=None,
         max_ctime=None,
+        show_pb=True,
     ):
         """
         Adds all files from an archive to the File and Frame sqlite tables.
@@ -361,8 +361,6 @@ class G3tSmurf:
 
         Args
         ----
-        verbose: bool
-            Verbose mode
         stop_at_error: bool
             If True, will stop if there is an error indexing a file.
         skip_old_format: bool
@@ -374,6 +372,8 @@ class G3tSmurf:
         max_ctime: int, float, or None
             If set, files with session-ids higher than this ctime will be
             skipped.
+        show_pb: bool
+            If true, will show progress bar for file indexing
         """
         session = self.Session()
         indexed_files = [f[0] for f in session.query(Files.name).all()]
@@ -398,21 +398,20 @@ class G3tSmurf:
                             continue
                     files.append(path)
 
-        if verbose:
-            print(f"Indexing {len(files)} files...")
+        logger.info(f"Indexing {len(files)} files...")
 
-        for f in tqdm(sorted(files)[::-1]):
+        for f in tqdm(sorted(files)[::-1], disable=(not show_pb)):
             try:
                 self.add_file(os.path.join(root, f), session)
                 session.commit()
             except IntegrityError as e:
                 # Database Integrity Errors, such as duplicate entries
                 session.rollback()
-                print(e)
+                logger.warning(f"Integrity error with error {e}")
             except RuntimeError as e:
                 # End of stream errors, for G3Files that were not fully flushed
                 session.rollback()
-                print(f"Failed on file {f} due to end of stream error!")
+                logger.warning(f"Failed on file {f} due to end of stream error!")
             except Exception as e:
                 # This will catch generic errors such as attempting to load
                 # out-of-date files that do not have the required frame
@@ -420,8 +419,7 @@ class G3tSmurf:
                 session.rollback()
                 if stop_at_error:
                     raise e
-                elif verbose:
-                    print(f"Failed on file {f}:\n{e}")
+                logger.warning(f"Failed on file {f}:\n{e}")
         session.close()
 
     def add_new_channel_assignment(self, stream_id, ctime, cha, cha_path, session):

--- a/sotodlib/site_pipeline/update_g3tsmurf_database.py
+++ b/sotodlib/site_pipeline/update_g3tsmurf_database.py
@@ -1,10 +1,16 @@
+"""
+Script for running updates on (or creating) a g3tsmurf database. This setup
+is specifically designed to work when the data is dynamically coming in. Meaning is 
+is designed to work from something like a cronjob. 
+"""
 import os
 
 import datetime as dt
 import numpy as np
 import argparse
 
-from sotodlib.io.load_smurf import G3tSmurf, Observations, dump_DetDb
+import logging
+from sotodlib.io.load_smurf import G3tSmurf, Observations, dump_DetDb, logger
 
 
 if __name__ == '__main__':
@@ -23,6 +29,9 @@ if __name__ == '__main__':
                                default=2, type=float)
     parser.add_argument('--from-scratch', help="Builds or updates database from scratch",
                         action="store_true")
+    parser.add_argument("--verbosity", help="increase output verbosity. 0:Error, 1:Warning, 2:Info(default), 3:Debug",
+                       default=2, type=int)
+
     
     args = parser.parse_args()
     
@@ -32,7 +41,20 @@ if __name__ == '__main__':
     if args.smurf_folder is None:
         args.smurf_folder = os.path.join( args.data_prefix, 'smurf/')
     
-    
+    if args.verbosity > 1:
+        show_pb=True
+    else:
+        show_pb=False
+        
+    if args.verbosity == 0:
+        logger.setLevel(logging.ERROR)
+    elif args.verbosity == 1:
+        logger.setLevel(logging.WARNING)
+    elif args.verbosity == 2:
+        logger.setLevel(logging.INFO)
+    elif args.verbosity == 3:
+        logger.setLevel(logging.DEBUG)
+        
     SMURF = G3tSmurf(args.timestream_folder, 
                      db_path=args.db_path,
                      meta_path=args.smurf_folder)
@@ -43,7 +65,7 @@ if __name__ == '__main__':
     else:
         min_time = dt.datetime.now() - dt.timedelta(days=args.update_delay)
         
-    SMURF.index_archive(min_ctime=min_time.timestamp())
+    SMURF.index_archive(min_ctime=min_time.timestamp(), show_pb=show_pb)
     SMURF.index_metadata(min_ctime=min_time.timestamp())
 
     session = SMURF.Session()

--- a/sotodlib/site_pipeline/update_g3tsmurf_database.py
+++ b/sotodlib/site_pipeline/update_g3tsmurf_database.py
@@ -12,9 +12,7 @@ import argparse
 import logging
 from sotodlib.io.load_smurf import G3tSmurf, Observations, dump_DetDb, logger
 
-
-if __name__ == '__main__':
-    
+def get_parser():
     parser = argparse.ArgumentParser()
     parser.add_argument('data_prefix', help="The prefix to data locations, use individual"
                                             "locations flags if data is stored in non-standard folders")
@@ -31,8 +29,11 @@ if __name__ == '__main__':
                         action="store_true")
     parser.add_argument("--verbosity", help="increase output verbosity. 0:Error, 1:Warning, 2:Info(default), 3:Debug",
                        default=2, type=int)
+    return parser
 
+if __name__ == '__main__':
     
+    parser = get_parser()
     args = parser.parse_args()
     
     if args.timestream_folder is None:


### PR DESCRIPTION
Several things I've been meaning to do for awhile for the database update script that's part of the first light pipeline. Moved to the correct place, print statements are now entirely replaced with logger, control over logging level in the script, and some documentation updates. 