### PR TITLE
Loading batcher extension

### DIFF
--- a/sotodlib/io/g3tsmurf_utils.py
+++ b/sotodlib/io/g3tsmurf_utils.py
@@ -4,6 +4,7 @@
 import os
 import numpy as np
 import logging
+import datetime as dt
 
 from sotodlib.io.load_smurf import load_file, SmurfStatus
 from sotodlib.io.g3tsmurf_db import Observations, Files

--- a/sotodlib/io/g3tsmurf_utils.py
+++ b/sotodlib/io/g3tsmurf_utils.py
@@ -168,7 +168,7 @@ def get_batch(
         obs = session.query(Observations).filter(Observations.start<s).order_by(Observations.start.desc()).first()
         partial=True
 
-    
+    obs_id = obs.obs_id 
     db_files = session.query(Files).filter(Files.obs_id==obs_id).order_by(Files.start)
     filenames = sorted( [f.name for f in db_files])
     

--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -34,6 +34,8 @@ from sotodlib.io.g3tsmurf_db import (
     Frames,
 )
 
+from sotodlib.io.g3tsmurf_utils import make_datetime
+
 Session = sessionmaker()
 num_bias_lines = 16
 
@@ -202,30 +204,6 @@ class G3tSmurf:
                    configs["g3tsmurf_db"],
                    meta_path=os.path.join(configs["data_prefix"],"smurf"))
 
-    @staticmethod
-    def _make_datetime(x):
-        """
-        Takes an input (either a timestamp or datetime), and returns a datetime.
-        Intended to allow flexibility in inputs for various other functions
-        Note that x will be assumed to be in UTC if timezone is not specified
-
-        Args
-        ----
-            x: input datetime of timestamp
-
-        Returns
-        ----
-            datetime: datetime of x if x is a timestamp
-        """
-        if np.issubdtype(type(x), np.floating) or np.issubdtype(type(x), np.integer):
-            return dt.datetime.utcfromtimestamp(x)
-        elif isinstance(x, np.datetime64):
-            return x.astype(dt.datetime).replace(tzinfo=dt.timezone.utc)
-        elif isinstance(x, dt.datetime) or isinstance(x, dt.date):
-            if x.tzinfo == None:
-                return x.replace(tzinfo=dt.timezone.utc)
-            return x
-        raise (Exception("Input not a datetime or timestamp"))
 
     def add_file(self, path, session, overwrite=False):
         """
@@ -1162,8 +1140,8 @@ class G3tSmurf:
             stream_ids: List of stream ids.
         """
         session = self.Session()
-        start = self._make_datetime(start)
-        end = self._make_datetime(end)
+        start = make_datetime(start)
+        end = make_datetime(end)
         all_ids = (
             session.query(Files.stream_id)
             .filter(Files.start < end, Files.stop >= start)
@@ -1238,8 +1216,8 @@ class G3tSmurf:
 
         """
         session = self.Session()
-        start = self._make_datetime(start)
-        end = self._make_datetime(end)
+        start = make_datetime(start)
+        end = make_datetime(end)
 
         if stream_id is None:
             sids = self._stream_ids_in_range(start, end)
@@ -1632,7 +1610,7 @@ class SmurfStatus:
             status : (SmurfStatus instance)
                 object indexing of rogue variables at specified time.
         """
-        time = archive._make_datetime(time)
+        time = make_datetime(time)
         session = archive.Session()
         q = (
             session.query(Frames)

--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -34,10 +34,36 @@ from sotodlib.io.g3tsmurf_db import (
     Frames,
 )
 
-from sotodlib.io.g3tsmurf_utils import make_datetime
-
 Session = sessionmaker()
 num_bias_lines = 16
+
+
+"""
+Used for the input of many functions below
+"""
+def make_datetime(x):
+    """
+    Takes an input (either a timestamp or datetime), and returns a datetime.
+    Intended to allow flexibility in inputs for various other functions
+    Note that x will be assumed to be in UTC if timezone is not specified
+
+    Args
+    ----
+        x: input datetime of timestamp
+
+    Returns
+    ----
+        datetime: datetime of x if x is a timestamp
+    """
+    if np.issubdtype(type(x), np.floating) or np.issubdtype(type(x), np.integer):
+        return dt.datetime.utcfromtimestamp(x)
+    elif isinstance(x, np.datetime64):
+        return x.astype(dt.datetime).replace(tzinfo=dt.timezone.utc)
+    elif isinstance(x, dt.datetime) or isinstance(x, dt.date):
+        if x.tzinfo == None:
+            return x.replace(tzinfo=dt.timezone.utc)
+        return x
+    raise (Exception("Input not a datetime or timestamp"))
 
 
 """


### PR DESCRIPTION
It will be useful to be able to batch subsets of observation, so this extends get_batch to take start, end times and loop only through that piece of the observation.

Other changes:
- get_batch can take an `Observation` object and not just an `obs_id` string (for convenience)
- Since I'm now using the `make_datetime` tool in get_batch too, it seemed better to make it it's own function that can be imported rather than a static method of `G3tSmurf`. 