### PR TITLE
Update hardware sim and toast workflows.

### DIFF
--- a/docs/toast.rst
+++ b/docs/toast.rst
@@ -1,5 +1,5 @@
 ===========
-TOAST 
+TOAST
 ===========
 
 The ``sotodlib.toast`` package contains toast operators for use in
@@ -45,7 +45,7 @@ easiest way forward is to use a conda environment.  This is also the
 path to take if you want to use the latest upstream code version.
 
 To begin, make sure you already have a recent conda "base" environment.
-If you are starting from scratch, I recommend running the "miniforge" `installer from conda-forge <https://github.com/conda-forge/miniforge>`_.  
+If you are starting from scratch, I recommend running the "miniforge" `installer from conda-forge <https://github.com/conda-forge/miniforge>`_.
 Make sure your base conda environment is activated::
 
     conda env list
@@ -73,8 +73,8 @@ Now we can install the toast package itself after activating our environment::
     conda activate simons
     ./platforms/conda.sh
 
-Whenever you pull new changes to your git checkout, you can re-run the 
-``platforms/conda.sh`` script to install an updated version of the toast 
+Whenever you pull new changes to your git checkout, you can re-run the
+``platforms/conda.sh`` script to install an updated version of the toast
 package.  Now install ``so3g``::
 
     pip install so3g
@@ -101,12 +101,19 @@ Batch Use
 -------------------
 
 When running workflows in batch mode, we typically use a slightly different
-structure from a notebook.  There are helper functions in toast to parse
-operator options from the commandline and / or a config file, and to automatically
-create named instances of those operators for use in workflow.  There is
-a large-scale workflow in ``sotodlib/workflows/toast_so_sim.py``.  This
-script has nearly every possible operator in its config options, and they
-can be selectively enabled or disabled from the commandline or config file.
+structure from a notebook. There are helper functions in toast to parse
+operator options from the commandline and / or a config file, and to
+automatically create named instances of those operators for use in workflow.
+There is a large-scale simulation and reduction workflow in
+``sotodlib/workflows/toast_so_sim.py``. This script has nearly every possible
+operator in its config options, and they can be selectively enabled or disabled
+from the commandline or config file.
+
+For processing data that already exists on disk, you can use
+``sotodlib/workflows/toast_so_map.py`` as an example workflow. This loads data
+in the native toast HDF5 format and / or L3 books.
+
+.. note:: Loading data from books will be added in PR 183.
 
 
 Reference
@@ -124,6 +131,8 @@ instance usually contains detectors from one readout card / wafer.
 
 .. autoclass:: sotodlib.toast.SOFocalplane
    :members:
+
+.. note::  There are more extensive updates to the S.O. toast instrument classes coming in PR 183.
 
 
 Operators

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup_opts["entry_points"] = {
 
 scripts = [
     "workflows/toast_so_sim.py",
+    "workflows/toast_so_map.py",
     "workflows/get_wafer_offset.py",
 ]
 

--- a/sotodlib/core/hardware.py
+++ b/sotodlib/core/hardware.py
@@ -16,11 +16,16 @@ import numpy as np
 
 import toml
 
-# The orientation of the projected LAT focalplane on the sky is
-#   `LAT_COROTATOR_OFFSET` + observing elevation, unless the receiver
-# is being rotated to maintain the orientation.
 
-LAT_COROTATOR_OFFSET = u.Quantity(90.0, u.degree)
+# The extra rotation to apply to the projected LAT focalplane on the
+# sky is given by:
+#
+#      R = Elevation - Offset - Corotator
+#
+# and the offset is defined as the "design elevation" which places
+# the focalplane at the correct orientation with no co-rotation.
+
+LAT_COROTATOR_OFFSET = u.Quantity(60.0, u.degree)
 
 
 class Hardware(object):

--- a/sotodlib/scripts/hardware_plot.py
+++ b/sotodlib/scripts/hardware_plot.py
@@ -5,6 +5,8 @@
 
 import argparse
 
+import astropy.units as u
+
 from ..core import Hardware
 
 from ..vis_hardware import plot_detectors, summary_text
@@ -42,6 +44,27 @@ def main():
         help="Add pixel and polarization labels to the plot."
     )
 
+    parser.add_argument(
+        "--xieta", required=False, default=False, action="store_true",
+        help="Plot in Xi / Eta coordinates."
+    )
+
+    parser.add_argument(
+        "--lat_corotate",
+        required=False,
+        default=False,
+        action="store_true",
+        help="Rotate LAT receiver to maintain focalplane orientation",
+    )
+
+    parser.add_argument(
+        "--lat_elevation_deg",
+        required=False,
+        default=60.0,
+        type=float,
+        help="Observing elevation of the LAT if not co-rotating",
+    )
+
     args = parser.parse_args()
 
     outfile = args.out
@@ -53,8 +76,23 @@ def main():
     hw = Hardware(args.hardware)
     # summary_text(hw)
 
+    width = args.width
+    if width is not None:
+        width = float(width)
+    height = args.height
+    if height is not None:
+        height = float(height)
+
     print("Generating detector plot...", flush=True)
-    plot_detectors(hw.data["detectors"], outfile, width=args.width,
-                   height=args.height, labels=args.labels)
+    plot_detectors(
+        hw.data["detectors"],
+        outfile,
+        width=width,
+        height=height,
+        labels=args.labels,
+        xieta=args.xieta,
+        lat_corotate=args.lat_corotate,
+        lat_elevation=args.lat_elevation_deg * u.degree,
+    )
 
     return

--- a/sotodlib/scripts/hardware_sim.py
+++ b/sotodlib/scripts/hardware_sim.py
@@ -8,7 +8,7 @@ import argparse
 
 from collections import OrderedDict
 
-from ..sim_hardware import get_example, sim_telescope_detectors
+from ..sim_hardware import sim_nominal, sim_detectors_toast
 
 
 def main():
@@ -34,14 +34,12 @@ def main():
 
     args = parser.parse_args()
 
-    print("Getting example config...", flush=True)
-    hw = get_example()
-    hw.data["detectors"] = OrderedDict()
+    print("Getting nominal config...", flush=True)
+    hw = sim_nominal()
     for tele, teleprops in hw.data["telescopes"].items():
         print("Simulating detectors for telescope {}...".format(tele),
               flush=True)
-        dets = sim_telescope_detectors(hw, tele)
-        hw.data["detectors"].update(dets)
+        sim_detectors_toast(hw, tele)
 
     if args.plain:
         outpath = "{}.toml".format(args.out)

--- a/sotodlib/sim_hardware.py
+++ b/sotodlib/sim_hardware.py
@@ -11,757 +11,72 @@ from copy import deepcopy
 
 import numpy as np
 
-import quaternionarray as qa
-
-import so3g.proj.quat as so3q
-
-from .coords import ScalarLastQuat
-
 from .core import Hardware
 
-# Important note on coordinate systems
-#
-# The functions in this module help to lay out the detectors in the
-# focal plane by combining various components, such as assembling
-# rhombi into wafers and wafers into optical tubes.  This is done in a
-# cartesian projection plane with axes oriented like this:
-#
-#        Layout coordinates here
-#        -----------------------
-#
-#      Y^                   O
-#       |                  O O
-#       |                   O O
-#       |                  O + O
-#       +-----> X           O O O
-#
-#   (Z into the page)     Some dets
-#
-# with the idea being that the detectors are sensitive to radiation
-# coming from some point on the sphere (x, y, z) near z=1.  In the
-# final layout, that one would want to rigidly attach to the
-# boresight, the X-axis points in the direction of increasing azimuth
-# and the Y-axis in the direction of increasing elevation.  The
-# encoded quaternion is the rotation that takes vectors in detector
-# coordinates to vectors in this system.
-#
-# However, this XYZ cartesian system is left-handed, and thus does not
-# naturally connect with the pointing codes used in TOAST (and so3g).
-# What is needed for TOAST is illustrated here:
-#
-#     TOAST focal plane coordinates
-#     -----------------------------
-#
-#      X^                   O
-#       |                  O O
-#       |                   O O
-#       |                  O + O
-#       +-----> Y           O O O
-#
-#   (Z into the page)   Those same dets
-#
-# Here's how this discrepancy is dealt with.  In this module, the
-# final quaternion stored in each detector's info dict is transformed,
-# right at the end, from the left-handed layout system into the
-# right-handed TOAST focal plane system.  When decoding the "quat"
-# property of detectors for plotting, the "X" and "Y" coordinates so
-# extracted must not be naively plotted as pylab.scatter(x, y)!  To
-# show the layout "as it would project onto the sky", you want
-# pylab.scatter(y, x).  (See vis_hardware, for example.)
 
-
-# FIXME:  much of this code is copy/pasted from the toast source, simply to
-# avoid a dependency.  Once we can "pip install toast", we should consider
-# just calling that package.
-
-
-def ang_to_quat(offsets):
-    """Convert cartesian angle offsets and rotation into quaternions.
-
-    Each offset contains two angles specifying the distance from the Z axis
-    in orthogonal directions (called "X" and "Y").  The third angle is the
-    rotation about the Z axis.  A quaternion is computed that first rotates
-    about the Z axis and then rotates this axis to the specified X/Y angle
-    location.
-
-    Args:
-        offsets (list of arrays):  Each item of the list has 3 elements for
-            the X / Y angle offsets in radians and the rotation in radians
-            about the Z axis.
-
-    Returns:
-        (list): List of quaternions, one for each item in the input list.
-
-    """
-    out = list()
-
-    zaxis = np.array([0, 0, 1], dtype=np.float64)
-
-    for off in offsets:
-        angrot = qa.rotation(zaxis, off[2])
-        wx = np.sin(off[0])
-        wy = np.sin(off[1])
-        wz = np.sqrt(1.0 - (wx*wx + wy*wy))
-        wdir = np.array([wx, wy, wz])
-        posrot = qa.from_vectors(zaxis, wdir)
-        out.append(qa.mult(posrot, angrot))
-
-    return out
-
-
-def hex_nring(npos):
-    """Return the number of rings in a hexagonal layout.
-
-    For a hexagonal layout with a given number of positions, return the
-    number of rings.
-
-    Args:
-        npos (int): The number of positions.
-
-    Returns:
-        (int): The number of rings.
-
-    """
-    test = npos - 1
-    nrings = 1
-    while (test - 6 * nrings) >= 0:
-        test -= 6 * nrings
-        nrings += 1
-    if test != 0:
-        raise RuntimeError("{} is not a valid number of positions for a "
-                           "hexagonal layout".format(npos))
-    return nrings
-
-
-def hex_row_col(npos, pos):
-    """Return the location of a given position.
-
-    For a hexagonal layout, indexed in a "spiral" scheme (see hex_layout),
-    this function returnes the "row" and "column" of a single position.
-    The row is zero along the main vertex-vertex axis, and is positive
-    or negative above / below this line of positions.
-
-    Args:
-        npos (int): The number of positions.
-        pos (int): The position.
-
-    Returns:
-        (tuple): The (row, column) location of the position.
-
-    """
-    if pos >= npos:
-        raise ValueError("position value out of range")
-    test = npos - 1
-    nrings = 1
-    while (test - 6 * nrings) >= 0:
-        test -= 6 * nrings
-        nrings += 1
-    if pos == 0:
-        row = 0
-        col = nrings - 1
-    else:
-        test = pos - 1
-        ring = 1
-        while (test - 6 * ring) >= 0:
-            test -= 6 * ring
-            ring += 1
-        sector = int(test / ring)
-        steps = np.mod(test, ring)
-        coloff = nrings - ring - 1
-        if sector == 0:
-            row = steps
-            col = coloff + 2*ring - steps
-        elif sector == 1:
-            row = ring
-            col = coloff + ring - steps
-        elif sector == 2:
-            row = ring - steps
-            col = coloff
-        elif sector == 3:
-            row = -steps
-            col = coloff
-        elif sector == 4:
-            row = -ring
-            col = coloff + steps
-        elif sector == 5:
-            row = -ring + steps
-            col = coloff + ring + steps
-    return (row, col)
-
-
-def hex_layout(npos, width, rotate=None):
-    """Compute positions in a hexagon layout.
-
-    Place the given number of positions in a hexagonal layout projected on
-    the sphere and centered at z axis.  The width specifies the angular
-    extent from vertex to vertex along the "X" axis.  For example::
-
-        Y ^             O O O
-        |              O O O O
-        |             O O + O O
-        +--> X         O O O O
-                        O O O
-
-    Each position is numbered 0..npos-1.  The first position is at the center,
-    and then the positions are numbered moving outward in rings.
-
-    Args:
-        npos (int): The number of positions packed onto wafer.
-        width (float): The angle (in degrees) subtended by the width along
-            the X axis.
-        rotate (array, optional): Optional array of rotation angles in degrees
-            to apply to each position.
-
-    Returns:
-        (array): Array of quaternions for the positions.
-
-    """
-    zaxis = np.array([0, 0, 1], dtype=np.float64)
-    nullquat = np.array([0, 0, 0, 1], dtype=np.float64)
-    sixty = np.pi/3.0
-    thirty = np.pi/6.0
-    rtthree = np.sqrt(3.0)
-    rtthreebytwo = 0.5 * rtthree
-
-    angdiameter = width * np.pi / 180.0
-
-    # find the angular packing size of one detector
-    nrings = hex_nring(npos)
-    posdiam = angdiameter / (2 * nrings - 2)
-
-    result = np.zeros((npos, 4), dtype=np.float64)
-
-    for pos in range(npos):
-        if pos == 0:
-            # center position has no offset
-            posrot = nullquat
-        else:
-            # Not at the center, find ring for this position
-            test = pos - 1
-            ring = 1
-            while (test - 6 * ring) >= 0:
-                test -= 6 * ring
-                ring += 1
-            sectors = int(test / ring)
-            sectorsteps = np.mod(test, ring)
-
-            # Convert angular steps around the ring into the angle and distance
-            # in polar coordinates.  Each "sector" of 60 degrees is essentially
-            # an equilateral triangle, and each step is equally spaced along
-            # the edge opposite the vertex:
-            #
-            #          O
-            #         O O (step 2)
-            #        O   O (step 1)
-            #       X O O O (step 0)
-            #
-            # For a given ring, "R" (center is R=0), there are R steps along
-            # the sector edge.  The line from the origin to the opposite edge
-            # that bisects this triangle has length R*sqrt(3)/2.  For each
-            # equally-spaced step, we use the right triangle formed with this
-            # bisection line to compute the angle and radius within this
-            # sector.
-
-            # The distance from the origin to the midpoint of the opposite
-            # side.
-            midline = rtthreebytwo * float(ring)
-
-            # the distance along the opposite edge from the midpoint (positive
-            # or negative)
-            edgedist = float(sectorsteps) - 0.5 * float(ring)
-
-            # the angle relative to the midpoint line (positive or negative)
-            relang = np.arctan2(edgedist, midline)
-
-            # total angle is based on number of sectors we have and the angle
-            # within the final sector.
-            posang = sectors * sixty + thirty + relang
-
-            posdist = rtthreebytwo * posdiam * float(ring) / np.cos(relang)
-
-            posx = np.sin(posdist) * np.cos(posang)
-            posy = np.sin(posdist) * np.sin(posang)
-            posz = np.cos(posdist)
-            posdir = np.array([posx, posy, posz], dtype=np.float64)
-            norm = np.sqrt(np.dot(posdir, posdir))
-            posdir /= norm
-
-            posrot = qa.from_vectors(zaxis, posdir)
-
-        if rotate is None:
-            result[pos] = posrot
-        else:
-            prerot = qa.rotation(zaxis, rotate[pos] * np.pi / 180.0)
-            result[pos] = qa.mult(posrot, prerot)
-
-    return result
-
-
-def rhomb_dim(npos):
-    """Compute the dimensions of a rhombus.
-
-    For a rhombus with the specified number of positions, return the dimension
-    of one side.  This function is just a check around a sqrt.
-
-    Args:
-        npos (int): The number of positions.
-
-    Returns:
-        (int): The dimension of one side.
-
-    """
-    dim = int(np.sqrt(float(npos)))
-    if dim**2 != npos:
-        raise ValueError("The number of positions for a rhombus must "
-                         "be square")
-    return dim
-
-
-def rhomb_row_col(npos, pos):
-    """Return the location of a given position.
-
-    For a rhombus layout, indexed from top to bottom (see rhombus_layout),
-    this function returnes the "row" and "column" of a position.  The column
-    starts at zero on the left hand side of a row.
-
-    Args:
-        npos (int): The number of positions.
-        pos (int): The position.
-
-    Returns:
-        (tuple): The (row, column) location of the position.
-
-    """
-    if pos >= npos:
-        raise ValueError("position value out of range")
-    dim = rhomb_dim(npos)
-    col = pos
-    rowcnt = 1
-    row = 0
-    while (col - rowcnt) >= 0:
-        col -= rowcnt
-        row += 1
-        if row >= dim:
-            rowcnt -= 1
-        else:
-            rowcnt += 1
-    return (row, col)
-
-
-def rhombus_layout(npos, width, rotate=None):
-    """Compute positions in a hexagon layout.
-
-    This particular rhombus geometry is essentially a third of a
-    hexagon.  In other words the aspect ratio of the rhombus is
-    constrained to have the long dimension be sqrt(3) times the short
-    dimension.
-
-    The rhombus is projected on the sphere and centered on the Z axis.
-    The X axis is along the short direction.  The Y axis is along the longer
-    direction.  For example::
-
-                          O
-        Y ^              O O
-        |               O O O
-        |              O O O O
-        +--> X          O O O
-                         O O
-                          O
-
-    Each position is numbered 0..npos-1.  The first position is at the
-    "top", and then the positions are numbered moving downward and left to
-    right.
-
-    The extent of the rhombus is directly specified by the width parameter
-    which is the angular extent along the X direction.
-
-    Args:
-        npos (int): The number of positions in the rhombus.
-        width (float): The angle (in degrees) subtended by the width along
-            the X axis.
-        rotate (array, optional): Optional array of rotation angles in degrees
-            to apply to each position.
-
-    Returns:
-        (array): Array of quaternions for the positions.
-
-    """
-    zaxis = np.array([0, 0, 1], dtype=np.float64)
-    rtthree = np.sqrt(3.0)
-
-    angwidth = width * np.pi / 180.0
-    dim = rhomb_dim(npos)
-
-    # find the angular packing size of one detector
-    posdiam = angwidth / (dim - 1)
-
-    result = np.zeros((npos, 4), dtype=np.float64)
-
-    for pos in range(npos):
-        posrow, poscol = rhomb_row_col(npos, pos)
-
-        rowang = 0.5 * rtthree * ((dim - 1) - posrow) * posdiam
-        relrow = posrow
-        if posrow >= dim:
-            relrow = (2 * dim - 2) - posrow
-        colang = (float(poscol) - float(relrow) / 2.0) * posdiam
-        distang = np.sqrt(rowang**2 + colang**2)
-        zang = np.cos(distang)
-        posdir = np.array([colang, rowang, zang], dtype=np.float64)
-        norm = np.sqrt(np.dot(posdir, posdir))
-        posdir /= norm
-
-        posrot = qa.from_vectors(zaxis, posdir)
-
-        if rotate is None:
-            result[pos] = posrot
-        else:
-            prerot = qa.rotation(zaxis, rotate[pos] * np.pi / 180.0)
-            result[pos] = qa.mult(posrot, prerot)
-
-    return result
-
-
-def rhombus_hex_layout(rhombus_npos, rhombus_width, gap, rhombus_rotate=None,
-                       killpix=None):
-    """
-    Construct a hexagon from 3 rhombi.
-
-    Args:
-        rhombus_npos (int): The number of positions in one rhombus.
-        rhombus_width (float): The angle (in degrees) subtended by the
-            width of one rhombus along the X axis.
-        gap (float): The gap between the edges of the rhombi, in degrees.
-        rhombus_rotate (array, optional): An additional angle rotation of
-            each position on each rhombus before the rhombus is rotated
-            into place.
-        killpix (list, optional): Pixel indices to remove for mechanical
-            reasons.
-
-    Returns:
-        (dict): Keys are the hexagon position and values are quaternions.
-
-    """
-    sixty = np.pi / 3.0
-    thirty = np.pi / 6.0
-
-    # rhombus dim
-    dim = rhomb_dim(rhombus_npos)
-
-    # width in radians
-    radwidth = rhombus_width * np.pi / 180.0
-
-    # First layout one rhombus
-    rquat = rhombus_layout(rhombus_npos, rhombus_width,
-                           rotate=rhombus_rotate)
-
-    # angular separation of rhombi
-    gap *= np.pi / 180.0
-
-    # half-width of rhombus in radians
-    halfwidth = 0.5 * radwidth
-
-    # width of one pixel
-    pixwidth = radwidth / (dim - 1)
-
-    # Compute the individual rhombus centers.  This is the shift of origin
-    # in the X direction for the "vertical" rhombus.
-    shift = halfwidth + (0.5 * pixwidth) + ((0.5 * gap) / np.cos(thirty))
-
-    centers = [
-        np.array([shift, 0.0, 0.0]),
-        np.array([-shift * np.cos(sixty), shift * np.sin(sixty),
-                  2 * sixty]),
-        np.array([-shift * np.cos(sixty), -shift * np.sin(sixty),
-                  4 * sixty])
-    ]
-    qcenters = ang_to_quat(centers)
-
-    nkill = len(killpix)
-    result = np.zeros((3 * rhombus_npos - nkill, 4), dtype=np.float64)
-
-    off = 0
-    px = 0
-    for qc in qcenters:
-        for p in range(rhombus_npos):
-            if px not in killpix:
-                result[off] = qa.mult(qc, rquat[p])
-                off += 1
-            px += 1
-
-    return result
-
-
-def sim_wafer_detectors(hw, wafer_slot, platescale, fwhm, band=None,
-                        center=np.array([0, 0, 0, 1], dtype=np.float64)):
-    """Generate detector properties for a wafer.
-
-    Given a Hardware configuration, generate all detector properties for
-    the specified wafer and optionally only the specified band.
-
-    Args:
-        hw (Hardware): The hardware properties.
-        wafer_slot (str): The wafer slot name.
-        platescale (float): The plate scale in degrees / mm.
-        fwhm (dict): Dictionary of nominal FWHM values in arcminutes for
-            each band.
-        band (str, optional): Optionally only use this band.
-        center (array, optional): The quaternion offset of the center.
-
-    Returns:
-        (OrderedDict): The properties of all selected detectors.
-
-    """
-    # The properties of this wafer
-    wprops = hw.data["wafer_slots"][wafer_slot]
-    # The readout card and its properties
-    card_slot = wprops["card_slot"]
-    cardprops = hw.data["card_slots"][card_slot]
-    # The bands
-    bands = wprops["bands"]
-    if band is not None:
-        if band in bands:
-            bands = [band]
-        else:
-            raise RuntimeError("band '{}' not valid for wafer '{}'"
-                               .format(band, wafer_slot))
-
-    # Lay out the pixel locations depending on the wafer type.  Also
-    # compute the polarization orientation rotation, as well as the A/B
-    # handedness for the Sinuous detectors.
-
-    npix = wprops["npixel"]
-    pixsep = platescale * wprops["pixsize"]
-    layout_A = None
-    layout_B = None
-    handed = None
-    kill = []
-    if wprops["packing"] == "F":
-        # Feedhorn (NIST style)
-        gap = platescale * wprops["rhombusgap"]
-        nrhombus = npix // 3
-        # This dim is also the number of pixels along the short axis.
-        dim = rhomb_dim(nrhombus)
-        # This is the center-center distance along the short axis
-        width = (dim - 1) * pixsep
-        # The orientation within each rhombus alternates between zero and 45
-        # degrees.  However there is an offset.  We choose this arbitrarily
-        # for the nominal rhombus position, and then the rotation of the
-        # other 2 rhombi will naturally modulate this.
-        pol_A = np.zeros(nrhombus, dtype=np.float64)
-        pol_B = np.zeros(nrhombus, dtype=np.float64)
-        poloff = 22.5
-        for p in range(nrhombus):
-            # get the row / col of the pixel
-            row, col = rhomb_row_col(nrhombus, p)
-            if np.mod(row, 2) == 0:
-                pol_A[p] = 0.0 + poloff
-            else:
-                pol_A[p] = 45.0 + poloff
-            pol_B[p] = 90.0 + pol_A[p]
-        # We are going to remove 2 pixels for mechanical reasons
-        kf = dim * (dim - 1) // 2
-        kill = [(dim*dim+kf), (dim*dim+kf) + dim - 2]
-        layout_A = rhombus_hex_layout(nrhombus, width, gap,
-                                      rhombus_rotate=pol_A, killpix=kill)
-        layout_B = rhombus_hex_layout(nrhombus, width, gap,
-                                      rhombus_rotate=pol_B, killpix=kill)
-    elif wprops["packing"] == "S":
-        # Sinuous (Berkeley style)
-        # This is the center-center distance along the vertex-vertex axis
-        width = (2 * (hex_nring(npix) - 1)) * pixsep
-        # The sinuous handedness is chosen so that A/B pairs of pixels have the
-        # same nominal orientation but trail each other along the
-        # vertex-vertex axis of the hexagon.  The polarization orientation
-        # changes every other column
-
-        if npix==37:
-            pol_A=np.array([45.,0.,45.,45.,45.,45.,0.,0.,0.,45.,45.,0.,0.,0.,45.,45.,0.,0.,0.,
-                            45.,0.,0.,45.,45.,0.,0.,0.,0.,0.,0.,45.,45.,0.,0.,45.,45.,45.])
-            handed=["R","L","R","L","L","R","L","R","L","R","L","R","R","R","L","R","L","R","R",
-                    "L","R","L","R","L","R","L","L","L","L","R","L","R","L","R","L","L","L"]
-            pol_B=90.0+pol_A
-        else:
-            handed = list()
-            pol_A = np.zeros(npix, dtype=np.float64)
-            pol_B = np.zeros(npix, dtype=np.float64)
-            for p in range(npix):
-                row, col = hex_row_col(npix, p)
-                if np.mod(col, 2) == 0:
-                    handed.append("L")
-                else:
-                    handed.append("R")
-                if np.mod(col, 4) < 2:
-                    pol_A[p] = 0.0
-                else:
-                    pol_A[p] = 45.0
-                pol_B[p] = 90.0 + pol_A[p]
-        layout_A = hex_layout(npix, width, rotate=pol_A)
-        layout_B = hex_layout(npix, width, rotate=pol_B)
-    else:
-        raise RuntimeError(
-            "Unknown wafer packing '{}'".format(wprops["packing"]))
-
-    # Now we go through each pixel and create the orthogonal detectors for
-    # each band.
-    dets = OrderedDict()
-
-    #chan_per_AMC = cardprops["nchannel"] // cardprops["nAMC"]
-    chan_per_AMC = 910
-    chan_per_mux = 64
-    chan_per_bias = cardprops["nchannel"] // cardprops["nbias"]
-    readout_freq_range=np.linspace(4.,6.,chan_per_AMC)
-    readout_freq=np.append(readout_freq_range,readout_freq_range)
-    
-    doff = 0
-    p = 0
-    idoff = int(wafer_slot[-2:]) * 10000
-    for px in range(npix):
-        if px in kill:
-            continue
-        pstr = "{:03d}".format(p)
-        for b in bands:
-            for pl, layout, pol in zip(
-                    ["A", "B"], [layout_A, layout_B], [pol_A, pol_B],
-            ):
-                dprops = OrderedDict()
-                dprops["wafer_slot"] = wafer_slot
-                dprops["ID"] = idoff + doff
-                dprops["pixel"] = pstr
-                dprops["band"] = b
-                dprops["fwhm"] = fwhm[b]
-                dprops["pol"] = pl
-                if handed is not None:
-                    dprops["handed"] = handed[p]
-                # Made-up assignment to readout channels
-                dprops["card_slot"] = card_slot
-                dprops["channel"] = doff
-                dprops["AMC"] = doff // chan_per_AMC
-                dprops["bias"] = doff // chan_per_bias
-                dprops["readout_freq_GHz"] = readout_freq[doff]
-                dprops["bondpad"] = doff-(doff//chan_per_mux)*chan_per_mux
-                dprops["mux_position"] = doff//chan_per_mux
-                # Layout quaternion offset is from the origin.  Now we apply
-                # the rotation of the wafer center.
-                dprops["quat"] = qa.mult(center, layout[p]).flatten()
-                dprops["detector_name"]= ""
-                dname = "{}_p{}_{}_{}".format(wafer_slot, pstr, b, pl)
-                dets[dname] = dprops
-                doff += 1
-        p += 1
-
-    return dets
-
-
-def sim_telescope_detectors(hw, tele, tube_slots=None):
-    """Generate detector properties for a telescope.
+def sim_detectors_toast(hw, tele, tube_slots=None):
+    """Update hardware model with simulated detector positions.
 
     Given a Hardware model, generate all detector properties for the specified
-    telescope and optionally a subset of optics tube slots (for the LAT).
+    telescope and optionally a subset of optics tube slots (for the LAT).  The
+    detector dictionary of the hardware model is updated in place.
+
+    This function requires the toast subpackage (and hence toast) to be
+    importable.
 
     Args:
-        hw (Hardware): The hardware object to use.
+        hw (Hardware): The hardware object to update.
         tele (str): The telescope name.
         tube_slots (list, optional): The optional list of tube slots to include.
 
     Returns:
-        (OrderedDict): The properties of all selected detectors.
+        None
 
     """
-    zaxis = np.array([0, 0, 1], dtype=np.float64)
-    thirty = np.pi / 6.0
-    # The properties of this telescope
-    teleprops = hw.data["telescopes"][tele]
-    platescale = teleprops["platescale"]
-    fwhm = teleprops["fwhm"]
+    try:
+        from . import toast as sotoast
+    except ImportError:
+        msg = "Toast package is not importable, cannot simulate detector positions"
+        raise RuntimeError(msg)
 
-    # The tubes
-    alltubes = teleprops["tube_slots"]
-    ntube = len(alltubes)
-    if tube_slots is None:
-        tube_slots = alltubes
-    else:
-        for t in tube_slots:
-            if t not in alltubes:
-                raise RuntimeError("Invalid tube_slot '{}' for telescope '{}'"
-                                   .format(t, tele))
+    sotoast.sim_focalplane.sim_telescope_detectors(
+        hw, tele, tube_slots=tube_slots,
+    )
 
-    alldets = OrderedDict()
-    if ntube == 1:
-        # This is a SAT.  We have one tube at the center.
-        tubeprops = hw.data["tube_slots"][tube_slots[0]]
-        waferspace = tubeprops["waferspace"]
 
-        shift = waferspace * platescale * np.pi / 180.0
-        wcenters = [
-            np.array([0.0, 0.0, 0.0]),
-            np.array([shift * np.cos(thirty), shift * np.sin(thirty), 0.0]),
-            np.array([0.0, shift, 0.0]),
-            np.array([-shift * np.cos(thirty), shift * np.sin(thirty), 0.0]),
-            np.array([-shift * np.cos(thirty), -shift * np.sin(thirty), 0.0]),
-            np.array([0.0, -shift, 0.0]),
-            np.array([shift * np.cos(thirty), -shift * np.sin(thirty), 0.0])
-        ]
-        centers = ang_to_quat(wcenters)
+def sim_detectors_physical_optics(hw, tele, tube_slots=None):
+    """Update hardware model with simulated detector positions.
 
-        windx = 0
-        for wafer_slot in tubeprops["wafer_slots"]:
-            dets = sim_wafer_detectors(hw, wafer_slot, platescale, fwhm,
-                                       center=centers[windx])
-            alldets.update(dets)
-            windx += 1
-    else:
-        # This is the LAT.  Compute the tube centers.
-        # Rotate each tube by 90 degrees, so that it is pointed "down".
-        tubespace = teleprops["tubespace"]
-        tuberot = 90.0 * np.ones(19, dtype=np.float64)
-        tcenters = hex_layout(19, 4 * (tubespace * platescale), rotate=tuberot)
+    Given a Hardware model, generate all detector properties for the specified
+    telescope and optionally a subset of optics tube slots (for the LAT).  The
+    detector dictionary of the hardware model is updated in place.
 
-        tindx = 0
-        for tube_slot in tube_slots:
-            tubeprops = hw.data["tube_slots"][tube_slot]
-            waferspace = tubeprops["waferspace"]
-            location = tubeprops["location"]
+    This function uses information from physical optics simulations to estimate
+    the location of detectors.
 
-            wradius = 0.5 * (waferspace * platescale * np.pi / 180.0)
-            wcenters = [
-                np.array([np.tan(thirty) * wradius, wradius, thirty*4]),
-                np.array([-wradius / np.cos(thirty), 0.0, thirty*8]),
-                np.array([np.tan(thirty) * wradius, -wradius, 0.0])
-            ]
-            qwcenters = ang_to_quat(wcenters)
-            centers = list()
-            for qwc in qwcenters:
-                centers.append(qa.mult(tcenters[location], qwc))
-
-            windx = 0
-            for wafer_slot in tubeprops["wafer_slots"]:
-                dets = sim_wafer_detectors(hw, wafer_slot, platescale, fwhm,
-                                           center=centers[windx])
-                alldets.update(dets)
-                windx += 1
-            tindx += 1
-
-    # Transform quats from left-handed layout coordinates to
-    # right-handed TOAST-compatible coordintes -- see note at top of
-    # this file.  Note the ScalarLastQuat is just helping us convert to
-    # and from 3g quats.
-    quats_in = ScalarLastQuat([d['quat'] for d in alldets.values()])  # shape (n, 4)
-    xi, eta, gamma = so3q.decompose_xieta(quats_in.to_g3())
-    quats_out = ScalarLastQuat(so3q.rotation_xieta(eta, xi, np.pi/2 - gamma))
-    for d, q in zip(alldets.values(), quats_out):
-        d['quat'] = q
-
-    return alldets
-
-def get_example():
-    """Return an example Hardware config with the required sections.
-
-    The returned Hardware object has 4 fake detectors as an example.  These
-    detectors can be replaced by the results of other simulation functions.
+    Args:
+        hw (Hardware): The hardware object to update.
+        tele (str): The telescope name.
+        tube_slots (list, optional): The optional list of tube slots to include.
 
     Returns:
-        (Hardware): Hardware object with example parameters.
+        None
+
+    """
+    raise NotImplementedError("Not yet implemented")
+
+
+def sim_nominal():
+    """Return a simulated nominal hardware configuration.
+
+    This returns a simulated Hardware object with the nominal instrument
+    properties / metadata, but with an empty set of detector locations.
+
+    This can then be passed to one of the detector simulation functions
+    to build up the list of detectors.
+
+    Returns:
+        (Hardware): Hardware object with nominal metadata.
 
     """
     cnf = OrderedDict()
@@ -853,7 +168,7 @@ def get_example():
     bnd["C"] = 0.53
     bnd["NET_corr"] = 1.00
     bands["LAT_f290"] = bnd
-    
+
     bnd = OrderedDict()
     bnd["center"] = 25.7
     bnd["low"] = 21.7
@@ -869,7 +184,7 @@ def get_example():
     bnd["C"] = 0.92
     bnd["NET_corr"] = 1.06
     bands["SAT_f030"] = bnd
-    
+
     bnd = OrderedDict()
     bnd["center"] = 38.9
     bnd["low"] = 30.9
@@ -883,7 +198,7 @@ def get_example():
     bnd["C"] = 0.76
     bnd["NET_corr"] = 1.01
     bands["SAT_f040"] = bnd
-    
+
     bnd = OrderedDict()
     bnd["center"] = 92.0
     bnd["low"] = 79.0
@@ -897,7 +212,7 @@ def get_example():
     bnd["C"] = 0.76
     bnd["NET_corr"] = 1.04
     bands["SAT_f090"] = bnd
-    
+
     bnd = OrderedDict()
     bnd["center"] = 147.5
     bnd["low"] = 130.0
@@ -911,7 +226,7 @@ def get_example():
     bnd["C"] = 0.70
     bnd["NET_corr"] = 1.02
     bands["SAT_f150"] = bnd
-    
+
     bnd = OrderedDict()
     bnd["center"] = 225.7
     bnd["low"] = 196.7
@@ -925,7 +240,7 @@ def get_example():
     bnd["C"] = 0.54
     bnd["NET_corr"] = 1.00
     bands["SAT_f230"] = bnd
-    
+
     bnd = OrderedDict()
     bnd["center"] = 285.4
     bnd["low"] = 258.4
@@ -1018,8 +333,20 @@ def get_example():
     }
 
     ltubes = ["LAT_UHF", "LAT_UHF", "LAT_MF", "LAT_MF", "LAT_MF", "LAT_MF", "LAT_LF"]
-    ltubepos = [0, 1, 2, 3, 5, 6, 10]
+
+    # The optics tubes are arranged using several conventions and here we map between
+    # them.  Note that for this hardware model, the projection on the sky is defined
+    # at 60 degree elevation with no boresight rotation.
+
+    # TOAST hexagon layout positions in Xi/Eta coordinates
+    ltube_toasthex_pos = [0, 1, 2, 3, 5, 6, 10]
+
+    # "Optics" locations as given in several SO slide decks
+    ltube_optics_pos = [1, 3, 5, 4, 8, 9, 12]
+
+    # Cryo team names for these positions
     ltube_cryonames=["c1", "i5", "i6", "i1", "i3", "i4", "o6"]
+
     for tindx in range(7):
         nm = ltube_cryonames[tindx]
         ttyp = ltubes[tindx]
@@ -1036,7 +363,8 @@ def get_example():
                         woff[ttyp] += 1
                         break
                     off += 1
-        tb["location"] = ltubepos[tindx]
+        tb["toast_hex_pos"] = ltube_toasthex_pos[tindx]
+        tb["optics_pos"] = ltube_optics_pos[tindx]
         tb["tube_name"] = ""
         tb["receiver_name"] = ""
         tube_slots[nm] = tb
@@ -1058,7 +386,8 @@ def get_example():
                         woff[ttyp] += 1
                         break
                     off += 1
-        tb["location"] = 0
+        tb["toast_hex_pos"] = 0
+        tb["optics_pos"] = 0
         tb["tube_name"] = ""
         tb["receiver_name"] = ""
         tube_slots[nm] = tb
@@ -1167,35 +496,9 @@ def get_example():
     cnf["card_slots"] = card_slots
     cnf["crate_slots"] = crate_slots
 
-    pl = ["A", "B"]
-    hand = ["L", "R"]
-    bandarr=["SAT_f030","SAT_f040"]
-
-    dets = OrderedDict()
-    for d in range(4):
-        dprops = OrderedDict()
-        dprops["wafer_slot"] = "w42"
-        dprops["ID"] = d
-        dprops["pixel"] = "000"
-        bindx = d % 2
-        dprops["band"] = bandarr[bindx]
-        dprops["fwhm"] = 1.0
-        dprops["pol"] = pl[bindx]
-        dprops["handed"] = hand[bindx]
-        dprops["card_slot"] = "card_slot42"
-        dprops["channel"] = d
-        dprops["AMC"] = 0
-        dprops["bias"] = 0
-        dprops["readout_freq_GHz"] = 4.
-        dprops["bondpad"] = 0
-        dprops["mux_position"] = 0
-        dprops["quat"] = np.array([0.0, 0.0, 0.0, 1.0])
-        dprops["detector_name"] = ""
-        dname = "w{}_p{}_{}_{}".format("42", "000", dprops["band"],
-                                     dprops["pol"])
-        dets[dname] = dprops
-
-    cnf["detectors"] = dets
+    # Add an empty set of detectors here, in case the user just wants access to
+    # the hardware metadata.
+    cnf["detectors"] = OrderedDict()
 
     hw = Hardware()
     hw.data = cnf

--- a/sotodlib/toast/focalplane.py
+++ b/sotodlib/toast/focalplane.py
@@ -12,7 +12,8 @@ from toast.instrument import Focalplane
 from toast.utils import Logger
 
 from ..core import Hardware
-from ..sim_hardware import get_example, sim_telescope_detectors
+from ..sim_hardware import sim_nominal
+from .sim_focalplane import sim_telescope_detectors
 
 
 FOCALPLANE_RADII = {
@@ -30,7 +31,7 @@ def get_telescope(telescope, wafer_slots, tube_slots):
         return telescope
     # User did not set telescope so we infer it from the
     # tube and wafer slots
-    hwexample = get_example()
+    hwexample = sim_nominal()
     if wafer_slots is not None:
         wafer_slots = wafer_slots.split(",")
         wafer_map = hwexample.wafer_map()
@@ -78,10 +79,10 @@ class SOFocalplane(Focalplane):
             if hwfile is not None:
                 log.info(f"Loading hardware configuration from {hwfile}...")
                 hw = Hardware(hwfile)
-            elif self.telescope in ["LAT", "SAT1", "SAT2", "SAT3"]:
+            elif self.telescope in ["LAT", "SAT1", "SAT2", "SAT3", "SAT4"]:
                 log.info("Simulating default hardware configuration")
-                hw = get_example()
-                hw.data["detectors"] = sim_telescope_detectors(
+                hw = sim_nominal()
+                sim_telescope_detectors(
                     hw,
                     self.telescope,
                 )
@@ -217,7 +218,7 @@ class SOFocalplane(Focalplane):
             # Get noise parameters.  If detector-specific entries are
             # absent, use band averages
             nets.append(
-                get_par_float(det_data, "NET", band_data["NET"]) * u.uK * u.s ** 0.5
+                get_par_float(det_data, "NET", band_data["NET"]) * 1.0e-6 * u.K * u.s ** 0.5
             )
             net_corrs.append(get_par_float(det_data, "NET_corr", band_data["NET_corr"]))
             fknees.append(get_par_float(det_data, "fknee", band_data["fknee"]) * u.mHz)

--- a/sotodlib/toast/ops/h_n.py
+++ b/sotodlib/toast/ops/h_n.py
@@ -157,18 +157,18 @@ class Hn(Operator):
                 hwpang = None
             if n == 1:
                 for name in [
-                        self.cos_1_name,
-                        self.sin_1_name,
-                        self.hweight_name,
-                        self.cos_n_name,
-                        self.sin_n_name,
+                    self.cos_1_name,
+                    self.sin_1_name,
+                    self.hweight_name,
+                    self.cos_n_name,
+                    self.sin_n_name,
                 ]:
                     obs.detdata.ensure(name, detectors=[det])
                 # Compute detector quaternions
                 obs_data = data.select(obs_uid=obs.uid)
                 self.pixel_pointing.detector_pointing.apply(obs_data, detectors=[det])
                 quats = obs.detdata[self.pixel_pointing.detector_pointing.quats][det]
-                theta, phi, psi = qa.to_angles(quats)
+                theta, phi, psi = qa.to_iso_angles(quats)
                 cos_n_new = np.cos(psi)
                 sin_n_new = np.sin(psi)
                 obs.detdata[self.cos_1_name][det] = cos_n_new

--- a/sotodlib/toast/ops/sim_stimulator.py
+++ b/sotodlib/toast/ops/sim_stimulator.py
@@ -20,7 +20,7 @@ from toast.ops.operator import Operator
 from toast.timing import function_timer
 from toast.traits import (Bool, Float, Instance, Int, Quantity, Unicode,
                           trait_docs)
-from toast.utils import Environment, Logger, Timer
+from toast.utils import Environment, Logger, Timer, unit_conversion
 
 XAXIS, YAXIS, ZAXIS = np.eye(3)
 
@@ -288,7 +288,10 @@ class SimStimulator(Operator):
             self.get_stimulator_temperature(obs)
 
             dets = obs.select_local_detectors(detectors)
-            obs.detdata.ensure(self.det_data, detectors=dets)
+            obs.detdata.ensure(self.det_data, detectors=dets, create_units=u.K)
+            det_units = obs.detdata[self.det_data].units
+            scale = unit_conversion(u.K, det_units)
+
             focalplane = obs.telescope.focalplane
             for det in dets:
                 signal = obs.detdata[self.det_data][det]
@@ -297,7 +300,7 @@ class SimStimulator(Operator):
 
                 stim = self.get_stimulator_signal(obs, band, quat)
 
-                signal += stim
+                signal += scale * stim
 
         return
 

--- a/sotodlib/toast/ops/sim_wiregrid.py
+++ b/sotodlib/toast/ops/sim_wiregrid.py
@@ -20,7 +20,7 @@ from toast.ops.operator import Operator
 from toast.timing import function_timer
 from toast.traits import (Bool, Float, Instance, Int, Quantity, Unicode,
                           trait_docs)
-from toast.utils import Environment, Logger, Timer
+from toast.utils import Environment, Logger, Timer, unit_conversion
 
 XAXIS, YAXIS, ZAXIS = np.eye(3)
 
@@ -215,7 +215,10 @@ class SimWireGrid(Operator):
             self.get_wiregrid_angle(obs)
 
             dets = obs.select_local_detectors(detectors)
-            obs.detdata.ensure(self.det_data, detectors=dets)
+            obs.detdata.ensure(self.det_data, detectors=dets, create_units=u.K)
+            det_units = obs.detdata[self.det_data].units
+            scale = unit_conversion(u.K, det_units)
+
             focalplane = obs.telescope.focalplane
             for det in dets:
                 signal = obs.detdata[self.det_data][det]
@@ -251,7 +254,7 @@ class SimWireGrid(Operator):
                 else:
                     weights_U = 0
 
-                signal += I * weights_I + Q * weights_Q + U * weights_U
+                signal += scale * (I * weights_I + Q * weights_Q + U * weights_U)
 
         return
 

--- a/sotodlib/toast/sim_focalplane.py
+++ b/sotodlib/toast/sim_focalplane.py
@@ -1,0 +1,513 @@
+# Copyright (c) 2018-2022 Simons Observatory.
+# Full license can be found in the top level "LICENSE" file.
+"""Focalplane simulation tools.
+"""
+
+import re
+from collections import OrderedDict
+
+import astropy.units as u
+import numpy as np
+from toast.instrument_coords import xieta_to_quat, quat_to_xieta
+from toast.instrument_sim import (
+    hex_nring,
+    hex_xieta_row_col,
+    hex_layout,
+    rhomb_dim,
+    rhomb_xieta_row_col,
+    rhombus_layout,
+    rhomb_gamma_angles_qu,
+)
+import toast.qarray as qa
+
+
+def rhombus_hex_layout(rhombus_npos, rhombus_width, gap, pos_rotate=None, killpos=None):
+    """
+    Construct a hexagon from 3 rhombi.
+
+    Args:
+        rhombus_npos (int):  The number of positions in one rhombus.
+        rhombus_width (Quantity):  The angle subtended by the width of one rhombus
+            along the short dimension.
+        gap (Quantity):  The angular gap between the edges of the rhombi.
+        pos_rotate (array, Quantity): An additional angle rotation of each position
+            on each rhombus before the rhombus is rotated into place.
+        killpos (list, optional): Pixel indices to remove for mechanical
+            reasons.
+
+    Returns:
+        (array):  Quaternion array of pixel positions.
+
+    """
+    # width in radians
+    width_rad = rhombus_width.to_value(u.radian)
+
+    # Gap between rhombi in radians
+    gap_rad = gap.to_value(u.radian)
+
+    # Quaternion offsets of the 3 rhombi
+    centers = [
+        xieta_to_quat(
+            0.25 * np.sqrt(3.0) * width_rad + 0.5 * gap_rad,
+            -0.25 * width_rad - gap_rad / (2 * np.sqrt(3.0)),
+            np.pi / 6,
+        ),
+        xieta_to_quat(
+            0.0,
+            0.5 * width_rad + gap_rad / np.sqrt(3.0),
+            -0.5 * np.pi,
+        ),
+        xieta_to_quat(
+            -0.25 * np.sqrt(3.0) * width_rad - 0.5 * gap_rad,
+            -0.25 * width_rad - gap_rad / (2 * np.sqrt(3.0)),
+            5 * np.pi / 6,
+        ),
+    ]
+
+    # Quaternion array of outputs, without missing pixel locations.
+    nkill = len(killpos)
+    killset = set(killpos)
+    result = np.zeros((3 * rhombus_npos - nkill, 4), dtype=np.float64)
+
+    # Pre-rotation of all pixels
+    pos_ang = u.Quantity(np.zeros(rhombus_npos, dtype=np.float64), u.radian)
+    if pos_rotate is not None:
+        pos_ang = pos_rotate
+
+    all_quat = dict()
+    for irhomb, cent in enumerate(centers):
+        quat = rhombus_layout(
+            rhombus_npos,
+            rhombus_width,
+            "",
+            "",
+            pos_ang,
+            center=cent,
+            pos_offset=irhomb * rhombus_npos,
+        )
+        all_quat.update(quat)
+    pquat = {int(x): y["quat"] for x, y in all_quat.items()}
+
+    poff = 0
+    for p, q in pquat.items():
+        if p not in killset:
+            result[poff, :] = q
+            poff += 1
+
+    return result
+
+
+def sim_wafer_detectors(
+    hw,
+    wafer_slot,
+    platescale,
+    fwhm,
+    band=None,
+    center=None,
+):
+    """Generate detector properties for a wafer.
+
+    Given a Hardware configuration, generate all detector properties for
+    the specified wafer and optionally only the specified band.
+
+    Args:
+        hw (Hardware): The hardware properties.
+        wafer_slot (str): The wafer slot name.
+        platescale (float): The plate scale in degrees / mm.
+        fwhm (dict): Dictionary of nominal FWHM values in arcminutes for
+            each band.
+        band (str, optional): Optionally only use this band.
+        center (array, optional): The quaternion offset of the center.
+
+    Returns:
+        (OrderedDict): The properties of all selected detectors.
+
+    """
+    zaxis = np.array([0, 0, 1], dtype=np.float64)
+
+    # The properties of this wafer
+    wprops = hw.data["wafer_slots"][wafer_slot]
+
+    # The readout card and its properties
+    card_slot = wprops["card_slot"]
+    cardprops = hw.data["card_slots"][card_slot]
+
+    # The bands
+    bands = wprops["bands"]
+    if band is not None:
+        if band in bands:
+            bands = [band]
+        else:
+            raise RuntimeError(
+                "band '{}' not valid for wafer '{}'".format(band, wafer_slot)
+            )
+
+    # Lay out the pixel locations depending on the wafer type.  Also
+    # compute the polarization orientation rotation, as well as the A/B
+    # handedness for the Sinuous detectors.
+
+    npix = wprops["npixel"]
+    pixsep = platescale * wprops["pixsize"]
+    layout_A = None
+    layout_B = None
+    handed = None
+    kill = []
+    if wprops["packing"] == "F":
+        # Feedhorn (NIST style)
+        gap = platescale * wprops["rhombusgap"]
+        nrhombus = npix // 3
+
+        # This dim is also the number of pixels along the short axis.
+        dim = rhomb_dim(nrhombus)
+
+        # This is the center-center distance along the short axis
+        width = (dim - 1) * pixsep
+
+        # The orientation within each rhombus alternates between zero and 45
+        # degrees.  However there is an offset.  We choose this arbitrarily
+        # for the nominal rhombus position, and then the rotation of the
+        # other 2 rhombi will naturally modulate this.
+        pol_A = np.zeros(nrhombus, dtype=np.float64)
+        pol_B = np.zeros(nrhombus, dtype=np.float64)
+        poloff = 22.5
+        for p in range(nrhombus):
+            # get the row / col of the pixel
+            row, col = rhomb_xieta_row_col(nrhombus, p)
+            if np.mod(row, 2) == 0:
+                pol_A[p] = 0.0 + poloff
+            else:
+                pol_A[p] = 45.0 + poloff
+            pol_B[p] = 90.0 + pol_A[p]
+
+        # We are going to remove 2 pixels for mechanical reasons
+        kf = dim * (dim - 1) // 2
+        kill = [(dim * dim + kf), (dim * dim + kf) + dim - 2]
+        layout_A = rhombus_hex_layout(
+            nrhombus,
+            width * u.degree,
+            gap * u.degree,
+            pos_rotate=pol_A * u.degree,
+            killpos=kill,
+        )
+        layout_B = rhombus_hex_layout(
+            nrhombus,
+            width * u.degree,
+            gap * u.degree,
+            pos_rotate=pol_B * u.degree,
+            killpos=kill,
+        )
+    elif wprops["packing"] == "S":
+        # Sinuous (Berkeley style)
+        # This is the center-center distance along the vertex-vertex axis
+        width = (2 * (hex_nring(npix) - 1)) * pixsep
+
+        # We rotate the hex layout 30 degrees about the center
+        hex_cent = qa.from_axisangle(zaxis, np.pi / 6)
+
+        # The sinuous handedness is chosen so that A/B pairs of pixels have the
+        # same nominal orientation but trail each other along the
+        # vertex-vertex axis of the hexagon.  The polarization orientation
+        # changes every other column
+
+        if npix == 37:
+            pol_A = np.array(
+                [
+                    45.0,
+                    0.0,
+                    45.0,
+                    45.0,
+                    45.0,
+                    45.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    45.0,
+                    45.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    45.0,
+                    45.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    45.0,
+                    0.0,
+                    0.0,
+                    45.0,
+                    45.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    45.0,
+                    45.0,
+                    0.0,
+                    0.0,
+                    45.0,
+                    45.0,
+                    45.0,
+                ]
+            )
+            handed = [
+                "R",
+                "L",
+                "R",
+                "L",
+                "L",
+                "R",
+                "L",
+                "R",
+                "L",
+                "R",
+                "L",
+                "R",
+                "R",
+                "R",
+                "L",
+                "R",
+                "L",
+                "R",
+                "R",
+                "L",
+                "R",
+                "L",
+                "R",
+                "L",
+                "R",
+                "L",
+                "L",
+                "L",
+                "L",
+                "R",
+                "L",
+                "R",
+                "L",
+                "R",
+                "L",
+                "L",
+                "L",
+            ]
+            pol_B = 90.0 + pol_A
+        else:
+            handed = list()
+            pol_A = np.zeros(npix, dtype=np.float64)
+            pol_B = np.zeros(npix, dtype=np.float64)
+            for p in range(npix):
+                row, col = hex_xieta_row_col(npix, p)
+                if np.mod(col, 2) == 0:
+                    handed.append("L")
+                else:
+                    handed.append("R")
+                if np.mod(col, 4) < 2:
+                    pol_A[p] = 0.0
+                else:
+                    pol_A[p] = 45.0
+                pol_B[p] = 90.0 + pol_A[p]
+        quat_A = hex_layout(
+            npix, width * u.degree, "", "", pol_A * u.degree, center=hex_cent
+        )
+        quat_B = hex_layout(
+            npix, width * u.degree, "", "", pol_B * u.degree, center=hex_cent
+        )
+
+        layout_A = np.zeros((len(quat_A), 4), dtype=np.float64)
+        pquat_A = {int(x): y["quat"] for x, y in quat_A.items()}
+        for p, q in pquat_A.items():
+            layout_A[p, :] = q
+
+        layout_B = np.zeros((len(quat_B), 4), dtype=np.float64)
+        pquat_B = {int(x): y["quat"] for x, y in quat_B.items()}
+        for p, q in pquat_B.items():
+            layout_B[p, :] = q
+    else:
+        raise RuntimeError("Unknown wafer packing '{}'".format(wprops["packing"]))
+
+    # Now we go through each pixel and create the orthogonal detectors for
+    # each band.
+    dets = OrderedDict()
+
+    # chan_per_AMC = cardprops["nchannel"] // cardprops["nAMC"]
+    chan_per_AMC = 910
+    chan_per_mux = 64
+    chan_per_bias = cardprops["nchannel"] // cardprops["nbias"]
+    readout_freq_range = np.linspace(4.0, 6.0, chan_per_AMC)
+    readout_freq = np.append(readout_freq_range, readout_freq_range)
+
+    doff = 0
+    p = 0
+    idoff = int(wafer_slot[-2:]) * 10000
+    for px in range(npix):
+        if px in kill:
+            continue
+        pstr = "{:03d}".format(p)
+        for b in bands:
+            for pl, layout, pol in zip(
+                ["A", "B"],
+                [layout_A, layout_B],
+                [pol_A, pol_B],
+            ):
+                dprops = OrderedDict()
+                dprops["wafer_slot"] = wafer_slot
+                dprops["ID"] = idoff + doff
+                dprops["pixel"] = pstr
+                dprops["band"] = b
+                dprops["fwhm"] = fwhm[b]
+                dprops["pol"] = pl
+                if handed is not None:
+                    dprops["handed"] = handed[p]
+                # Made-up assignment to readout channels
+                dprops["card_slot"] = card_slot
+                dprops["channel"] = doff
+                dprops["AMC"] = doff // chan_per_AMC
+                dprops["bias"] = doff // chan_per_bias
+                dprops["readout_freq_GHz"] = readout_freq[doff]
+                dprops["bondpad"] = doff - (doff // chan_per_mux) * chan_per_mux
+                dprops["mux_position"] = doff // chan_per_mux
+                # Layout quaternion offset is from the origin.  Now we apply
+                # the rotation of the wafer center.
+                if center is not None:
+                    dprops["quat"] = qa.mult(center, layout[p]).flatten()
+                else:
+                    dprops["quat"] = layout[p].flatten()
+                dprops["detector_name"] = ""
+                dname = "{}_p{}_{}_{}".format(wafer_slot, pstr, b, pl)
+                dets[dname] = dprops
+                doff += 1
+        p += 1
+
+    return dets
+
+
+def sim_telescope_detectors(hw, tele, tube_slots=None):
+    """Update hardware model with simulated detector positions.
+
+    Given a Hardware model, generate all detector properties for the specified
+    telescope and optionally a subset of optics tube slots (for the LAT).  The
+    detector dictionary of the hardware model is updated in place.
+
+    This uses helper functions for focalplane layout from the upstream toast
+    package
+
+    Args:
+        hw (Hardware): The hardware object to update.
+        tele (str): The telescope name.
+        tube_slots (list, optional): The optional list of tube slots to include.
+
+    Returns:
+        None
+
+    """
+
+    zaxis = np.array([0, 0, 1], dtype=np.float64)
+    thirty = np.pi / 6.0
+    # The properties of this telescope
+    teleprops = hw.data["telescopes"][tele]
+    platescale = teleprops["platescale"]
+    fwhm = teleprops["fwhm"]
+
+    # The tubes
+    alltubes = teleprops["tube_slots"]
+    ntube = len(alltubes)
+    if tube_slots is None:
+        tube_slots = alltubes
+    else:
+        for t in tube_slots:
+            if t not in alltubes:
+                raise RuntimeError(
+                    "Invalid tube_slot '{}' for telescope '{}'".format(t, tele)
+                )
+
+    alldets = OrderedDict()
+    if ntube == 1:
+        # This is a SAT.  We have one tube at the center.
+        tubeprops = hw.data["tube_slots"][tube_slots[0]]
+        waferspace = tubeprops["waferspace"] * platescale
+
+        # Wafers are arranged in a rotated hexagon shape, however these locations
+        # are rotated from a normal layout.
+        wcenters = hex_layout(
+            7,
+            (3.0 * np.sqrt(3.0) / 2) * waferspace * u.degree,
+            "",
+            "",
+            np.zeros(7) * u.degree,
+        )
+        centers = np.zeros((7, 4), dtype=np.float64)
+        qrot = qa.from_axisangle(zaxis, -np.pi / 6)
+        for p, q in wcenters.items():
+            centers[int(p), :] = qa.mult(qrot, q["quat"])
+
+        windx = 0
+        for wafer_slot in tubeprops["wafer_slots"]:
+            dets = sim_wafer_detectors(
+                hw, wafer_slot, platescale, fwhm, center=centers[windx]
+            )
+            alldets.update(dets)
+            windx += 1
+    else:
+        # This is the LAT.  We layout detectors for the case of 30 degree elevation
+        # and no boresight rotation.  Compute the tube centers.
+
+        # Inter-tube spacing
+        tubespace = teleprops["tubespace"]
+
+        # Pre-rotation of the tube arrangement
+        tuberot = 0.0 * np.ones(19, dtype=np.float64)
+
+        # Hexagon layout
+        tube_quats = hex_layout(
+            19,
+            4 * (tubespace * platescale) * u.degree,
+            "",
+            "",
+            tuberot * u.degree,
+        )
+        tcenters = np.zeros((19, 4), dtype=np.float64)
+        for p, q in tube_quats.items():
+            tcenters[int(p), :] = q["quat"]
+
+        tindx = 0
+        for tube_slot in tube_slots:
+            tubeprops = hw.data["tube_slots"][tube_slot]
+            waferspace = tubeprops["waferspace"]
+            location = tubeprops["toast_hex_pos"]
+
+            wradius = 0.5 * (waferspace * platescale * np.pi / 180.0)
+            qwcenters = [
+                xieta_to_quat(-wradius, wradius / np.sqrt(3.0), thirty * 4),
+                xieta_to_quat(0.0, -2.0 * wradius / np.sqrt(3.0), 0.0),
+                xieta_to_quat(wradius, wradius / np.sqrt(3.0), -thirty * 4),
+            ]
+
+            centers = list()
+            for qwc in qwcenters:
+                centers.append(qa.mult(tcenters[location], qwc))
+
+            windx = 0
+            for wafer_slot in tubeprops["wafer_slots"]:
+                dets = sim_wafer_detectors(
+                    hw, wafer_slot, platescale, fwhm, center=centers[windx]
+                )
+                # dname = list(dets.keys())[0]
+                # dquat = dets[dname]["quat"]
+                # ddir = qa.rotate(dquat, zaxis)
+                # dxi, deta, dgamma = quat_to_xieta(dquat)
+                # print(
+                #     f"tube {tube_slot} ({location}), wafer {wafer_slot}, det 0 dir = {ddir}, xi/eta/gamma = {dxi}, {deta}, {dgamma}"
+                # )
+                alldets.update(dets)
+                windx += 1
+            tindx += 1
+
+        # Rotate the focalplane to the nominal horizontal orientation
+        fp_rot = qa.from_axisangle(zaxis, 0.5 * np.pi)
+        for d, props in alldets.items():
+            props["quat"] = qa.mult(fp_rot, props["quat"])
+
+    if "detectors" in hw.data:
+        hw.data["detectors"].update(alldets)
+    else:
+        hw.data["detectors"] = alldets

--- a/sotodlib/vis_hardware.py
+++ b/sotodlib/vis_hardware.py
@@ -3,9 +3,18 @@
 """Hardware visualization tools.
 """
 
+import astropy.units as u
 import numpy as np
 import quaternionarray as qa
 import warnings
+
+import toast
+
+from so3g.proj import quat
+
+from .core.hardware import LAT_COROTATOR_OFFSET
+
+from .sim_hardware import sim_nominal
 
 
 default_band_colors = {
@@ -38,7 +47,15 @@ def set_matplotlib_pdf_backend():
 
 
 def plot_detectors(
-    dets, outfile, width=None, height=None, labels=False, bandcolor=None
+    dets,
+    outfile,
+    width=None,
+    height=None,
+    labels=False,
+    bandcolor=None,
+    xieta=False,
+    lat_corotate=True,
+    lat_elevation=None,
 ):
     """Visualize a dictionary of detectors.
 
@@ -54,6 +71,8 @@ def plot_detectors(
         height (float): Height of plot in degrees (None = autoscale).
         labels (bool): If True, label each detector.
         bandcolor (dict, optional): Dictionary of color values for each band.
+        xieta (bool):  If True, plot in Xi / Eta / Gamma coordinates rather
+            than focalplane X / Y / Z.
 
     Returns:
         None
@@ -62,62 +81,135 @@ def plot_detectors(
     try:
         plt = set_matplotlib_pdf_backend()
     except:
-        warnings.warn(
-            """Couldn't set the PDF matplotlib backend,
-focal plane plots will not render properly,
-proceeding with the default matplotlib backend"""
+        wmsg = (
+            "Couldn't set the PDF matplotlib backend, "
+            "focal plane plots will not render properly, "
+            "proceeding with the default matplotlib backend"
         )
+        warnings.warn(wmsg)
         import matplotlib.pyplot as plt
 
-    # If you rotate the zaxis by quat, then the X axis is upwards in
-    # the focal plane and the Y axis is to the right.  (This is what
-    # TOAST expects.)  Below we use "x" and "y" for those directions,
-    # and in plotting functions pass them in the order (y, x).
+    xaxis, yaxis, zaxis = np.eye(3)
 
-    xaxis = np.array([1.0, 0.0, 0.0], dtype=np.float64)
-    zaxis = np.array([0.0, 0.0, 1.0], dtype=np.float64)
-    quats = np.array([p['quat'] for p in dets.values()]).astype(float)
-    pos = qa.rotate(quats, zaxis)  # shape (n_det, 3)
+    # Get wafer to telescope map
+    hw = sim_nominal()
+    wfmap = hw.wafer_map()
+
+    n_det = len(dets)
+    detnames = list(dets.keys())
+    quats = np.array(
+        [dets[detnames[x]]["quat"] for x in range(n_det)], dtype=np.float64
+    )
+
+    lat_rot = None
+    lat_elstr = ""
+
+    have_lat = False
+    for d in range(n_det):
+        dn = detnames[d]
+        tele = wfmap["telescopes"][dets[dn]["wafer_slot"]]
+        if tele == "LAT":
+            have_lat = True
+
+    if have_lat:
+        if not lat_corotate:
+            if lat_elevation is None:
+                raise RuntimeError("Must specify elevation if not co-rotating")
+            lat_elstr = f"({lat_elevation.to_value(u.degree):0.1f} Degrees Elevation)"
+            lat_ang = lat_elevation.to_value(u.rad) - LAT_COROTATOR_OFFSET.to_value(
+                u.rad
+            )
+            lat_rot = qa.rotation(zaxis, lat_ang)
+        for d in range(n_det):
+            dn = detnames[d]
+            tele = wfmap["telescopes"][dets[dn]["wafer_slot"]]
+            if tele == "LAT" and lat_rot is not None:
+                quats[d] = qa.mult(lat_rot, quats[d])
+
+    if n_det == 0:
+        raise RuntimeError("No detectors specified")
 
     # arc_factor returns a scaling that can be used to reproject (X,
     # Y) to units corresponding to the angle subtended from (0,0,1) to
     # (X, Y, sqrt(X^2 + Y^2)).  This is called "ARC" (Zenithal
     # Equidistant) projection in FITS.
     def arc_factor(x, y):
-        r = (x**2 + y**2)**.5
+        r = (x**2 + y**2) ** 0.5
         if r < 1e-6:
-            return 1. + r**2/6
-        return np.arcsin(r)/r
-    detx = {k: p[0] * 180.0 / np.pi * arc_factor(p[0], p[1])
-            for k, p in zip(dets.keys(), pos)}
-    dety = {k: p[1] * 180.0 / np.pi * arc_factor(p[0], p[1])
-            for k, p in zip(dets.keys(), pos)}
+            return 1.0 + r**2 / 6
+        return np.arcsin(r) / r
 
-    # The detang is the polarization angle, measured CCW from vertical.
-    pol = qa.rotate(quats, xaxis)  # shape (n_det, 3)
-    detang = {k: np.arctan2(p[1], p[0])
-              for k, p in zip(dets.keys(), pol)}
+    if xieta:
+        # Plotting as seen from observer in Xi / Eta / Gamma
+        xi, eta, gamma = toast.instrument_coords.quat_to_xieta(quats)
+        # xi, eta, gamma = quat.decompose_xieta(quats)
 
-    wmin = 1.0
-    wmax = -1.0
-    hmin = 1.0
-    hmax = -1.0
+        detx = {
+            detnames[k]: xi[k] * 180.0 / np.pi * arc_factor(xi[k], eta[k])
+            for k in range(n_det)
+        }
+        dety = {
+            detnames[k]: eta[k] * 180.0 / np.pi * arc_factor(xi[k], eta[k])
+            for k in range(n_det)
+        }
+
+        for didx, dn in enumerate(detnames):
+            wf = dets[dn]["wafer_slot"]
+            px = int(dets[dn]["pixel"])
+            if px == 0:
+                q = quats[didx]
+                dd = qa.rotate(q, zaxis)
+
+        # In Xi / Eta coordinates, gamma is measured clockwise from line of
+        # decreasing elevation.  Here we convert into visualization X/Y
+        # coordinatates measured counter clockwise from the X axis.
+        polangs = {detnames[k]: 1.5 * np.pi - gamma[k] for k in range(n_det)}
+    else:
+        # Plotting in focalplane X / Y / Z coordinates.
+        # Compute direction and orientation vectors
+        dir = qa.rotate(quats, zaxis)
+        orient = qa.rotate(quats, xaxis)
+
+        small = np.fabs(1.0 - dir[:, 2]) < 1.0e-6
+        not_small = np.logical_not(small)
+        xp = np.zeros(n_det, dtype=np.float64)
+        yp = np.zeros(n_det, dtype=np.float64)
+
+        mag = np.arccos(dir[not_small, 2])
+        ang = np.arctan2(dir[not_small, 1], dir[not_small, 0])
+        xp[not_small] = mag * np.cos(ang)
+        yp[not_small] = mag * np.sin(ang)
+
+        polangs = {
+            detnames[k]: np.arctan2(orient[k, 1], orient[k, 0]) for k in range(n_det)
+        }
+
+        detx = {
+            detnames[k]: xp[k] * 180.0 / np.pi * arc_factor(xp[k], yp[k])
+            for k in range(n_det)
+        }
+        dety = {
+            detnames[k]: yp[k] * 180.0 / np.pi * arc_factor(xp[k], yp[k])
+            for k in range(n_det)
+        }
+
     if (width is None) or (height is None):
         # We are autoscaling.  Compute the angular extent of all detectors
         # and add some buffer.
-        if len(detx):
-            _y = np.array(list(dety.values()))
-            _x = np.array(list(detx.values()))
-            wmin, wmax = _y.min(), _y.max()
-            hmin, hmax = _x.min(), _x.max()
-        wbuf = 0.1 * (wmax - wmin)
-        hbuf = 0.1 * (hmax - hmin)
+        _y = np.array(list(dety.values()))
+        _x = np.array(list(detx.values()))
+        wmin, wmax = _x.min(), _x.max()
+        hmin, hmax = _y.min(), _y.max()
+        wbuf = 0.2 * (wmax - wmin)
+        hbuf = 0.2 * (hmax - hmin)
         wmin -= wbuf
         wmax += wbuf
         hmin -= hbuf
         hmax += hbuf
         width = wmax - wmin
         height = hmax - hmin
+        half_width = 0.5 * width
+        half_height = 0.5 * height
     else:
         half_width = 0.5 * width
         half_height = 0.5 * height
@@ -152,10 +244,14 @@ proceeding with the default matplotlib backend"""
     fig = plt.figure(figsize=(wfigsize, hfigsize), dpi=figdpi)
     ax = fig.add_subplot(1, 1, 1)
 
-    ax.set_xlabel("Degrees", fontsize="large")
-    ax.set_ylabel("Degrees", fontsize="large")
     ax.set_xlim([wmin, wmax])
     ax.set_ylim([hmin, hmax])
+    if xieta:
+        ax.set_xlabel(r"Boresight $\xi$ Degrees", fontsize="large")
+        ax.set_ylabel(r"Boresight $\eta$ Degrees", fontsize="large")
+    else:
+        ax.set_xlabel("Boresight X Degrees", fontsize="large")
+        ax.set_ylabel("Boresight Y Degrees", fontsize="large")
 
     # Draw wafer labels in the background
     if labels:
@@ -163,10 +259,17 @@ proceeding with the default matplotlib backend"""
         # between (0.01 and 0.1) times the size of the figure.
         for k, (center, size) in wafer_centers.items():
             fontpix = np.clip(0.7 * size * hpixperdeg, 0.01 * hfigpix, 0.10 * hfigpix)
-            ax.text(center[1] + fontpix/hpixperdeg, center[0], k,
-                    color='k', fontsize=fontpix, horizontalalignment='center',
-                    verticalalignment='center', zorder=100,
-                    bbox=dict(fc='white', ec='none', pad=0.2, alpha=1.0))
+            ax.text(
+                center[0],
+                center[1] + fontpix / hpixperdeg,
+                k,
+                color="k",
+                fontsize=fontpix,
+                horizontalalignment="center",
+                verticalalignment="center",
+                zorder=100,
+                bbox=dict(fc="white", ec="none", pad=0.2, alpha=1.0),
+            )
 
     for d, props in dets.items():
         band = props["band"]
@@ -180,12 +283,17 @@ proceeding with the default matplotlib backend"""
 
         # Position and polarization angle
         xpos, ypos = detx[d], dety[d]
-        polang = detang[d]
+        polang = polangs[d]
 
         detface = bandcolor[band]
 
-        circ = plt.Circle((ypos, xpos), radius=detradius, fc=detface,
-                          ec="black", linewidth=0.05*detradius)
+        circ = plt.Circle(
+            (xpos, ypos),
+            radius=detradius,
+            fc=detface,
+            ec="black",
+            linewidth=0.05 * detradius,
+        )
         ax.add_artist(circ)
 
         ascale = 1.5
@@ -201,24 +309,101 @@ proceeding with the default matplotlib backend"""
         if pol == "B":
             detcolor = (0.0, 0.0, 1.0, 1.0)
 
-        ax.arrow(ytail, xtail, dy, dx, width=0.1*detradius,
-                 head_width=0.3*detradius, head_length=0.3*detradius,
-                 fc=detcolor, ec="none", length_includes_head=True)
+        ax.arrow(
+            xtail,
+            ytail,
+            dx,
+            dy,
+            width=0.1 * detradius,
+            head_width=0.3 * detradius,
+            head_length=0.3 * detradius,
+            fc=detcolor,
+            ec="none",
+            length_includes_head=True,
+        )
 
         if labels:
             # Compute the font size to use for detector labels
             fontpix = 0.1 * detradius * hpixperdeg
-            ax.text(ypos, xpos, pixel,
-                    color='k', fontsize=fontpix, horizontalalignment='center',
-                    verticalalignment='center',
-                    bbox=dict(fc='white', ec='none', pad=0.2, alpha=1.0))
+            ax.text(
+                xpos,
+                ypos,
+                pixel,
+                color="k",
+                fontsize=fontpix,
+                horizontalalignment="center",
+                verticalalignment="center",
+                bbox=dict(fc="white", ec="none", pad=0.2, alpha=1.0),
+            )
             labeloff = fontpix * len(pol) / hpixperdeg
             if dy < 0:
                 labeloff = -labeloff
-            ax.text((ytail+1.0*dy+labeloff), (xtail+1.0*dx), pol,
-                    color='k', fontsize=fontpix, horizontalalignment='center',
-                    verticalalignment='center',
-                    bbox=dict(fc='none', ec='none', pad=0, alpha=1.0))
+            ax.text(
+                (xtail + 1.0 * dx + labeloff),
+                (ytail + 1.0 * dy),
+                pol,
+                color="k",
+                fontsize=fontpix,
+                horizontalalignment="center",
+                verticalalignment="center",
+                bbox=dict(fc="none", ec="none", pad=0, alpha=1.0),
+            )
+
+    # Draw a "mini" coordinate axes for reference
+    shortest = min(half_width, half_height)
+    xmini = -0.7 * half_width
+    ymini = -0.7 * half_height
+    xlen = 0.06 * shortest
+    ylen = 0.06 * shortest
+    mini_width = 0.005 * shortest
+    mini_head_width = 3 * mini_width
+    mini_head_len = 3 * mini_width
+    if xieta:
+        aprops = [
+            (xlen, 0, "-", r"$\xi$"),
+            (0, ylen, "-", r"$\eta$"),
+            (-xlen, 0, "--", "Y"),
+            (0, -ylen, "--", "X"),
+        ]
+    else:
+        aprops = [
+            (xlen, 0, "-", "X"),
+            (0, ylen, "-", "Y"),
+            (-xlen, 0, "--", r"$\eta$"),
+            (0, -ylen, "--", r"$\xi$"),
+        ]
+    for ap in aprops:
+        lx = xmini + 1.5 * ap[0]
+        ly = ymini + 1.5 * ap[1]
+        lw = figdpi / 200.0
+        ax.arrow(
+            xmini,
+            ymini,
+            ap[0],
+            ap[1],
+            width=mini_width,
+            head_width=mini_head_width,
+            head_length=mini_head_len,
+            fc="k",
+            ec="k",
+            linestyle=ap[2],
+            linewidth=lw,
+            length_includes_head=True,
+        )
+        ax.text(
+            lx,
+            ly,
+            ap[3],
+            color="k",
+            fontsize=int(figdpi / 10),
+            horizontalalignment="center",
+            verticalalignment="center",
+        )
+
+    st = f"Focalplane Looking Towards Observer {lat_elstr}"
+    if xieta:
+        st = f"Focalplane on Sky From Observer {lat_elstr}"
+    fig.suptitle(st)
 
     plt.savefig(outfile)
     plt.close()
@@ -256,8 +441,11 @@ def summary_text(hw):
     """
     for obj, props in hw.data.items():
         nsub = len(props)
-        print("{}{:<12}: {}{:5d} objects{}".format(clr.WHITE, obj, clr.RED,
-                                                   nsub, clr.ENDC))
+        print(
+            "{}{:<12}: {}{:5d} objects{}".format(
+                clr.WHITE, obj, clr.RED, nsub, clr.ENDC
+            )
+        )
         if nsub <= 2000:
             line = ""
             for k in list(props.keys()):
@@ -266,8 +454,7 @@ def summary_text(hw):
                     line = ""
                 line = "{}{}, ".format(line, k)
             if len(line) > 0:
-                print("    {}{}{}".format(clr.BLUE, line.rstrip(", "),
-                      clr.ENDC))
+                print("    {}{}{}".format(clr.BLUE, line.rstrip(", "), clr.ENDC))
         else:
             # Too many to print!
             print("    {}(Too many to print){}".format(clr.BLUE, clr.ENDC))

--- a/workflows/make_hardware_maps.py
+++ b/workflows/make_hardware_maps.py
@@ -64,13 +64,11 @@ def main():
     # Nominal configuration
 
     print("Getting nominal config...", flush=True)
-    hw = hardware.get_example()
-    hw.data["detectors"] = OrderedDict()
+    hw = hardware.sim_nominal()
     for tele, teleprops in hw.data["telescopes"].items():
         print("Simulating detectors for telescope {}...".format(tele),
               flush=True)
-        dets = hardware.sim_telescope_detectors(hw, tele)
-        hw.data["detectors"].update(dets)
+        hardware.sim_detectors_toast(hw, tele)
     write_hw(args.out + '.nominal', hw, plain=args.plain)
 
     # Perturb configuration

--- a/workflows/mapmaker_test.py
+++ b/workflows/mapmaker_test.py
@@ -5,6 +5,8 @@
 """
 This script runs a basic mapmaking test.
 
+DEPRECATED:  This script is left here for reference, but was only used for debugging.
+
 """
 
 import os

--- a/workflows/toast_so_map.py
+++ b/workflows/toast_so_map.py
@@ -1,0 +1,695 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2019-2021 Simons Observatory.
+# Full license can be found in the top level "LICENSE" file.
+
+"""
+This workflow runs basic data reduction and map-making:
+
+- A single MPI process group is used
+
+- All input observations are loaded and made into the output map
+
+In particular, this script is designed for testing mapmaking techniques on data that
+already exists on disk.  It does not simulate data and it is not a full workflow for
+running null tests, building observation matrices, etc.
+
+You can see the automatically generated command line options with:
+
+    toast_so_map.py --help
+
+Or you can dump a config file with all the default values with:
+
+    toast_so_map.py --default_toml config.toml
+
+This script contains just comments about what is going on.  For details about all the
+options for a specific Operator, see the documentation or use the help() function from
+an interactive python session.
+
+"""
+
+import argparse
+import datetime
+import os
+import sys
+import traceback
+
+import numpy as np
+
+from astropy import units as u
+
+# Import sotodlib.toast first, since that sets default object names
+# to use in toast.
+import sotodlib.toast as sotoast
+
+import toast
+import toast.ops
+from toast.mpi import MPI, Comm
+from toast.observation import default_values as defaults
+
+import sotodlib.toast.ops as so_ops
+import sotodlib.mapmaking
+
+# Make sure pixell uses a reliable FFT engine
+import pixell.fft
+
+pixell.fft.engine = "fftw"
+
+
+def parse_config(operators, templates, comm):
+    """Parse command line arguments and load any config files.
+
+    Return the final config, remaining args, and job size args.
+
+    """
+    # Argument parsing
+    parser = argparse.ArgumentParser(description="Make maps of SO data")
+
+    # Arguments specific to this script
+
+    parser.add_argument(
+        "--obs_hdf5",
+        required=False,
+        action="extend",
+        nargs="*",
+        help="Path to a TOAST hdf5 observation dump (can use multiple times)",
+    )
+
+    parser.add_argument(
+        "--obs_book",
+        required=False,
+        action="extend",
+        nargs="*",
+        help="Path to a L3 book directory (can use multiple times)",
+    )
+
+    parser.add_argument(
+        "--obs_raw",
+        required=False,
+        action="extend",
+        nargs="*",
+        help="Path to raw data directory (can use multiple times)",
+    )
+
+    parser.add_argument(
+        "--band",
+        required=False,
+        default=None,
+        help="Only use detectors from this band (e.g. LAT_f150, SAT_f040)",
+    )
+
+    parser.add_argument(
+        "--wafer_slots",
+        required=False,
+        default=None,
+        help="Comma-separated list of wafer slots to use. ",
+    )
+
+    parser.add_argument(
+        "--out_dir",
+        required=False,
+        type=str,
+        default="output_maps",
+        help="The output directory",
+    )
+
+    # Build a config dictionary starting from the operator defaults, overriding with any
+    # config files specified with the '--config' commandline option, followed by any
+    # individually specified parameter overrides.
+
+    config, args, jobargs = toast.parse_config(
+        parser,
+        operators=operators,
+        templates=templates,
+    )
+
+    # Create our output directory
+    if comm is None or comm.rank == 0:
+        if not os.path.isdir(args.out_dir):
+            os.makedirs(args.out_dir, exist_ok=True)
+
+    # Log the config that was actually used at runtime.
+    outlog = os.path.join(args.out_dir, "config_log.toml")
+    toast.config.dump_toml(outlog, config, comm=comm)
+
+    return config, args, jobargs
+
+
+def use_full_pointing(job):
+    # Are we using full pointing?  We determine this from whether the binning operator
+    # used in the solve has full pointing enabled.
+    full_pointing = False
+    if job.operators.binner.full_pointing:
+        full_pointing = True
+    return full_pointing
+
+
+def job_create(config, comm):
+    # Instantiate our objects that were configured from the command line / files
+    job = toast.create_from_config(config)
+
+    # For this workflow, we will just use one process group
+    full_pointing = use_full_pointing(job)
+    if comm is None:
+        group_size = 1
+    else:
+        group_size = comm.size
+    return job, group_size, full_pointing
+
+
+def select_pointing(job, args, data):
+    """Select the pixelization scheme for both the solver and final binning."""
+    log = toast.utils.Logger.get()
+
+    ops = job.operators
+
+    n_enabled_solve = np.sum(
+        [
+            ops.pixels_wcs_azel.enabled,
+            ops.pixels_wcs_radec.enabled,
+            ops.pixels_healpix_radec.enabled,
+        ]
+    )
+    if n_enabled_solve != 1:
+        raise RuntimeError(
+            "Only one pixelization operator should be enabled for the solver."
+        )
+
+    n_enabled_final = np.sum(
+        [
+            ops.pixels_wcs_azel_final.enabled,
+            ops.pixels_wcs_radec_final.enabled,
+            ops.pixels_healpix_radec_final.enabled,
+        ]
+    )
+    if n_enabled_final > 1:
+        raise RuntimeError(
+            "At most, one pixelization operator can be enabled for the final binning."
+        )
+
+    # Configure Az/El and RA/DEC boresight and detector pointing and weights
+
+    ops.det_pointing_azel.boresight = defaults.boresight_azel
+    ops.det_pointing_radec.boresight = defaults.boresight_radec
+
+    ops.pixels_wcs_azel.detector_pointing = ops.det_pointing_azel
+    ops.pixels_wcs_radec.detector_pointing = ops.det_pointing_radec
+    ops.pixels_healpix_radec.detector_pointing = ops.det_pointing_radec
+
+    ops.pixels_wcs_azel_final.detector_pointing = ops.det_pointing_azel
+    ops.pixels_wcs_radec_final.detector_pointing = ops.det_pointing_radec
+    ops.pixels_healpix_radec_final.detector_pointing = ops.det_pointing_radec
+
+    ops.weights_azel.detector_pointing = ops.det_pointing_azel
+    ops.weights_radec.detector_pointing = ops.det_pointing_radec
+
+    if job.has_HWP:
+        ops.weights_azel.hwp_angle = defaults.hwp_angle
+        ops.weights_radec.hwp_angle = defaults.hwp_angle
+
+    # Select Pixelization and weights for solve and final binning
+
+    if ops.pixels_wcs_azel.enabled:
+        job.pixels_solve = ops.pixels_wcs_azel
+        job.weights_solve = ops.weights_azel
+    elif ops.pixels_wcs_radec.enabled:
+        job.pixels_solve = ops.pixels_wcs_radec
+        job.weights_solve = ops.weights_radec
+    else:
+        job.pixels_solve = ops.pixels_healpix_radec
+        job.weights_solve = ops.weights_radec
+    job.weights_final = job.weights_solve
+
+    if n_enabled_final == 0:
+        # Use same as solve
+        job.pixels_final = job.pixels_solve
+    else:
+        if ops.pixels_wcs_azel_final.enabled:
+            job.pixels_final = ops.pixels_wcs_azel_final
+        elif ops.pixels_wcs_radec_final.enabled:
+            job.pixels_final = ops.pixels_wcs_radec_final
+        else:
+            job.pixels_final = ops.pixels_healpix_radec_final
+    log.info_rank(
+        f"Template solve using pixelization: {job.pixels_solve.name}",
+        comm=data.comm.comm_world,
+    )
+    log.info_rank(
+        f"Template solve using weights: {job.weights_solve.name}",
+        comm=data.comm.comm_world,
+    )
+    log.info_rank(
+        f"Final binning using pixelization: {job.pixels_final.name}",
+        comm=data.comm.comm_world,
+    )
+    log.info_rank(
+        f"Final binning using weights: {job.weights_final.name}",
+        comm=data.comm.comm_world,
+    )
+
+
+def load_data(job, args, toast_comm):
+    log = toast.utils.Logger.get()
+    ops = job.operators
+    tmpls = job.templates
+
+    # Create the (initially empty) data
+
+    data = toast.Data(comm=toast_comm)
+
+    # Timer for reporting the progress
+    timer = toast.timing.Timer()
+    timer.start()
+
+    ops.mem_count.prefix = "Before Data Load"
+    ops.mem_count.apply(data)
+
+    # Load all of our toast HDF5 datasets
+
+    job.has_HWP = False
+    for hobs in list(args.obs_hdf5):
+        log.info_rank(f"Starting load of HDF5 data {hobs}", comm=data.comm.comm_group)
+        ob = toast.io.load_hdf5(
+            hobs,
+            toast_comm,
+            process_rows=toast_comm.group_size,
+            meta=None,
+            detdata=None,
+            shared=None,
+            intervals=None,
+            force_serial=True,
+        )
+        if defaults.hwp_angle in ob.shared:
+            job.has_HWP = True
+        # print("boresight_radec:  ", ob.shared["boresight_radec"].data)
+        # print("boresight_azel:  ", ob.shared["boresight_azel"].data)
+        # print("shared_flags:  ", ob.shared["flags"].data)
+        # bad = (ob.shared["flags"].data & defaults.shared_mask_invalid) != 0
+        # print("shared_flags invalid:  ", np.count_nonzero(bad))
+        # print("det_flags:  ", ob.detdata["flags"].data)
+        # print("noise:  ", ob["noise_model"])
+        data.obs.append(ob)
+        log.info_rank(
+            f"Finished load of HDF5 data {hobs} in",
+            comm=data.comm.comm_group,
+            timer=timer,
+        )
+        ops.mem_count.prefix = f"After Loading {hobs}"
+        ops.mem_count.apply(data)
+
+    # Load all of our book directories
+    if args.obs_book is not None and len(args.obs_book) > 0:
+        raise NotImplementedError("Book loading not supported until PR #183 is merged")
+
+    # Load raw data
+    if args.obs_raw is not None and len(args.obs_raw) > 0:
+        raise NotImplementedError("Raw loading not supported until PR #183 is merged")
+
+    if len(data.obs) == 0:
+        raise RuntimeError("No input data specified!")
+
+    return data
+
+
+def reduce_data(job, args, data):
+    log = toast.utils.Logger.get()
+    ops = job.operators
+    tmpls = job.templates
+
+    world_comm = data.comm.comm_world
+
+    # Timer for reporting the progress
+    timer = toast.timing.Timer()
+    timer.start()
+
+    # Set up pointing, pixelization, and weights
+
+    select_pointing(job, args, data)
+
+    # Set up pointing matrices for binning operators
+
+    ops.binner.pixel_pointing = job.pixels_solve
+    ops.binner.stokes_weights = job.weights_solve
+
+    ops.binner_final.pixel_pointing = job.pixels_final
+    ops.binner_final.stokes_weights = job.weights_final
+
+    # If we are not using a different binner for our final binning, use the same one
+    # as the solve.
+    if not ops.binner_final.enabled:
+        ops.binner_final = ops.binner
+
+    # Flag Sun, Moon and the planets
+
+    ops.flag_sso.detector_pointing = ops.det_pointing_azel
+    if ops.flag_sso.enabled:
+        ops.flag_sso.apply(data)
+        log.info_rank("Flagged SSOs in", comm=world_comm, timer=timer)
+        ops.mem_count.prefix = "After flagging SSOs"
+        ops.mem_count.apply(data)
+    else:
+        log.info_rank("SSO Flagging disabled", comm=world_comm)
+
+    # Noise model.  If noise estimation is not enabled, and no existing noise model
+    # is found, then create a fake noise model with uniform weighting.
+
+    noise_model = None
+
+    if ops.noise_estim.enabled:
+        ops.noise_estim.detector_pointing = job.pixels_final.detector_pointing
+        ops.noise_estim.pixel_pointing = job.pixels_final
+        ops.noise_estim.stokes_weights = job.weights_final
+        ops.noise_estim.pixel_dist = ops.binner_final.pixel_dist
+        ops.noise_estim.output_dir = args.out_dir
+        ops.noise_estim.apply(data)
+        log.info_rank("Estimated noise in", comm=world_comm, timer=timer)
+
+        if ops.noise_fit.enabled:
+            ops.noise_fit.apply(data)
+            log.info_rank("Fit noise model in", comm=world_comm, timer=timer)
+            log.info_rank("Using noise model from 1/f fit", comm=world_comm)
+            noise_model = ops.noise_fit.out_model
+        else:
+            log.info_rank("Using noise model from raw estimate", comm=world_comm)
+            noise_model = ops.noise_estim.out_model
+    else:
+        have_noise = True
+        for ob in data.obs:
+            if "noise_model" not in ob:
+                have_noise = False
+        if have_noise:
+            log.info_rank("Using noise model from data files", comm=world_comm)
+            noise_model = "noise_model"
+        else:
+            for ob in data.obs:
+                (estrate, _, _, _, _) = toast.utils.rate_from_times(
+                    ob.shared[defaults.times].data
+                )
+                ob["fake_noise"] = toast.noise_sim.AnalyticNoise(
+                    detectors=ob.all_detectors,
+                    rate={x: estrate * u.Hz for x in ob.all_detectors},
+                    fmin={x: 1.0e-5 * u.Hz for x in ob.all_detectors},
+                    fknee={x: 0.0 * u.Hz for x in ob.all_detectors},
+                    alpha={x: 1.0 for x in ob.all_detectors},
+                    NET={
+                        x: 1.0 * u.K * np.sqrt(1.0 * u.second) for x in ob.all_detectors
+                    },
+                )
+            log.info_rank(
+                "Using fake noise model with uniform weighting", comm=world_comm
+            )
+            noise_model = "fake_noise"
+    ops.binner.noise_model = noise_model
+    ops.binner_final.noise_model = noise_model
+
+    # Optional geometric factors
+
+    ops.h_n.pixel_pointing = job.pixels_final
+    ops.h_n.pixel_dist = ops.binner_final.pixel_dist
+    ops.h_n.noise_model = noise_model
+    ops.h_n.output_dir = args.out_dir
+    if ops.h_n.enabled:
+        ops.h_n.apply(data)
+        log.info_rank("Calculated h_n in", comm=world_comm, timer=timer)
+        ops.mem_count.prefix = "After h_n map"
+        ops.mem_count.apply(data)
+    else:
+        log.info_rank("H_n map calculation disabled", comm=world_comm)
+
+    ops.cadence_map.pixel_pointing = job.pixels_final
+    ops.cadence_map.pixel_dist = ops.binner_final.pixel_dist
+    ops.cadence_map.output_dir = args.out_dir
+    if ops.cadence_map.enabled:
+        ops.cadence_map.apply(data)
+        log.info_rank("Calculated cadence map in", comm=world_comm, timer=timer)
+        ops.mem_count.prefix = "After cadence map"
+        ops.mem_count.apply(data)
+    else:
+        log.info_rank("Cadence map calculation disabled", comm=world_comm)
+
+    ops.crosslinking.pixel_pointing = job.pixels_final
+    ops.crosslinking.pixel_dist = ops.binner_final.pixel_dist
+    ops.crosslinking.output_dir = args.out_dir
+    if ops.crosslinking.enabled:
+        ops.crosslinking.apply(data)
+        log.info_rank("Calculated crosslinking in", comm=world_comm, timer=timer)
+        ops.mem_count.prefix = "After crosslinking map"
+        ops.mem_count.apply(data)
+    else:
+        log.info_rank("Crosslinking map calculation disabled", comm=world_comm)
+
+    # Collect signal statistics before filtering
+
+    ops.raw_statistics.output_dir = args.out_dir
+    if ops.raw_statistics.enabled:
+        ops.raw_statistics.apply(data)
+        log.info_rank("Calculated raw statistics in", comm=world_comm, timer=timer)
+        ops.mem_count.prefix = "After raw statistics"
+        ops.mem_count.apply(data)
+    else:
+        log.info_rank("Raw statistics disabled", comm=world_comm)
+
+    # Deconvolve a time constant
+
+    if ops.deconvolve_time_constant.enabled:
+        ops.deconvolve_time_constant.apply(data)
+        log.info_rank("Deconvolved time constant in", comm=world_comm, timer=timer)
+        ops.mem_count.prefix = "After deconvolving time constant"
+        ops.mem_count.apply(data)
+    else:
+        log.info_rank("Timeconstant deconvolution disabled", comm=world_comm)
+
+    # Run ML mapmaker
+
+    ops.mlmapmaker.out_dir = args.out_dir
+    if ops.mlmapmaker.enabled:
+        ops.mlmapmaker.apply(data)
+        log.info_rank("Finished ML map-making in", comm=world_comm, timer=timer)
+    else:
+        log.info_rank("ML map-making disabled", comm=world_comm)
+
+    # Apply the filter stack
+
+    log.info_rank("Begin Filtering", comm=world_comm)
+
+    if ops.groundfilter.enabled:
+        ops.groundfilter.apply(data)
+        log.info_rank("Finished ground-filtering in", comm=world_comm, timer=timer)
+    else:
+        log.info_rank("Ground-filtering disabled", comm=world_comm)
+
+    if ops.polyfilter1D.enabled:
+        ops.polyfilter1D.apply(data)
+        log.info_rank("Finished 1D-poly-filtering in", comm=world_comm, timer=timer)
+    else:
+        log.info_rank("1D-poly-filtering disabled", comm=world_comm)
+
+    if ops.polyfilter2D.enabled:
+        ops.polyfilter2D.apply(data)
+        log.info_rank("Finished 2D-poly-filtering in", comm=world_comm, timer=timer)
+    else:
+        log.info_rank("2D-poly-filtering disabled", comm=world_comm)
+
+    if ops.common_mode_filter.enabled:
+        ops.common_mode_filter.apply(data)
+        log.info_rank("Finished common-mode-filtering in", comm=world_comm, timer=timer)
+    else:
+        log.info_rank("common-mode-filtering disabled", comm=world_comm)
+
+    ops.mem_count.prefix = "After filtering"
+    ops.mem_count.apply(data)
+
+    # The map maker requires the binning operators used for the solve and final,
+    # the templates, and the noise model.
+
+    ops.mapmaker.binning = ops.binner
+
+    tmpls.baselines.noise_model = noise_model
+
+    ops.mapmaker.template_matrix = toast.ops.TemplateMatrix(
+        templates=[tmpls.baselines,]
+    )
+    ops.mapmaker.map_binning = ops.binner_final
+    ops.mapmaker.det_data = defaults.det_data
+    ops.mapmaker.output_dir = args.out_dir
+    if ops.mapmaker.enabled:
+        log.info_rank("Begin generalized destriping map-maker", comm=world_comm)
+        # if not tmpls.baselines.enabled and not tmpls.fourier.enabled:
+        if not tmpls.baselines.enabled:
+            log.info_rank(
+                "  No solver templates are enabled- only making a binned map",
+                comm=world_comm,
+            )
+        ops.mapmaker.apply(data)
+        log.info_rank("Finished generalized destriper in", comm=world_comm, timer=timer)
+        ops.mem_count.prefix = "After generalized destriping map-maker"
+        ops.mem_count.apply(data)
+    else:
+        log.info_rank("Generalized destriping map-maker disabled", comm=world_comm)
+
+    ops.filterbin.binning = ops.binner_final
+    ops.filterbin.det_data = defaults.det_data
+    ops.filterbin.output_dir = args.out_dir
+    if ops.filterbin.enabled:
+        log.info_rank(
+            "Begin simultaneous filter/bin map-maker and observation matrix",
+            comm=world_comm,
+        )
+        ops.filterbin.apply(data)
+        ops.mem_count.prefix = "After simultaneous filter/bin map-maker"
+        ops.mem_count.apply(data)
+    else:
+        log.info_rank("Simultaneous filter/bin map-maker disabled", comm=world_comm)
+
+    if ops.mlmapmaker.enabled:
+        log.info_rank(
+            "Begin ML map-maker",
+            comm=world_comm,
+        )
+        ops.mlmapmaker.apply(data)
+        log.info_rank("Finished ML map-making in", comm=world_comm, timer=timer)
+    else:
+        log.info_rank("ML map-maker disabled", comm=world_comm)
+
+    # Collect signal statistics after filtering/destriping
+
+    ops.filtered_statistics.output_dir = args.out_dir
+    if ops.filtered_statistics.enabled:
+        ops.filtered_statistics.apply(data)
+        log.info_rank("Calculated filtered statistics in", comm=world_comm, timer=timer)
+        ops.mem_count.prefix = "After filtered statistics"
+        ops.mem_count.apply(data)
+    else:
+        log.info_rank("Filtered statistics disabled", comm=world_comm)
+
+
+def main():
+    env = toast.utils.Environment.get()
+    log = toast.utils.Logger.get()
+    gt = toast.timing.GlobalTimers.get()
+    gt.start("toast_so_map (total)")
+    timer0 = toast.timing.Timer()
+    timer0.start()
+
+    # Get optional MPI parameters
+    comm, procs, rank = toast.get_world()
+
+    if "OMP_NUM_THREADS" in os.environ:
+        nthread = os.environ["OMP_NUM_THREADS"]
+    else:
+        nthread = 1
+    log.info_rank(
+        f"Executing workflow with {procs} MPI tasks, each with "
+        f"{nthread} OpenMP threads at {datetime.datetime.now()}",
+        comm,
+    )
+
+    mem = toast.utils.memreport(msg="(whole node)", comm=comm, silent=True)
+    log.info_rank(f"Start of the workflow:  {mem}", comm)
+
+    # The operators we want to configure from the command line or a parameter file.
+    # We will use other operators, but these are the ones that the user can configure.
+    # The "name" of each operator instance controls what the commandline and config
+    # file options will be called.
+    #
+    # We can also set some default values here for the traits, including whether an
+    # operator is disabled by default.
+
+    operators = [
+        toast.ops.PointingDetectorSimple(name="det_pointing_azel", quats="quats_azel"),
+        toast.ops.PointingDetectorSimple(
+            name="det_pointing_radec", quats="quats_radec"
+        ),
+        toast.ops.StokesWeights(
+            name="weights_azel", weights="weights_azel", mode="IQU"
+        ),
+        toast.ops.StokesWeights(name="weights_radec", mode="IQU"),
+        toast.ops.PixelsHealpix(
+            name="pixels_healpix_radec",
+            enabled=False,
+        ),
+        toast.ops.PixelsWCS(
+            name="pixels_wcs_radec",
+            project="CAR",
+            resolution=(0.005 * u.degree, 0.005 * u.degree),
+            auto_bounds=True,
+            enabled=True,
+        ),
+        toast.ops.PixelsWCS(
+            name="pixels_wcs_azel",
+            project="CAR",
+            resolution=(0.05 * u.degree, 0.05 * u.degree),
+            auto_bounds=True,
+            enabled=False,
+        ),
+        toast.ops.NoiseEstim(
+            name="noise_estim",
+            out_model="estimated_noise",
+            enabled=False,
+        ),
+        toast.ops.FitNoiseModel(
+            name="noise_fit",
+            noise_model="estimated_noise",
+            out_model="estimated_noise_fit",
+            enabled=False,
+        ),
+        toast.ops.FlagSSO(name="flag_sso", enabled=False),
+        so_ops.Hn(name="h_n", enabled=False),
+        toast.ops.CadenceMap(name="cadence_map", enabled=False),
+        toast.ops.CrossLinking(name="crosslinking", enabled=False),
+        toast.ops.Statistics(name="raw_statistics", enabled=False),
+        toast.ops.TimeConstant(
+            name="deconvolve_time_constant", deconvolve=True, enabled=False
+        ),
+        toast.ops.GroundFilter(name="groundfilter", enabled=False),
+        toast.ops.PolyFilter(name="polyfilter1D", enabled=False),
+        toast.ops.PolyFilter2D(name="polyfilter2D", enabled=False),
+        toast.ops.CommonModeFilter(name="common_mode_filter", enabled=False),
+        toast.ops.Statistics(name="filtered_statistics", enabled=False),
+        toast.ops.BinMap(name="binner", pixel_dist="pix_dist"),
+        toast.ops.MapMaker(name="mapmaker"),
+        toast.ops.PixelsHealpix(name="pixels_healpix_radec_final", enabled=False),
+        toast.ops.PixelsWCS(name="pixels_wcs_radec_final", enabled=False),
+        toast.ops.PixelsWCS(name="pixels_wcs_azel_final", enabled=False),
+        toast.ops.BinMap(
+            name="binner_final", enabled=False, pixel_dist="pix_dist_final"
+        ),
+        toast.ops.FilterBin(name="filterbin", enabled=False),
+        so_ops.MLMapmaker(name="mlmapmaker", enabled=False, comps="TQU"),
+        toast.ops.MemoryCounter(name="mem_count", enabled=False),
+    ]
+
+    # Templates we want to configure from the command line or a parameter file.
+    templates = [
+        toast.templates.Offset(name="baselines", enabled=False),
+        # toast.templates.Fourier2D(name="fourier", enabled=False),
+    ]
+
+    # Parse options
+    config, args, jobargs = parse_config(operators, templates, comm)
+
+    # Instantiate our operators and get the size of the process groups
+    job, group_size, full_pointing = job_create(config, comm)
+
+    # Create the toast communicator
+    toast_comm = toast.Comm(world=comm, groupsize=group_size)
+
+    # Load one or more observations
+    data = load_data(job, args, toast_comm)
+
+    # Reduce the data
+    reduce_data(job, args, data)
+
+    # Collect optional timing information
+    alltimers = toast.timing.gather_timers(comm=toast_comm.comm_world)
+    if toast_comm.world_rank == 0:
+        out = os.path.join(args.out_dir, "timing")
+        toast.timing.dump(alltimers, out)
+
+    log.info_rank("Workflow completed in", comm=comm, timer=timer0)
+
+
+if __name__ == "__main__":
+    world, procs, rank = toast.mpi.get_world()
+    with toast.mpi.exception_guard(comm=world):
+        main()


### PR DESCRIPTION
* Use new xi/eta/gamma support in toast when simulating detector layout.

* Fix projected LAT rotation on the sky, and also the tube positions.

* Add LAT co-rotation options when making focalplane plots.

* Support focalplane plots in both Xi / Eta and X / Y coordinates.

* Cache detector beams in SimSSO and SimSource, in case we have the same beam for many detectors.

* Small tweaks to get_wafer_offsets arguments

* Add a new toast workflow that just loads data and reduces it.