### PR TITLE
Have update_hwp_angle find it's own files.

### DIFF
--- a/docs/hwp.rst
+++ b/docs/hwp.rst
@@ -24,18 +24,12 @@ We can include a time range + data path or a full-path file list of input g3 dat
 Here's an annotated example of yaml config file:
 
 .. code-block:: yaml
-  
-  # start and end time for `update_hwp_angle.load_data` 
-  start: 1618369921
-  end: 1618373521
 
-  # path to L2 HK directory 
-  data_dir: '/mnt/so1/data/ucsd-sat1/hk/'
-   
-  # input file name for `update_hwp_angle.load_file` 
-  file_list:
-  - '/mnt/so1/data/ucsd-sat1/hk/16183/1618383667.g3'
-  - '/mnt/so1/data/ucsd-sat1/hk/16183/1618372860.g3'
+  # path to L2 HK directory
+  data_dir: '/data/prefix/hk/'
+
+  # path to L2.5 HK directory
+  output_dir: '/path/to/save/files/'
 
   # prefix of field name
   field_instance: 'observatory.HBA.feeds.HWPEncoder'
@@ -65,9 +59,6 @@ Here's an annotated example of yaml config file:
   # Search range of reference slot
   ref_range: 0.1
 
-  # path+filename of output g3 file
-  output: output.g3
-   
  
 
 Data Loading 


### PR DESCRIPTION
I've changed around the update hwp angle script to make it find it's own files instead of just running on a single file. The script looks through the `data_dir` and compares the file names to the `output_dir`. All existing files except the last one are assumed to have been complete and ignored. 

I tested this as data was actively coming in for P10r1, so I think this is a stable enough solution for now. 

I have a new config file shared at `/mnt/so1/shared/site-pipeline/data_pkg/p10r1/update_hwp_angle.yaml` and updated in the docs. This might break some of the usages in `G3tHWP` but I don't _think_ it will break how people have been interactively using it. 

@yukisakurai  could you please make sure I didn't do anything stupid? Will this still work for you?

@guanyilun  I think this is good enough to start trying to run it off prefect for p10r1. 