### PR TITLE
Adds obs and oper tags to obs_ids

### DIFF
--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -700,9 +700,9 @@ class G3tSmurf:
                     break
 
             if calibration:
-                obs_id=f"cal_{stream_id}_{session_id}"
+                obs_id=f"oper_{stream_id}_{session_id}"
             else:
-                obs_id=f"{stream_id}_{session_id}"
+                obs_id=f"obs_{stream_id}_{session_id}"
 
             # Build Observation
             obs = Observations(


### PR DESCRIPTION
Closes https://github.com/simonsobs/sotodlib/issues/327, changing the obs_id for operations to have `oper` instead of `cal` prepended, and also prepends `obs` to the observation obs_ids.

Do we need a database update script for this?