### PR TITLE
HWPSS simulation fix

### DIFF
--- a/pipelines/toast_so_sim.py
+++ b/pipelines/toast_so_sim.py
@@ -302,8 +302,6 @@ def main():
 
         memreport("after atmosphere", comm.comm_world)
 
-        so_tools.simulate_hwpss(args, comm, data, mc, totalname)
-
         # update_atmospheric_noise_weights(args, comm, data, freq, mc)
 
         toast_tools.add_signal(
@@ -319,6 +317,10 @@ def main():
         toast_tools.simulate_noise(args, comm, data, mc, totalname)
 
         memreport("after simulating noise", comm.comm_world)
+
+        so_tools.simulate_hwpss(args, comm, data, mc, totalname)
+
+        memreport("after simulating HWPSS", comm.comm_world)
 
         so_tools.apply_sim_sso(args, comm, data, mc, totalname)
 

--- a/sotodlib/toast/sim_hwpss.py
+++ b/sotodlib/toast/sim_hwpss.py
@@ -16,7 +16,11 @@ XAXIS, YAXIS, ZAXIS = np.eye(3)
 
 
 class OpSimHWPSS(toast.Operator):
-    """ Simulate HWP synchronous signal """
+    """ Simulate HWP synchronous signal 
+        N.B: The HWPSS template is interpolated (with a 5th order spline interpolation).
+            Interpolation errors produce spurious peaks in the frequency domain which are 7 to 8 orders of magnitude below
+            the amplitude of the original signal.
+    """
 
     def __init__(self, name, fname_hwpss, mc=0):
         """

--- a/sotodlib/toast/sim_hwpss.py
+++ b/sotodlib/toast/sim_hwpss.py
@@ -6,7 +6,7 @@ import pickle
 import sys
 
 import numpy as np
-import scipy.signal
+import scipy.interpolate as scp
 
 import toast
 import toast.qarray as qa
@@ -44,19 +44,8 @@ class OpSimHWPSS(toast.Operator):
         for obs in data.obs:
             tod = obs["tod"]
             focalplane = obs["focalplane"]
-            
             # Get HWP angle
             chi = tod.local_hwp_angle()
-            
-            # Get times
-            times = tod.local_times()
-            
-            # Fast sample HWP angle with a factor 100
-            fast_time = np.linspace(times[0], times[-1], 1+(len(times)-1)*100)
-            hwp_rate = (chi[1] - chi[0]) / (times[1] - times[0]) / (2*np.pi) # Assuming constant HWP rotation
-            fast_chi = chi[0] + 2*np.pi*hwp_rate*(fast_time-fast_time[0])
-            fast_chi %= 2*np.pi
-            
             for det in tod.local_dets:
                 signal = tod.local_signal(det, self._name)
                 band = focalplane[det]["band"]
@@ -81,7 +70,7 @@ class OpSimHWPSS(toast.Operator):
 
                 # Get polarization weights
 
-                iweights = np.ones_like(fast_time)
+                iweights = np.ones_like(signal.size)
                 qweights = np.cos(2 * det_psi)
                 uweights = np.sin(2 * det_psi)
         
@@ -111,31 +100,24 @@ class OpSimHWPSS(toast.Operator):
                 # Scale HWPSS for observing elevation
                 el_ref = np.radians(50)
                 scale = np.sin(el_ref) / np.sin(el)
-
-                # Interpolate elevation scaling factor for fast sampling
-                fast_scale = np.interp(fast_time,times,scale)
                 
                 # Observe HWPSS with the detector
 
                 iquv = (transmission + reflection).T
-                fast_iquss = (
-                    iweights * np.interp(fast_chi, self.chis, iquv[0]) +
-                    qweights * np.interp(fast_chi, self.chis, iquv[1]) +
-                    uweights * np.interp(fast_chi, self.chis, iquv[2])
-                ) * fast_scale
+                iquss = (
+                    iweights * scp.splev(chi, scp.splrep(self.chis, iquv[0],k=5)) +
+                    qweights * scp.splev(chi, scp.splrep(self.chis, iquv[1],k=5)) +
+                    uweights * scp.splev(chi, scp.splrep(self.chis, iquv[2],k=5))
+                ) * scale
 
                 iquv = emission.T
-                fast_iquss += (
-                    iweights * np.interp(fast_chi, self.chis, iquv[0]) +
-                    qweights * np.interp(fast_chi, self.chis, iquv[1]) +
-                    uweights * np.interp(fast_chi, self.chis, iquv[2])
+                iquss += (
+                    iweights * scp.splev(chi, scp.splrep(self.chis, iquv[0],k=5)) +
+                    qweights * scp.splev(chi, scp.splrep(self.chis, iquv[1],k=5)) +
+                    uweights * scp.splev(chi, scp.splrep(self.chis, iquv[1],k=5))
                 )
 
-                fast_iquss -= np.median(fast_iquss)
-
-                # Downsample iquss to original sampling rate
-                iquss = scipy.signal.decimate(fast_iquss,10)
-                iquss = scipy.signal.decimate(iquss, 10) # decimate needs to be called multiple times for decimation factors > 13
+                iquss -= np.median(iquss)
 
                 # Co-add with the cached signal
                 signal += iquss

--- a/sotodlib/toast/sim_hwpss.py
+++ b/sotodlib/toast/sim_hwpss.py
@@ -70,7 +70,7 @@ class OpSimHWPSS(toast.Operator):
 
                 # Get polarization weights
 
-                iweights = np.ones_like(signal.size)
+                iweights = np.ones(signal.size)
                 qweights = np.cos(2 * det_psi)
                 uweights = np.sin(2 * det_psi)
         


### PR DESCRIPTION
This is a fix to a bug in the HWPSS simulation which was causing spurious peaks to appear in the Fourrier spectrum. This implementation avoids this by first interpolating the HWPSS template to fast sampled HWP angles, and then downsampling to the original sample rate using [`scipy.signal.decimate`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.decimate.html#scipy.signal.decimate)