### PR TITLE
Create dependabot config for actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This configures dependabot to automatically check and update the versions of reused github actions, i.e. `actions/checkout`.

This was motivated when I recently noticed in the Actions logs a bunch of warnings related to `actions/checkout` and `actions/setup-python`, which are both out of date.

I've used dependabot on several other repos and find it really helpful, it'll automatically create a PR to update actions to the latest version when one becomes available. It can automatically request reviews from a list of users if desired as well, though I've left that off for now.