### PR TITLE
Change default concatenation behavior for AxisManagers

### DIFF
--- a/sotodlib/core/axisman.py
+++ b/sotodlib/core/axisman.py
@@ -430,7 +430,7 @@ class AxisManager:
           target axis).
 
         """
-        assert other_fields in ['exact','fail', 'first', 'drop']
+        assert other_fields in ['exact', 'fail', 'first', 'drop']
         if not isinstance(axis, str):
             axis = list(items[0]._axes.keys())[axis]
         fields = []

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -185,15 +185,37 @@ class TestAxisManager(unittest.TestCase):
 
         # Handling of array that does not share the axis?
         amanA.wrap_new('azimuth', shape=('samps',))[:] = 1.
-        amanB.wrap_new('azimuth', shape=('samps',))[:] = 2.
+        amanB.wrap_new('azimuth', shape=('samps',))[:] = 1.
 
-        # ... other_fields="fail"
+        # ... other_fields="exact"
+        aman = core.AxisManager.concatenate([amanA, amanB], axis='dets')
+        
+        # ... other_fields="exact"
+        amanB.azimuth[:] = 2.
         with self.assertRaises(ValueError):
             aman = core.AxisManager.concatenate([amanA, amanB], axis='dets')
+        
+        # ... other_fields="exact"
+        amanB.move("azimuth",None)
+        amanB.wrap("azimuth", np.array([43,5,2,3]))
+        with self.assertRaises(ValueError):
+            aman = core.AxisManager.concatenate([amanA, amanB], axis='dets')
+        
+        # ... other_fields="fail"
+        amanB.move("azimuth",None)
+        amanB.wrap_new('azimuth', shape=('samps',))[:] = 2.
+        with self.assertRaises(ValueError):
+            aman = core.AxisManager.concatenate([amanA, amanB], axis='dets',
+                                               other_fields='fail')
+        amanB.azimuth[:] = 1.
+        with self.assertRaises(ValueError):
+            aman = core.AxisManager.concatenate([amanA, amanB], axis='dets',
+                                               other_fields='fail')
 
         # ... other_fields="drop"
+        amanB.azimuth[:] = 2.
         aman = core.AxisManager.concatenate([amanA, amanB], axis='dets',
-                                            other_fields='drop')
+                                            other_fields="drop")
         self.assertNotIn('azimuth', aman)
 
         # ... other_fields="first"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -190,13 +190,18 @@ class TestAxisManager(unittest.TestCase):
         # ... other_fields="exact"
         aman = core.AxisManager.concatenate([amanA, amanB], axis='dets')
         
+        ## add scalars
+        amanA.wrap("ans", 42)
+        amanB.wrap("ans", 42)
+        aman = core.AxisManager.concatenate([amanA, amanB], axis='dets')
+        
         # ... other_fields="exact"
         amanB.azimuth[:] = 2.
         with self.assertRaises(ValueError):
             aman = core.AxisManager.concatenate([amanA, amanB], axis='dets')
         
-        # ... other_fields="exact"
-        amanB.move("azimuth",None)
+        # ... other_fields="exact" and arrays of different shapes
+        amanB.move("azimuth", None)
         amanB.wrap("azimuth", np.array([43,5,2,3]))
         with self.assertRaises(ValueError):
             aman = core.AxisManager.concatenate([amanA, amanB], axis='dets')


### PR DESCRIPTION
I would really like to change the default behavior of AxisManager concatenation because the current behavior is causing issues for what I'd like to save in my todo pre-processing scripts. Effectively I have a script that saves an AxisManager with `dets` and `dets,samps` fields along with an additional field aligned just along `samps` that I'd like to have available later through the metadata loading. 

When I try and load these the [loader is calling concatenate](https://github.com/simonsobs/sotodlib/blob/master/sotodlib/core/metadata/loader.py#L285) on them and the presence of the `samps` only field is causing an error. I don't think we can change the default behavior of the loader because it's able to call concatenate on AxisManagers, ResultSets, and numpy arrays. So instead I'd like to change AxisManager.concatenate. 

This PR adds a fourth option for what to do with fields we aren't concatenating along called `'exact'`. The idea is if the field is identical across all of the items we'll just add it to the new AxisManager. I added a bunch of test cases to make sure it was working for as many of the cases I think of, and it seems to all work. It deals with scalars and anything that has a `.shape` property. 