### PR TITLE
HWP angle calculator with quad enable option

### DIFF
--- a/docs/axisman.rst
+++ b/docs/axisman.rst
@@ -227,12 +227,13 @@ Pointing information required for :mod:`sotodlib.coords`.
 * | ``boresight_equ`` `[samps]` - AxisManager with boresight in equitorial
   |  coordinates.
 
+
 HWP information 
 
 * | ``hwp_angle`` `[samps]` - AxisManager with hwp rotation angle required for
   | :mod:`sotodlib.io.g3tsmurf_utils.load_hwp_data`
 * | ``hwpss_ext`` `[dets, samps]` - the fields of extracted HWP synchronous signal
-  | required for :mod:`sotodlib.hwp.extract_hwpss`
+  | derived from :mod:`sotodlib.hwp.extract_hwpss`
 
 ---------
 Reference

--- a/docs/axisman.rst
+++ b/docs/axisman.rst
@@ -227,6 +227,13 @@ Pointing information required for :mod:`sotodlib.coords`.
 * | ``boresight_equ`` `[samps]` - AxisManager with boresight in equitorial
   |  coordinates.
 
+HWP information 
+
+* | ``hwp_angle`` `[samps]` - AxisManager with hwp rotation angle required for
+  | :mod:`sotodlib.io.g3tsmurf_utils.load_hwp_data`
+* | ``hwpss_ext`` `[dets, samps]` - the fields of extracted HWP synchronous signal
+  | required for :mod:`sotodlib.hwp.extract_hwpss`
+
 ---------
 Reference
 ---------

--- a/docs/hwp.rst
+++ b/docs/hwp.rst
@@ -59,6 +59,8 @@ Here's an annotated example of yaml config file:
   # Search range of reference slot
   ref_range: 0.1
 
+  # Boolian to enable quad (rotation direction)
+  enable_quad: True
  
 
 Data Loading 

--- a/docs/hwp.rst
+++ b/docs/hwp.rst
@@ -59,8 +59,10 @@ Here's an annotated example of yaml config file:
   # Search range of reference slot
   ref_range: 0.1
 
-  # Boolian to enable quad (rotation direction)
-  enable_quad: True
+  # force to quad value
+  # 0: use measured quad value (default)
+  # 1: positive rotation direction, -1: negative rotation direction
+  force_quad: 0
  
 
 Data Loading 

--- a/sotodlib/hwp/g3thwp.py
+++ b/sotodlib/hwp/g3thwp.py
@@ -99,7 +99,7 @@ class G3tHWP():
         self._enable_quad = True
         if 'enable_quad' in self.configs.keys():
             self._enable_quad = self.configs['enable_quad']
-
+        
         # Output path + filename
         self._output = None
         if 'output' in self.configs.keys():
@@ -713,7 +713,8 @@ class G3tHWP():
                 fill_value='extrapolate')(
                 self._time),
             interp=True)
-        direction = list(map(lambda x: 1 if x == 0 else -1, quad))
+        direction = 1
+        if self._enable_quad: direction = list(map(lambda x: 1 if x == 0 else -1, quad))
         self._angle = direction * \
             (self._encd_cnt - self._ref_cnt[0]
              ) * self._delta_angle % (2 * np.pi)

--- a/sotodlib/hwp/g3thwp.py
+++ b/sotodlib/hwp/g3thwp.py
@@ -100,9 +100,9 @@ class G3tHWP():
         # 1: positive rotation direction, -1: negative rotation direction
         self._force_quad = 0
         if 'force_quad' in self.configs.keys():
-            self._force_quad = self.configs['force_quad']
-        print (self._force_quad)
-        if self._force_quad !=0 or abs(self._force_quad) != 1:
+            self._force_quad = int(self.configs['force_quad'])
+        
+        if np.abs(self._force_quad) > 1:
             logger.error("force_quad in config file must be 0 or 1 or -1")
             sys.exit(1)
         # Output path + filename

--- a/sotodlib/hwp/g3thwp.py
+++ b/sotodlib/hwp/g3thwp.py
@@ -99,7 +99,7 @@ class G3tHWP():
         self._enable_quad = True
         if 'enable_quad' in self.configs.keys():
             self._enable_quad = self.configs['enable_quad']
-        
+
         # Output path + filename
         self._output = None
         if 'output' in self.configs.keys():

--- a/sotodlib/hwp/g3thwp.py
+++ b/sotodlib/hwp/g3thwp.py
@@ -95,6 +95,11 @@ class G3tHWP():
         if 'slit_width_lim' in self.configs.keys():
             self._slit_width_lim = self.configs['slit_width_lim']
 
+        # Boolean to enable quad
+        self._enable_quad = True
+        if 'enable_quad' in self.configs.keys():
+            self._enable_quad = self.configs['enable_quad']
+
         # Output path + filename
         self._output = None
         if 'output' in self.configs.keys():
@@ -617,6 +622,10 @@ class G3tHWP():
             print(
                 'WARNING: can not find reference points, please adjust ratio parameter!')
             sys.exit(1)
+
+        ## delete unexpected ref slit indexes ##
+        self._ref_indexes = np.delete(self._ref_indexes, np.where(np.diff(self._ref_indexes) < self._num_edges-10)[0])
+
         self._ref_clk = np.take(self._encd_clk, self._ref_indexes)
         self._ref_cnt = np.take(self._encd_cnt, self._ref_indexes)
         logger.debug('found {} reference points'.format(

--- a/sotodlib/hwp/g3thwp.py
+++ b/sotodlib/hwp/g3thwp.py
@@ -95,11 +95,16 @@ class G3tHWP():
         if 'slit_width_lim' in self.configs.keys():
             self._slit_width_lim = self.configs['slit_width_lim']
 
-        # Boolean to enable quad
-        self._enable_quad = True
-        if 'enable_quad' in self.configs.keys():
-            self._enable_quad = self.configs['enable_quad']
-
+        # force to quad value
+        # 0: use readout quad value (default)
+        # 1: positive rotation direction, -1: negative rotation direction
+        self._force_quad = 0
+        if 'force_quad' in self.configs.keys():
+            self._force_quad = self.configs['force_quad']
+        print (self._force_quad)
+        if self._force_quad !=0 or abs(self._force_quad) != 1:
+            logger.error("force_quad in config file must be 0 or 1 or -1")
+            sys.exit(1)
         # Output path + filename
         self._output = None
         if 'output' in self.configs.keys():
@@ -713,8 +718,9 @@ class G3tHWP():
                 fill_value='extrapolate')(
                 self._time),
             interp=True)
-        direction = 1
-        if self._enable_quad: direction = list(map(lambda x: 1 if x == 0 else -1, quad))
+        if self._force_quad == 0:
+            direction = list(map(lambda x: 1 if x == 0 else -1, quad))
+        else: direction = self._force_quad 
         self._angle = direction * \
             (self._encd_cnt - self._ref_cnt[0]
              ) * self._delta_angle % (2 * np.pi)


### PR DESCRIPTION
There is a hardware issue that makes frequently flipping quad value (rotation direction) in P10R1. This PR adds an option to enable quad or not in config file. This option should be basically on if hwp readout is working correctly, but it is useful for lab. testing and debug.
You need to include `enable_quad: False` to config yaml file if you want to turn off it.
Also I modified reference slit finding module to fix hwp_rate and updated docs.  
(This PR has been overwritten from RP#315.)

**Angle solution**
![image](https://user-images.githubusercontent.com/10991568/197772440-e99c6414-1269-4dc4-860c-11b378199ba9.png)
![image](https://user-images.githubusercontent.com/10991568/197772393-da2c7114-d85b-4196-9e2d-31a9e42060bc.png)
**hwp_rate**
![image](https://user-images.githubusercontent.com/10991568/197771400-fb447108-3bf7-4e3a-878a-db2ce393cc0b.png)
![image](https://user-images.githubusercontent.com/10991568/197771525-b8b9d42c-e3b3-4f01-8709-647ca4069e63.png)
