### PR TITLE
Bookbinder: Check for timing system

### DIFF
--- a/sotodlib/io/bookbinder.py
+++ b/sotodlib/io/bookbinder.py
@@ -15,7 +15,7 @@ def pos2vel(p):
     ----------
     p : np.ndarray
         Position vector
-    
+
     Returns
     -------
     np.ndarray
@@ -98,7 +98,7 @@ class _SmurfBundle():
         self.readout_ids = readout_ids
         self.times = []
         self.signal = None
-        self.bias = None
+        self.biases = None
         self.primary = None
 
     def ready(self, flush_time):
@@ -158,10 +158,10 @@ class _SmurfBundle():
         self.signal.data = np.hstack((self.signal.data, f['data'].data)).astype(np.int32)
 
         if 'tes_biases' in f.keys():
-            if self.bias is None:
-                self.bias = self.create_new_supertimestream(f['tes_biases'])
-            self.bias.times.extend(f['tes_biases'].times)
-            self.bias.data = np.hstack((self.bias.data, f['tes_biases'].data)).astype(np.int32)
+            if self.biases is None:
+                self.biases = self.create_new_supertimestream(f['tes_biases'])
+            self.biases.times.extend(f['tes_biases'].times)
+            self.biases.data = np.hstack((self.biases.data, f['tes_biases'].data)).astype(np.int32)
 
         if 'primary' in f.keys():
             if self.primary is None:
@@ -186,7 +186,7 @@ class _SmurfBundle():
         signalout : G3SuperTimestream or None
             Output signal timestream
         biasout : G3SuperTimestream or None
-            Output TES bias timestream
+            Output TES biases timestream
         primout : G3SuperTimestream or None
             Output primary timestream
         """
@@ -227,7 +227,7 @@ class _SmurfBundle():
             return stsout, newsts
 
         signalout, self.signal = rebundle_sts(self.signal, flush_time, use_rids=True)
-        biasout, self.bias = rebundle_sts(self.bias, flush_time)
+        biasout, self.biases = rebundle_sts(self.biases, flush_time)
         primout, self.primary = rebundle_sts(self.primary, flush_time)
 
         self.times = [t for t in self.times if t >= flush_time]
@@ -447,7 +447,7 @@ class FrameProcessor(object):
         f = core.G3Frame(core.G3FrameType.Scan)
         f['signal'] = sts
         if smurf_bias is not None:
-            f['tes_bias'] = smurf_bias
+            f['tes_biases'] = smurf_bias
         if smurf_primary is not None:
             f['primary'] = smurf_primary
 

--- a/sotodlib/io/bookbinder.py
+++ b/sotodlib/io/bookbinder.py
@@ -481,11 +481,10 @@ class FrameProcessor(object):
 
         self.current_state = state
 
-    def check_times(self, f):
+    def replace_times_and_trim_frame(self, f):
         """
-        Retrieve the timestamps for the data, then trim any samples occurring before the Book start
-        time and after the Book end time. If there are no such samples, the frame is passed through
-        untouched.
+        Replace the data timestamps with the most accurate available, then trim any samples
+        occurring before the Book start time and after the Book end time.
 
         Parameters
         ----------
@@ -683,7 +682,7 @@ class FrameProcessor(object):
 
             # Replace the times in 'data', 'tes_biases', and 'primary' with the correct timestamps
             # and trim any samples occuring outside the specified start/end times
-            f = self.check_times(f)
+            f = self.replace_times_and_trim_frame(f)
             # Replace the channel names with readout IDs (if available)
             f['data'].names = get_channel_names(f['data'], rids=self._readout_ids)
 

--- a/sotodlib/io/bookbinder.py
+++ b/sotodlib/io/bookbinder.py
@@ -112,6 +112,8 @@ def get_timestamps(f, use_counters):
             timestamps *= core.G3Units.s
         else:
             raise TimingSystemError("No timing counters found")
+    elif use_counters and 'primary' not in f.keys():
+        raise TimingSystemError("'primary' field not found")
     else:
         timestamps = f['data'].times
     return core.G3VectorTime(timestamps)

--- a/tests/test_bookbinder.py
+++ b/tests/test_bookbinder.py
@@ -19,14 +19,74 @@ def generate_hk_frame(t):
     return frame
 
 def generate_smurf_frame(t):
+    if not isinstance(t, core.G3VectorTime):
+        t = core.G3VectorTime([core.G3Time(_t * core.G3Units.s) for _t in t])
+
     frame = core.G3Frame(core.G3FrameType.Scan)
-    data = so3g.G3SuperTimestream()
-    data.times = core.G3VectorTime([core.G3Time(_t * core.G3Units.s) for _t in t])
-    data.names = ['r0000']
-    data.quanta = np.ones(len(data.names), dtype=np.double)
-    data.data = np.ones((len(data.names), len(data.times)))
-    frame['data'] = data
+    frame['data'] = so3g.G3SuperTimestream(['r0000'], t, np.ones((1, len(t)), dtype=np.int32))
     return frame
+
+def test_check_timestamps():
+    import sotodlib.io.bookbinder as bb
+
+    F = bb.FrameProcessor()
+
+    ##################################################
+    # Test 1a: When the primary timestream is not
+    #          available, it should default to the
+    #          times recorded in the .times field
+    ##################################################
+    t = np.full(10, 167330757642916600) + np.array([0, 499600, 1001200, 1499500, 2000600,
+                                            2501300, 3001400, 3503100, 4001100, 4499000])
+    frame = generate_smurf_frame(core.G3VectorTime(t))
+    np.testing.assert_array_equal(F.check_times(frame)['data'].times, t)
+
+    ##################################################
+    # Test 1b: With the primary field present,
+    #          calculate the true timestamps from the
+    #          counters fields
+    ##################################################
+    c0 = [205909, 208309, 210709, 213109, 215509, 217909, 220309, 222709, 225109, 227509]
+    c1 = [4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295,
+          4294967295, 4294967295, 4294967295]
+    c2 = [4476024116700374110, 4476024116705374055, 4476024116710373999, 4476024116715373944,
+          4476024116720373889, 4476024116725373834, 4476024116730373779, 4476024116735373723,
+          4476024116740373668, 4476024116745373613]
+    true_timestamps = [167330757642897696, 167330757643397728, 167330757643897696, 167330757644397696,
+          167330757644897696, 167330757645397696, 167330757645897696, 167330757646397696,
+          167330757646897696, 167330757647397696]
+    frame['primary'] = so3g.G3SuperTimestream(["Counter0", "Counter1", "Counter2"],
+                                core.G3VectorTime(t), np.vstack((c0, c1, c2)))
+    np.testing.assert_array_equal(F.check_times(frame)['data'].times, true_timestamps)
+
+    ##################################################
+    # Test 2: Trim the samples outside start/end times
+    ##################################################
+    # Start/end times in middle of frame
+    F.BOOK_START_TIME = core.G3Time(true_timestamps[1] + 1)
+    F.BOOK_END_TIME   = None
+    np.testing.assert_array_equal(F.check_times(frame)['data'].times, true_timestamps[2:])
+    F.BOOK_END_TIME   = core.G3Time(true_timestamps[-1] - 1)
+    np.testing.assert_array_equal(F.check_times(frame)['data'].times, true_timestamps[2:-1])
+
+    # Start time after end of frame
+    F.BOOK_START_TIME = core.G3Time(true_timestamps[-1] + 1)
+    F.BOOK_END_TIME   = None
+    np.testing.assert_array_equal(F.check_times(frame)['data'].times, [])
+    F.BOOK_END_TIME   = core.G3Time(true_timestamps[-1] + 2)
+    np.testing.assert_array_equal(F.check_times(frame)['data'].times, [])
+
+    # End time before start of frame
+    F.BOOK_START_TIME = None
+    F.BOOK_END_TIME   = core.G3Time(true_timestamps[0] - 1)
+    np.testing.assert_array_equal(F.check_times(frame)['data'].times, [])
+    F.BOOK_START_TIME = core.G3Time(true_timestamps[0] - 2)
+    np.testing.assert_array_equal(F.check_times(frame)['data'].times, [])
+
+    # Frame contained well within start/end times
+    F.BOOK_START_TIME = core.G3Time(true_timestamps[0] - 1)
+    F.BOOK_END_TIME   = core.G3Time(true_timestamps[-1] + 1)
+    np.testing.assert_array_equal(F.check_times(frame)['data'].times, true_timestamps)
 
 def test_hk_gaps():
     import sotodlib.io.bookbinder as bb

--- a/tests/test_bookbinder.py
+++ b/tests/test_bookbinder.py
@@ -42,9 +42,22 @@ def test_check_timestamps():
     np.testing.assert_array_equal(F.check_times(frame)['data'].times, t)
 
     ##################################################
-    # Test 1b: With the primary field present,
-    #          calculate the true timestamps from the
-    #          counters fields
+    # Test 1b: When the timing system is on but the
+    #          timing counters are absent, an
+    #          exception should be raised
+    ##################################################
+    F.timing_system = True
+    c0 = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+    c1 = c0
+    c2 = c0
+    frame['primary'] = so3g.G3SuperTimestream(["Counter0", "Counter1", "Counter2"],
+                                core.G3VectorTime(t), np.vstack((c0, c1, c2)))
+    np.testing.assert_raises(bb.TimingSystemError, F.check_times, frame)
+
+    ##################################################
+    # Test 1c: When the timing system is on and the
+    #          timing counters are present, calculate
+    #          the true timestamps from the counters
     ##################################################
     c0 = [205909, 208309, 210709, 213109, 215509, 217909, 220309, 222709, 225109, 227509]
     c1 = [4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295,
@@ -55,8 +68,7 @@ def test_check_timestamps():
     true_timestamps = [167330757642897696, 167330757643397728, 167330757643897696, 167330757644397696,
           167330757644897696, 167330757645397696, 167330757645897696, 167330757646397696,
           167330757646897696, 167330757647397696]
-    frame['primary'] = so3g.G3SuperTimestream(["Counter0", "Counter1", "Counter2"],
-                                core.G3VectorTime(t), np.vstack((c0, c1, c2)))
+    frame['primary'].data = np.vstack((c0, c1, c2))
     np.testing.assert_array_equal(F.check_times(frame)['data'].times, true_timestamps)
 
     ##################################################

--- a/tests/test_bookbinder.py
+++ b/tests/test_bookbinder.py
@@ -47,6 +47,7 @@ def test_check_timestamps():
     #          exception should be raised
     ##################################################
     F.timing_system = True
+    np.testing.assert_raises(bb.TimingSystemError, F.check_times, frame)
     c0 = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
     c1 = c0
     c2 = c0

--- a/tests/test_bookbinder.py
+++ b/tests/test_bookbinder.py
@@ -26,7 +26,7 @@ def generate_smurf_frame(t):
     frame['data'] = so3g.G3SuperTimestream(['r0000'], t, np.ones((1, len(t)), dtype=np.int32))
     return frame
 
-def test_check_timestamps():
+def test_replace_times_and_trim_frame():
     import sotodlib.io.bookbinder as bb
 
     F = bb.FrameProcessor()


### PR DESCRIPTION
As pointed out in #357, if the timing system isn’t on, the timestamps between wafers don't line up and the system should fall back to making individual books for each wafer. Although the Imprinter will check for a timing system from the database and instruct the Bookbinder, the Bookbinder should still double-check for the presence of timing counters.

* If the counters are missing where they are expected (i.e., the database indicates the timing system was on), an error should be thrown to be caught by Imprinter, which will rerun Bookbinder in single-wafer mode.

* If the counters are present, calculate the correct timestamps and write them into every `.times` field in the output Book. Timestamps are calculated using the logic in load_smurf.py (ver. Jan 23, 2023):

https://github.com/simonsobs/sotodlib/blob/0f3c7b7a0ff882d39cd3e3b8c2258ede0c7ba308/sotodlib/io/load_smurf.py#L2160-L2166