### PR TITLE
When running unit tests, cleanup MPI communicators.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,7 @@ jobs:
           python3 -m pip install --upgrade wheel
           python3 -m pip install mpi4py
           python3 -m pip install so3g
+          python3 -m pip install pshmem
           python3 -m pip install --pre toast
 
       - name: Install sotodlib

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -78,6 +78,34 @@ def create_outdir(subdir=None, comm=None):
     return retdir
 
 
+def close_data_and_comm(data):
+    """Delete a toast data object AND the input Comm.
+
+    Multiple toast.Data objects can be created from a single toast.Comm,
+    and so the communicators are not freed when deleting the data object.
+    However for unit tests we frequently use a helper function to produce
+    a simulated dataset and then want to fully clean up that along with
+    the communicators that were used.  This is especially true on CI
+    services where repeatedly creating communicators without cleanup seem
+    to cause sporadic deadlocks.  This is a convenience function which
+    does that cleanup.
+
+    Args:
+        data (toast.Data):  The input data object
+
+    Returns:
+        None
+
+    """
+    cm = data.comm
+    if cm.comm_world is not None:
+        cm.comm_world.barrier()
+    data.clear()
+    del data
+    cm.close()
+    del cm
+
+
 # FIXME:  PR #183 has additional helper functions for instrument classes.
 # Just use those once that is merged and delete this.
 def toast_site():

--- a/tests/test_sim_stimulator.py
+++ b/tests/test_sim_stimulator.py
@@ -18,7 +18,7 @@ try:
 except ImportError as e:
     toast_available = False
 
-from ._helpers import toast_site, calibration_schedule
+from ._helpers import toast_site, calibration_schedule, close_data_and_comm
 
 
 class SimStimulatorTest(unittest.TestCase):
@@ -62,6 +62,8 @@ class SimStimulatorTest(unittest.TestCase):
         sim_ground.apply(data)
 
         so_ops.SimStimulator(name="sim_stimulator").apply(data)
+
+        close_data_and_comm(data)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_sim_wiregrid.py
+++ b/tests/test_sim_wiregrid.py
@@ -18,7 +18,7 @@ try:
 except ImportError as e:
     toast_available = False
 
-from ._helpers import toast_site, calibration_schedule
+from ._helpers import toast_site, calibration_schedule, close_data_and_comm
 
 
 class SimWireGridTest(unittest.TestCase):
@@ -80,6 +80,8 @@ class SimWireGridTest(unittest.TestCase):
             wiregrid_angular_speed=10.0*u.degree/u.second,
             wiregrid_angular_acceleration=0.1*u.degree/u.second**2,
         ).apply(data)
+
+        close_data_and_comm(data)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This ensures that all communicators are cleaned up at the end of each unit test.  This seems to be needed on github CI services to avoid a deadlock when running MPI-enabled tests.