### PR TITLE
Add mod2pi option and fix handling of encoder instance name 

### DIFF
--- a/sotodlib/hwp/g3thwp.py
+++ b/sotodlib/hwp/g3thwp.py
@@ -803,7 +803,6 @@ class G3tHWP():
         if mod2pi:
             self._angle = self._angle % (2 * np.pi)
 
-        ii = np.where(np.diff(self._ref_indexes) != 1140)[0]
         return
 
     def _find_dropped_packets(self):


### PR DESCRIPTION
1
Fixed the default instance of `load_data` from `HAB` to None.

The instance name should be initialized by config.yaml, default values, or explicitly specified in load_data function.
Therefore the following error looks unnecessary.
> else:
>             logger.error("Can not find field instance")
>             return {}

2
Added mod2pi option to the `g3thwp.analyze`
I added this option because the monotonically increasing hwp angle is useful for evaluating hwp angle jitter.