### PR TITLE
Add smurf timestamps

### DIFF
--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -2157,7 +2157,7 @@ def _get_timestamps(streams, load_type=None, linearize_timestamps=True):
         # offset between EPICS time referenced to 1990 relative to UNIX time.
         counter2 = s + ns*1e-9 + 5*(4*365 - 1)*24*60*60
         counter0 = io_load.hstack_into(None,streams["primary"]["Counter0"])
-        timestamps = round(counter2 - (counter0 / 480000) ) + counter0 / 480000
+        timestamps = np.round(counter2 - (counter0 / 480000) ) + counter0 / 480000
         return timestamps
     if load_type == TimingParadigm.SmurfUnixTime:
         timestamps = io_load.hstack_into(None, streams["primary"]["UnixTime"]) / 1e9

--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -2140,8 +2140,8 @@ def _get_timestamps(streams, load_type=None, linearize_timestamps=True):
         # determine the desired loading type. Expand as logic as
         # data fields develop
         if "primary" in streams:
-            if np.diff(io_load.hstack_into(None,
-                                streams["primary"]["Counter0"])).mean() != 0:
+            if np.abs(np.diff(io_load.hstack_into(None,
+                                streams["primary"]["Counter0"]))).mean() != 0:
                 load_type = TimingParadigm.TimingSystem
             elif "UnixTime" in streams["primary"]:
                 load_type = TimingParadigm.SmurfUnixTime
@@ -2155,7 +2155,7 @@ def _get_timestamps(streams, load_type=None, linearize_timestamps=True):
                                 streams["primary"]["Counter2"]))
         # Add 20 years in seconds (accounting for leap years) to handle
         # offset between EPICS time referenced to 1990 relative to UNIX time.
-        counter2 = s + ns*1e-9 + 5*(4*365 - 1)*24*60*60
+        counter2 = s + ns*1e-9 + 5*(4*365 + 1)*24*60*60
         counter0 = io_load.hstack_into(None,streams["primary"]["Counter0"])
         timestamps = np.round(counter2 - (counter0 / 480000) ) + counter0 / 480000
         return timestamps

--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -2140,7 +2140,8 @@ def _get_timestamps(streams, load_type=None, linearize_timestamps=True):
         # determine the desired loading type. Expand as logic as
         # data fields develop
         if "primary" in streams:
-            if np.diff(streams["primary"]["Counter0"]) != 0:
+            if np.diff(io_load.hstack_into(None,
+                                streams["primary"]["Counter0"])).mean() != 0:
                 load_type = TimingParadigm.TimingSystem
             elif "UnixTime" in streams["primary"]:
                 load_type = TimingParadigm.SmurfUnixTime
@@ -2150,11 +2151,12 @@ def _get_timestamps(streams, load_type=None, linearize_timestamps=True):
             load_type = TimingParadigm.G3Timestream
 
     if load_type == TimingParadigm.TimingSystem:
-        s, ns = split_ts_bits(streams["primary"]["Counter2"])
+        s, ns = split_ts_bits(io_load.hstack_into(None,
+                                streams["primary"]["Counter2"]))
         # Add 20 years in seconds (accounting for leap years) to handle
         # offset between EPICS time referenced to 1990 relative to UNIX time.
         counter2 = s + ns*1e-9 + 5*(4*365 - 1)*24*60*60
-        counter0 = streams["primary"]["Counter0"]
+        counter0 = io_load.hstack_into(None,streams["primary"]["Counter0"])
         timestamps = round(counter2 - (counter0 / 480000) ) + counter0 / 480000
         return timestamps
     if load_type == TimingParadigm.SmurfUnixTime:


### PR DESCRIPTION
Added in functionality to process the high quality timing words from the Smurf timing system. I tested this on some data we took on when we were testing the timing system at 4kHz as below:
```
aman = load_smurf.load_file('/mnt/so1/data/ucsd-sat1/timestreams/16505/crate1slot3/1650583410_000.g3')
plt.plot(aman.timestamps, aman.primary['UnixTime'])
plt.xlabel('SMuRF EPICS Timestamps', fontsize = 16)
plt.ylabel('UNIX Timestamps', fontsize = 16)
```
![Test_SMuRF_Timestamps](https://user-images.githubusercontent.com/25913911/195230728-79b0b842-0d9f-4268-805e-73a477b793e0.png)

This data had the PPS level triggered not edge triggered (clearly visible in the plot) and the data wasn't downsampled so this should be tested on the data from SAT1 where these two issues are fixed