### PR TITLE
Fix det info multicast

### DIFF
--- a/docs/context.rst
+++ b/docs/context.rst
@@ -849,32 +849,24 @@ contain only the ``obs_id``.  For each item in the context.yaml
 Changing det_info
 -----------------
 
-Metadata entries can be used to change the active ``det_info`` table
-that is used to screen and match metadata results.  This is
-accomplished through special metadata entries with the following
-syntax::
+Metadata entries can be used to augment the  ``det_info`` table
+that is used to screen and match metadata results.  For example::
 
   metadata:
   - ...
   - db: 'more_det_info.sqlite'
     det_info: true
-    det_key: 'dets:name'
   - ...
 
-The boolean ``'det_info': true`` marks this as a special metadata
-entry to update ``det_info``.  The ``det_key`` entry specifies what
-column of the loaded metadata should be used as the index to add the
-information to the existing tracked ``det_info``; that key should
-exist in both the active ``det_info`` and in the result that is loaded
-here.
+The boolean ``'det_info': true`` marks the above as a special metadata
+entry to update ``det_info``.  It is expected that the database
+(``more_det_info.sqlite``) is a standard ManifestDb, which will be
+queried in the usual way except that when we get to the "Wrap
+Metadata" step, instead the following is performed:
 
-It is expected that ``more_det_info.sqlite`` is a standard ManifestDb,
-which will be queried in the usual way except that when we get to the
-"Wrap Metadata" step, instead the following is performed:
-
-  - The index field identified by ``det_key`` is looked up in the
-    current active ``det_info`` (after removing the dets: prefix) and
-    in the new metadata object (with prefix intact).
+  - An index field will be identified in the current active
+    ``det_info`` -- it can be either ``dets:readout_id`` or
+    ``dets:det_id`` -- to match against the new metadata.
   - The columns from the new metadata are merged into the active
     ``det_info``, ensuring that the index field values correspond.
   - Only the rows for which the index field has the same value in the
@@ -882,7 +874,23 @@ which will be queried in the usual way except that when we get to the
 
 As subsequent metadata are processed, they can match against any
 fields that have been added to ``det_info`` by preceding entries in
-the metadata list.
+the metadata list.  However, currently it is only possible to augment
+``det_info`` using ``readout_id`` or ``det_id``.
+
+By default, ``readout_id`` / ``det_id`` are expected to be unique
+indices.  It is often useful to permit multiple matches, especially
+for the special value "NOT_FOUND" in ``det_id``.  To permit this, add
+'multi: true' to the metadata block.  For example::
+
+  metadata:
+  ...
+  - db: 'wafer_det_map.sqlite'   # the 'readout_id' -> 'det_id' mapping
+    det_info: true
+  - db: 'wafer_info.sqlite'      # the 'det_id' -> misc properties table
+    det_info: true
+    multi: true                  # Set multi=true if det_id=NOT_FOUND might
+                                 # need to be broadcast to multiple readout_id
+  ...
 
 
 ------------------------------------

--- a/sotodlib/core/context.py
+++ b/sotodlib/core/context.py
@@ -293,7 +293,7 @@ class Context(odict):
         if loader_type is None:
             loader_type = self.get('obs_loader_type', 'default')
         loader_func = OBSLOADER_REGISTRY[loader_type]  # Register your loader?
-        aman = loader_func(self.obsfiledb, obs_id, dets,
+        aman = loader_func(self.obsfiledb, obs_id, dets=dets,
                            samples=samples, no_signal=no_signal)
 
         if aman is None:

--- a/sotodlib/core/metadata/obsfiledb.py
+++ b/sotodlib/core/metadata/obsfiledb.py
@@ -239,7 +239,7 @@ class ObsFileDb:
 
         """
         c = self.conn.execute(
-            'select detsets.name as `dets:detset`, det as `dets:readout_id`'
+            'select distinct detsets.name as `dets:detset`, det as `dets:readout_id`'
             'from detsets join files '
             'on files.detset=detsets.name where obs_id=?', (obs_id, ))
         return ResultSet.from_cursor(c)

--- a/sotodlib/core/util.py
+++ b/sotodlib/core/util.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-def get_coindices(v0, v1):
+def get_coindices(v0, v1, check_unique=False):
     """Given vectors v0 and v1, each of which contains no duplicate
     values, determine the elements that are found in both vectors.
     Returns (vals, i0, i1), i.e. the vector of common elements and
@@ -12,7 +12,14 @@ def get_coindices(v0, v1):
     but rather the elements will appear in the same order that they
     were found in v0 (so that i0 is strictly increasing).
 
+    The behavior is undefined if either v0 or v1 contain duplicates.
+    Pass check_unique=True to assert that condition.
+
     """
+    if check_unique:
+        assert(len(set(v0)) == len(v0))
+        assert(len(set(v1)) == len(v1))
+
     try:
         vals, i0, i1 = np.intersect1d(v0, v1, return_indices=True)
         order = np.argsort(i0)

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -79,12 +79,12 @@ class ContextTest(unittest.TestCase):
         n = len(dataset_sim.dets)
         obs_id = dataset_sim.obss['obs_id'][1]
         for selection, count in [
-                ({'dets:readout_id': ['det05']}, 1),
-                ({'dets:readout_id': np.array(['det05'])}, 1),
+                ({'dets:readout_id': ['read05']}, 1),
+                ({'dets:readout_id': np.array(['read05'])}, 1),
                 ({'dets:detset': 'neard'}, 4),
                 ({'dets:detset': ['neard']}, 4),
                 ({'dets:detset': ['neard', 'fard']}, 8),
-                ({'dets:detset': ['neard'], 'dets:readout_id': ['det00', 'det05']}, 1),
+                ({'dets:detset': ['neard'], 'dets:readout_id': ['read00', 'read05']}, 1),
                 ({'dets:band': ['f090']}, 4),
                 ({'dets:band': ['f090'], 'dets:detset': ['neard']}, 2),
         ]:
@@ -188,15 +188,16 @@ class DatasetSim:
     """
     def __init__(self):
         self.dets = metadata.ResultSet(
-            ['readout_id', 'band', 'pol_code', 'x', 'y', 'detset'],
-            [('det00', 'f090', 'A', 0.0, 0.0, 'neard'),
-             ('det01', 'f090', 'B', 0.0, 0.0, 'neard'),
-             ('det02', 'f150', 'A', 0.0, 0.0, 'neard'),
-             ('det03', 'f150', 'B', 0.0, 0.0, 'neard'),
-             ('det04', 'f090', 'A', 1.0, 0.0, 'fard'),
-             ('det05', 'f090', 'B', 1.0, 0.0, 'fard'),
-             ('det06', 'f150', 'A', 1.0, 0.0, 'fard'),
-             ('det07', 'f150', 'B', 1.0, 0.0, 'fard')])
+            ['readout_id', 'band', 'pol_code', 'x', 'y', 'detset', 'det_id', 'det_param'],
+            [('read00', 'f090', 'A', 0.0, 0.0, 'neard', 'det00', 120.),
+             ('read01', 'f090', 'B', 0.0, 0.0, 'neard', 'det01', 121.),
+             ('read02', 'f150', 'A', 0.0, 0.0, 'neard', 'det02', 122.),
+             ('read03', 'f150', 'B', 0.0, 0.0, 'neard', 'det03', 123.),
+             ('read04', 'f090', 'A', 1.0, 0.0, 'fard',  'det04', 124.), 
+             ('read05', 'f090', 'B', 1.0, 0.0, 'fard',  'det05', 125.),
+             ('read06', 'f150', 'A', 1.0, 0.0, 'fard',  'NOT_FOUND', -1.),
+             ('read07', 'f150', 'B', 1.0, 0.0, 'fard',  'NOT_FOUND', -1.),
+            ])
 
         self.obss = metadata.ResultSet(
             ['obs_id', 'timestamp', 'type', 'target'],
@@ -222,7 +223,7 @@ class DatasetSim:
                                     'pol_code string',
                                     'x float',
                                     'y float'])
-        save_for_later = ['band', 'detset']
+        save_for_later = ['band', 'detset', 'det_id', 'det_param']
         for row in self.dets.subset(keys=[k for k in self.dets.keys
                                           if k not in save_for_later]):
             detdb.add_props('base', row['readout_id'], **row)
@@ -312,7 +313,7 @@ class DatasetSim:
         ctx['metadata'] = [
             {'db': bands_db,
              'det_info': True,
-             'dets_key': 'readout_id'},
+            },
             {'db': abscal_db,
              'name': 'cal&abscal'},
             {'db': flags_db,

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -264,6 +264,24 @@ class DatasetSim:
             {'obs:timestamp': [0, 2e9], 'loader': 'unittest_loader'},
             'bands.h5')
 
+        # metadata: det_id.h5
+        _scheme = metadata.ManifestScheme() \
+                  .add_data_field('loader') \
+                  .add_range_match('obs:timestamp')
+        det_id_db = metadata.ManifestDb(scheme=_scheme)
+        det_id_db.add_entry(
+            {'obs:timestamp': [0, 2e9], 'loader': 'unittest_loader'},
+            'det_id.h5')
+
+        # metadata: det_param.h5
+        _scheme = metadata.ManifestScheme() \
+                  .add_data_field('loader') \
+                  .add_range_match('obs:timestamp')
+        det_par_db = metadata.ManifestDb(scheme=_scheme)
+        det_par_db.add_entry(
+            {'obs:timestamp': [0, 2e9], 'loader': 'unittest_loader'},
+            'det_param.h5')
+
         # metadata: abscals.h5
         _scheme = metadata.ManifestScheme() \
                   .add_range_match('obs:timestamp') \
@@ -314,12 +332,18 @@ class DatasetSim:
             {'db': bands_db,
              'det_info': True,
             },
+            {'db': det_id_db,
+             'det_info': True,
+            },
             {'db': abscal_db,
              'name': 'cal&abscal'},
             {'db': flags_db,
              'name': 'flags&'},
             {'db': info_db,
              'name': 'focal_plane'},
+#            {'db': det_par_db,
+#             'det_info': True,
+#            },
         ]
 
         if with_bad_metadata:
@@ -336,6 +360,17 @@ class DatasetSim:
         filename = os.path.split(kw['filename'])[1]
         if filename == 'bands.h5':
             rs = self.dets.subset(keys=['readout_id', 'band'])
+            rs.keys = ['dets:' + k for k in rs.keys]
+            return rs
+        elif filename == 'det_id.h5':
+            rs = self.dets.subset(keys=['readout_id', 'det_id'])
+            rs.keys = ['dets:' + k for k in rs.keys]
+            return rs
+        elif filename == 'det_param.h5':
+            rs = self.dets.subset(keys=['det_id', 'det_param'])
+            # Keep only 1 row with 'NOT_FOUND'
+            while sum(rs['det_id'] == 'NOT_FOUND') > 1:
+                rs.rows.pop(-1)
             rs.keys = ['dets:' + k for k in rs.keys]
             return rs
         elif filename == 'abscal.h5':

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -87,7 +87,7 @@ class ContextTest(unittest.TestCase):
                 ({'dets:detset': ['neard'], 'dets:readout_id': ['read00', 'read05']}, 1),
                 ({'dets:band': ['f090']}, 4),
                 ({'dets:band': ['f090'], 'dets:detset': ['neard']}, 2),
-                ({'dets:det_id': ['NOT_FOUND']}, 2),
+                ({'dets:det_id': ['NO_MATCH']}, 2),
         ]:
             meta = ctx.get_meta(obs_id, dets=selection)
             self.assertEqual(meta.dets.count, count, msg=f"{selection}")
@@ -149,9 +149,9 @@ class ContextTest(unittest.TestCase):
         for band, f in zip(tod.det_info['band'], tod.flags):
             # The f090 dets should have 0 flag intervals; f150 have 1
             self.assertEqual(len(f.ranges()), int(band == 'f150'))
-        # Check if NOT_FOUND det_id seemed to broadcast propertly ...
+        # Check if NO_MATCH det_id seemed to broadcast propertly ...
         self.assertEqual(list(tod.det_info['det_param'] == -1),
-                         list(dataset_sim.dets['det_id'] == 'NOT_FOUND'))
+                         list(dataset_sim.dets['det_id'] == 'NO_MATCH'))
 
         tod = ctx.get_obs(obs_id + ':f090')
         self.assertEqual(tod.signal.shape, (n_det // 2, n_samp))
@@ -196,10 +196,10 @@ class DatasetSim:
             [('read00', 'f090', 'A', 0.0, 0.0, 'neard', 'det00', 120.),
              ('read01', 'f090', 'B', 0.0, 0.0, 'neard', 'det01', 121.),
              ('read02', 'f150', 'A', 0.0, 0.0, 'neard', 'det02', 122.),
-             ('read03', 'f150', 'B', 0.0, 0.0, 'neard', 'NOT_FOUND', -1.),
+             ('read03', 'f150', 'B', 0.0, 0.0, 'neard', 'NO_MATCH', -1.),
              ('read04', 'f090', 'A', 1.0, 0.0, 'fard',  'det04', 124.), 
              ('read05', 'f090', 'B', 1.0, 0.0, 'fard',  'det05', 125.),
-             ('read06', 'f150', 'A', 1.0, 0.0, 'fard',  'NOT_FOUND', -1.),
+             ('read06', 'f150', 'A', 1.0, 0.0, 'fard',  'NO_MATCH', -1.),
              ('read07', 'f150', 'B', 1.0, 0.0, 'fard',  'det07', 127.),
             ])
 
@@ -373,9 +373,9 @@ class DatasetSim:
             return rs
         elif filename == 'det_param.h5':
             rs = self.dets.subset(keys=['det_id', 'det_param'])
-            # Keep only 1 row with 'NOT_FOUND'
-            while sum(rs['det_id'] == 'NOT_FOUND') > 1:
-                rs.rows.pop(list(rs['det_id']).index('NOT_FOUND'))
+            # Keep only 1 row with 'NO_MATCH'
+            while sum(rs['det_id'] == 'NO_MATCH') > 1:
+                rs.rows.pop(list(rs['det_id']).index('NO_MATCH'))
             rs.keys = ['dets:' + k for k in rs.keys]
             return rs
         elif filename == 'abscal.h5':


### PR DESCRIPTION
As mentioned in #346, det_info indices were enforced to be unique, which prevented broadcasting place-holder data using det_id='NOT_FOUND'.

This PR fixes that, tests it, and fixes a couple other minor things.

Check the docs for new context syntax... you want to set multi: true on the detector wafer info table, not the det_id-readout_id mapping input.