### PR TITLE
Batched Loading of level 2 AxisManagers

### DIFF
--- a/docs/g3tsmurf.rst
+++ b/docs/g3tsmurf.rst
@@ -239,15 +239,15 @@ Batched load of Observations
 ============================
 
 Loading long large observations into memory at once can cause issues with memory
-usage, especially on smaller computing facities. This function is a generator
+usage, especially on smaller computing facilities. This function is a generator
 than can be called to automatically split observations into smaller sections.
 
 .. automodule:: sotodlib.io.g3tsmurf_utils
     :special-members: get_batch
     :noindex:
 
-Obervations Files
-=================
+Observation Files
+==================
 
 There are many instances where we might want to load the SMuRF metadata
 associated with actions that have made it into the database. These function take

--- a/docs/g3tsmurf.rst
+++ b/docs/g3tsmurf.rst
@@ -119,7 +119,7 @@ AxisManagers loaded with G3tSmurf will all have the form::
             'TESRelaySetting', 'UnixTime'
         biases (optional): (bias_lines, samps)
             Bias values during the data
-        ch_info : AxisManager (dets,)
+        det_info : AxisManager (dets,)
             Information about channels, including SMuRF band, channel,
              frequency.
 
@@ -209,11 +209,13 @@ Here is the information for this script:
     :module: sotodlib.site_pipeline.update_g3tsmurf_database
     :func: get_parser
 
-Building off G3tSmurf
-=====================
+Utilities with G3tSmurf
+------------------------
 
+File System Searches
+====================
 Several of the generators used in the database indexing could be useful for
-building calibration databases off the same file set.
+building search functions off the same file set.
 **G3tSmurf.search_metadata_actions** and **G3tSmurf.search_metadata_files** are
 generators which can be used in loops to easily page through either actions or
 files. For Example::
@@ -232,8 +234,35 @@ files. For Example::
     
         return os.path.join(base_dir, 'outputs',info)
 
+ 
+Batched load of Observations
+============================
+
+Loading long large observations into memory at once can cause issues with memory
+usage, especially on smaller computing facities. This function is a generator
+than can be called to automatically split observations into smaller sections.
+
+.. automodule:: sotodlib.io.g3tsmurf_utils
+    :special-members: get_batch
+    :noindex:
+
+Obervations Files
+=================
+
+There are many instances where we might want to load the SMuRF metadata
+associated with actions that have made it into the database. These function take
+an obs_id and a G3tSmurf instance and return paths or file lists. 
+
+.. automodule:: sotodlib.io.g3tsmurf_utils
+    :special-members: get_obs_folder, get_obs_outputs, get_obs_plots
+    :noindex:
+
 Usage with Context
 ------------------
+
+.. py:module:: sotodlib.io.load_smurf
+    :noindex:
+
 The G3tSmurf database can now be used with the larger `sotodlib` Context system.
 In this setup, the main G3tSmurf database is both the ObsFileDb and the ObsDb.
 The DetDb needs to be created using the `dump_DetDb(SMURF, detdb_file)`. This

--- a/sotodlib/__init__.py
+++ b/sotodlib/__init__.py
@@ -26,6 +26,6 @@ import logging
 logger = logging.getLogger(__name__)
 _log_fmt = '%(levelname)s: %(name)s: %(message)s'
 _ch = logging.StreamHandler()
-_ch.setLevel(logging.DEBUG)
+_ch.setLevel(logging.INFO)
 _ch.setFormatter(logging.Formatter(_log_fmt))
 logger.addHandler(_ch)

--- a/sotodlib/io/g3tsmurf_utils.py
+++ b/sotodlib/io/g3tsmurf_utils.py
@@ -72,7 +72,19 @@ def get_batch(
     test = False,
     load_file_args={},
 ):
-    """Generator to loop through and load AxisManagers of sections of Observations
+    """A Generator to loop through and load AxisManagers of sections of
+    Observations. When run with none of the optional arguments it will default
+    to returning the full observations. Some arguments over-write others as
+    described in the docstrings below.
+
+    Example usage::
+
+        for aman in get_batch(obs_id, archive, ram_limit=2e9):
+            run_analysis_pipeline(aman)
+
+        for aman in get_batch(obs_id, archive, n_dets=200):
+            run_analysis_pipeline(aman)
+        
     
     Arguments
     ----------

--- a/sotodlib/io/g3tsmurf_utils.py
+++ b/sotodlib/io/g3tsmurf_utils.py
@@ -1,0 +1,50 @@
+"""Utility functions for interacting with level 2 data and g3tsmurf
+"""
+
+from sotodlib.io.g3tsmurf_db import Observations
+
+def get_obs_folder(obs_id, archive):
+    """
+    Get the folder associated with the observation action. Assumes
+    everything is following the standard suprsync formatting.
+    """
+    session = archive.Session()
+    obs = session.query(Observations).filter(Observations.obs_id == obs_id).one()
+    
+    return os.path.join(
+        archive.meta_path, 
+        str(obs.action_ctime)[:5], 
+        obs.stream_id, 
+        str(obs.action_ctime)+"_"+obs.action_name,
+    )
+    
+def get_obs_outputs(obs_id, archive):
+    """
+    Get the output files associated with the observation action. Assumes
+    everything is following the standard suprsync formatting. Returns 
+    absolute paths since everything in g3tsmurf is absolute paths.
+    """
+    path = os.path.join(
+        get_obs_folder(obs_id,archive),
+        "outputs"
+    )
+    
+    if not os.path.exists(path):
+        logger.error(f"Path {path} does not exist, how does {obs.obs_id} exist?")
+    return [os.path.join(path,f) for f in os.listdir(path)]
+
+
+def get_obs_plots(obs_id, archive):
+    """
+    Get the output plots associated with the observation action. Assumes
+    everything is following the standard suprsync formatting. Returns 
+    absolute paths since everything in g3tsmurf is absolute paths.
+    """
+    path = os.path.join(
+        get_obs_folder(obs_id,archive),
+        "plots"
+    )
+    
+    if not os.path.exists(path):
+        logger.error(f"Path {path} does not exist, how does {obs.obs_id} exist?")
+    return [os.path.join(path,f) for f in os.listdir(path)]

--- a/sotodlib/io/g3tsmurf_utils.py
+++ b/sotodlib/io/g3tsmurf_utils.py
@@ -3,8 +3,14 @@
 
 import os
 import numpy as np
+import logging
 
-from sotodlib.io.g3tsmurf_db import Observations
+from sotodlib.io.load_smurf import load_file
+from sotodlib.io.g3tsmurf_db import Observations, Files
+
+
+logger = logging.getLogger(__name__)
+
 
 def get_obs_folder(obs_id, archive):
     """
@@ -52,3 +58,126 @@ def get_obs_plots(obs_id, archive):
     if not os.path.exists(path):
         logger.error(f"Path {path} does not exist, how does {obs.obs_id} exist?")
     return [os.path.join(path,f) for f in os.listdir(path)]
+
+def get_batch( 
+    obs_id, 
+    archive,
+    ram_limit=None, 
+    n_det_chunks=None,
+    n_samp_chunks=None, 
+    n_dets=None, 
+    n_samps=None, 
+    det_chunks=None, 
+    samp_chunks=None,
+    test = False,
+    load_file_args={},
+):
+    """Generator to loop through and load AxisManagers of sections of Observations
+    
+    Arguments
+    ----------
+    obs_id : string
+        Level 2 observation IDs
+    archive : G3tSmurf Instance 
+        The G3tSmurf database connected to the obs_id
+    ram_limit : None or float
+        A (very simplistically calculated) limit on RAM per AxisManager. If specified 
+        it overrides all other inputs for how the AxisManager is split.
+    n_det_chunks : None or int
+        number of chunks of detectors to split the observation by. Each AxisManager
+        will have N_det = N_obs_det / n_det_chunks. If specified, it overrides n_dets
+        and det_chunks arguments.
+    n_samp_chunks: None or int
+        number of chunks of samples to split the observation by. Each AxisManager
+        will have N_samps = N_obs_samps / n_samps_chunks. If specified, it overrides n_samps
+        and samp_chunks arguments.
+    n_dets : None or int
+        number of detectors to load per AxisManager. If specified, it overrides the
+        det_chunks argument.
+    n_samps : None or int
+        number of samples to load per AxisManager. If specified it overrides the samps_chunks
+        arguments.
+    det_chunks: None or list of lists, tuples, or ranges
+        if specified, each entry in the list is successively passed to load the AxisManagers 
+        as  `load_file(... channels = list[i] ... )`
+    samp_chunks: None or list of tuples
+        if specified, each entry in the list is successively passed to load the AxisManagers 
+        as  `load_file(... samples = list[i] ... )`
+    test: bool
+        If true, yields a tuple of (det_chunks, samp_chunks) instead of a loaded AxisManager
+    load_file_kwargs: dict
+        additional arguments to pass to load_smurf
+    
+    Yields
+    --------
+    AxisManagers with loaded sections of data
+    """
+    
+    session = archive.Session()
+    obs = session.query(Observations).filter(Observations.obs_id==obs_id).one()
+    db_files = session.query(Files).filter(Files.obs_id==obs_id).order_by(Files.start)
+    filenames = sorted( [f.name for f in db_files])
+    
+    ts = obs.tunesets[0] ## if this throws an error we have some fallbacks
+    obs_dets, obs_samps = len(ts.dets), obs.n_samples
+    
+    logger.debug(f"{obs_id} has (n_dets, n_samps): ({obs_dets}, {obs_samps})")
+    if ram_limit is not None:
+        pts_limit = int(ram_limit // 4)
+        n_samp_chunks = 1
+        n_samps = obs_samps
+        n_dets = pts_limit // n_samps   
+        while n_dets == 0:
+            n_samp_chunks += 1
+            n_samps = obs_samps//n_samp_chunks
+            n_dets= pts_limit // (n_samps)
+        n_det_chunks = int(np.ceil( obs_dets/n_dets ))
+
+    if n_det_chunks is not None and n_dets is not None:
+        logger.warning("Both n_det_chunks and n_dets specified, n_det_chunks overrides")
+    if n_samp_chunks is not None and n_samps is not None:
+        logger.warning("Both n_samp_chunks and n_samps specified, n_samp_chunks overrides")
+        
+    if n_det_chunks is not None:
+        n_dets = int(np.ceil(obs_dets/n_det_chunks))
+        det_chunks = [range(i*n_dets,min((i+1)*n_dets,obs_dets)) for i in range(n_det_chunks)]
+    if n_samp_chunks is not None:
+        n_samps = int(np.ceil(obs_samps/n_samp_chunks))
+        samp_chunks = [(i*n_samps,min((i+1)*n_samps,obs_samps)) for i in range(n_samp_chunks)]
+
+    if n_dets is not None:
+        n_det_chunks = int(np.ceil(obs_dets/n_dets))
+        det_chunks = [range(i*n_dets,min((i+1)*n_dets,obs_dets)) for i in range(n_det_chunks)]
+    if n_samps is not None:
+        n_samp_chunks = int(np.ceil(obs_samps/n_samps))
+        samp_chunks = [(i*n_samps,min((i+1)*n_samps,obs_samps)) for i in range(n_samp_chunks)]
+        
+    if det_chunks is None:
+        det_chunks = [range(0,obs_dets)]
+    if samp_chunks is None:
+        samp_chunks = [(0,obs_samps)]
+        
+    ## should we let folks overwrite this here?
+    if "archive" in load_file_args:
+        archive = load_file_args.pop("archive")
+        
+    logger.debug(f"Loading data with det_chunks: {det_chunks}.")
+    logger.debug(f"Loading data in samp_chunks: {samp_chunks}.")
+    
+    try:
+        for det_chunk in det_chunks:
+            for samp_chunk in samp_chunks:
+                if test:
+                    yield (det_chunk, samp_chunk)
+                else:
+                    yield load_file( 
+                        filenames, 
+                        channels=det_chunk, 
+                        samples=samp_chunk, 
+                        archive=archive,
+                        **load_file_args,
+                    )
+    except GeneratorExit:
+        pass
+    session.close()
+    

--- a/sotodlib/io/g3tsmurf_utils.py
+++ b/sotodlib/io/g3tsmurf_utils.py
@@ -1,6 +1,9 @@
 """Utility functions for interacting with level 2 data and g3tsmurf
 """
 
+import os
+import numpy as np
+
 from sotodlib.io.g3tsmurf_db import Observations
 
 def get_obs_folder(obs_id, archive):
@@ -10,6 +13,7 @@ def get_obs_folder(obs_id, archive):
     """
     session = archive.Session()
     obs = session.query(Observations).filter(Observations.obs_id == obs_id).one()
+    session.close()
     
     return os.path.join(
         archive.meta_path, 

--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -17,7 +17,6 @@ from enum import Enum
 import logging
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 from .. import core
 from . import load as io_load


### PR DESCRIPTION
The main additional function here came from discussions at the face-to-face where we wanted to make easier ways to get sections of observations instead of just loading complete observations. `get_batch` is a generator that will yield AxisManagers that are subsets of complete observations. 

@mhasself @jlashner @jseibert575  Interested in what you all think of this?