### PR TITLE
fix hwp ref index

### DIFF
--- a/sotodlib/hwp/g3thwp.py
+++ b/sotodlib/hwp/g3thwp.py
@@ -655,7 +655,7 @@ class G3tHWP():
             n += (self._num_edges - 2)
             if n >= len(diff):
                 break
-        offset = 0
+        offset = 1
         # Conditions for idenfitying the ref slit
         # Slit distance somewhere between 2 slits:
         # 2 slit distances (defined above) +/- 10%


### PR DESCRIPTION
I found a bug in the hwp angle calculation and fixed it.
The ecoder ref_index is shifted by 1 and this is making an angle glitch once in one hwp revolution.
Please see the following notebook for the difference after debug.

https://gist.github.com/ykyohei/54f91be27dc9bf180dc7d6d196014b5f