### PR TITLE
G3tSmurf Timing Updates

### DIFF
--- a/sotodlib/io/g3tsmurf_db.py
+++ b/sotodlib/io/g3tsmurf_db.py
@@ -79,7 +79,8 @@ class Observations(Base):
     action_name = db.Column(db.String)
     
     stream_id = db.Column(db.String)
-    
+    timing = db.Column(db.Boolean)
+
     # in seconds
     duration = db.Column(db.Float)
     n_samples = db.Column(db.Integer)
@@ -182,7 +183,8 @@ class Files(Base):
     observation = relationship("Observations", back_populates='files')
     
     stream_id = db.Column(db.String)
-    
+    timing = db.Column(db.Boolean)
+
     n_frames = db.Column(db.Integer)
     frames = relationship("Frames", back_populates='file')
     

--- a/sotodlib/io/g3tsmurf_db.py
+++ b/sotodlib/io/g3tsmurf_db.py
@@ -49,6 +49,9 @@ class Observations(Base):
         The stream_id of this observation. Generally corresponds to UFM or Smurf
         slot. Column is implemented since level 2 data is not perfectly co-sampled 
         across stream_ids.
+    timing : bool
+        If true, the files of the entry observation were made with times
+        referenced to the timing system.
     duration : float
         The total observation time in seconds
     n_samples : integer
@@ -149,6 +152,8 @@ class Files(Base):
     observation : SQLAlchemy Observation Instance
     stream_id : The stream_id for the file. Generally of the form crateXslotY.
         These are expected to map one per UXM.
+    timing : bool
+        If true, every frame in the file has times that are referenced to the timing system
     n_frames : Integer
         Number of frames in the .g3 file
     frames : list of SQLALchemy Frame Instances

--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -278,6 +278,8 @@ class G3tSmurf:
         total_channels = 0
         file_start, file_stop = None, None
         frame_idx = -1
+        timing = None
+
         while True:
 
             try:
@@ -328,6 +330,11 @@ class G3tSmurf:
                     db_frame.stop = dt.datetime.utcfromtimestamp(
                         data.times[-1].time / spt3g_core.G3Units.s
                     )
+                    if timing is None:
+                        timing = frame.get("timing_paradigm", "") == "High Precision"
+                    else:
+                        timing = timing and (frame.get("timing_paradigm", "") == "High Precision")
+
                 else:
                     db_frame.n_samples = data.n_samples
                     db_frame.n_channels = len(data)
@@ -354,6 +361,7 @@ class G3tSmurf:
         db_file.stop = file_stop
         db_file.n_channels = total_channels
         db_file.n_frames = frame_idx
+        db_file.timing = timing
 
     def index_archive(
         self,
@@ -827,7 +835,7 @@ class G3tSmurf:
         if obs.stop is None and not obs_ended and (force or flist[-1].stop <=
                                                     dt.datetime.now()-dt.timedelta(hours=1)):
             ## try to brute force find the end if it's been awhile
-            for f in flist[::-1]:
+            for f in flist[::-1][:3]:
                 if not obs_ended:
                     obs_ended = _file_has_end_frames(f.name)
 
@@ -836,6 +844,7 @@ class G3tSmurf:
             obs.n_samples = obs_samps
             obs.duration = flist[-1].stop.timestamp() - flist[0].start.timestamp()
             obs.stop = flist[-1].stop
+            obs.timing = np.all([f.timing for f in flist])
             logger.debug(f"Setting {obs.obs_id} stop time to {obs.stop}")
         session.commit()
 

--- a/sotodlib/site_pipeline/monitor.py
+++ b/sotodlib/site_pipeline/monitor.py
@@ -1,3 +1,5 @@
+import yaml
+
 from influxdb import InfluxDBClient
 
 class Monitor:
@@ -33,6 +35,31 @@ class Monitor:
         """
         self.client = Monitor._connect_to_db(host, port, database, username, password, path, ssl)
         self.queue = []
+
+    @classmethod
+    def from_configs(cls, configs):
+        """Create a monitor from a configuration file
+        
+        Parameters
+        ----------
+        configs: dict or string
+            configuration dictionary or string that's a file name that can be
+            loaded by yaml into a configuration dictionary
+
+        Returns
+        -------
+        connected Monitor Instance
+        """
+        if type(configs) == str:
+            configs = yaml.safe_load( open(configs, "r") )    
+        return cls(
+            host = configs["host"],
+            port = configs["port"],
+            username = configs["username"],
+            password = configs["password"],
+            path = configs["path"],
+            ssl = configs["ssl"],
+        )
 
     @staticmethod
     def _connect_to_db(host, port, database, username, password, path, ssl):

--- a/sotodlib/site_pipeline/update_g3tsmurf_database.py
+++ b/sotodlib/site_pipeline/update_g3tsmurf_database.py
@@ -8,71 +8,41 @@ import os
 import datetime as dt
 import numpy as np
 import argparse
-
 import logging
-from sotodlib.io.load_smurf import G3tSmurf, Observations, dump_DetDb, logger
+from sotodlib.io.load_smurf import G3tSmurf, Observations, dump_DetDb, logger as default_logger
 
-def get_parser():
-    parser = argparse.ArgumentParser()
-    parser.add_argument('data_prefix', help="The prefix to data locations, use individual"
-                                            "locations flags if data is stored in non-standard folders")
-    parser.add_argument('db_path', help="Path to Database to update")
-    
-    parser.add_argument('--timestream-folder', help="Absolute path to folder with .g3 timestreams. Overrides data_prefix")
-    parser.add_argument('--smurf-folder', help="Absolute path to folder with pysmurf archived data. Overrides data_prefix")
-    
-    parser.add_argument('--detdb-filename', help="File for dumping the context detector database")
-    
-    parser.add_argument('--update-delay', help="Days to subtract from now to set as minimum ctime",
-                               default=2, type=float)
-    parser.add_argument('--from-scratch', help="Builds or updates database from scratch",
-                        action="store_true")
-    parser.add_argument("--verbosity", help="increase output verbosity. 0:Error, 1:Warning, 2:Info(default), 3:Debug",
-                       default=2, type=int)
-    return parser
 
-if __name__ == '__main__':
-    
-    parser = get_parser()
-    args = parser.parse_args()
-    
-    if args.timestream_folder is None:
-        args.timestream_folder = os.path.join( args.data_prefix, 'timestreams/')
-       
-    if args.smurf_folder is None:
-        args.smurf_folder = os.path.join( args.data_prefix, 'smurf/')
-    
-    if args.verbosity > 1:
-        show_pb=True
-    else:
-        show_pb=False
-        
-    if args.verbosity == 0:
+def update_g3tsmurf_db(config=None, detdb_filename=None, update_delay=2, from_scratch=False,
+                       verbosity=2, logger=None):
+
+    show_pb = True if verbosity > 1 else False
+
+    if logger is None:
+        logger = default_logger
+    if verbosity == 0:
         logger.setLevel(logging.ERROR)
-    elif args.verbosity == 1:
+    elif verbosity == 1:
         logger.setLevel(logging.WARNING)
-    elif args.verbosity == 2:
+    elif verbosity == 2:
         logger.setLevel(logging.INFO)
-    elif args.verbosity == 3:
+    elif verbosity == 3:
         logger.setLevel(logging.DEBUG)
-        
-    SMURF = G3tSmurf(args.timestream_folder, 
-                     db_path=args.db_path,
-                     meta_path=args.smurf_folder)
 
-    if args.from_scratch:
-        print("Building Database from Scratch, May take awhile")
+    SMURF = G3tSmurf.from_configs(config)
+
+    if from_scratch:
+        logger.info("Building Database from Scratch, May take awhile")
         min_time = dt.datetime.utcfromtimestamp(int(1.6e9))
     else:
-        min_time = dt.datetime.now() - dt.timedelta(days=args.update_delay)
+        min_time = dt.datetime.now() - dt.timedelta(days=update_delay)
         
     SMURF.index_archive(min_ctime=min_time.timestamp(), show_pb=show_pb)
     SMURF.index_metadata(min_ctime=min_time.timestamp())
 
     session = SMURF.Session()
 
-    new_obs = session.query(Observations).filter( Observations.start >= min_time,
-                                                  Observations.stop == None).all()
+    new_obs = session.query(Observations).filter(Observations.start >= min_time,
+                                                 Observations.stop == None).all()
     for obs in new_obs:
         SMURF.update_observation_files(
             obs, 
@@ -80,6 +50,23 @@ if __name__ == '__main__':
             force=True,
         )
 
-    if args.detdb_filename is not None:
-        dump_DetDb(SMURF, args.detdb_filename)
+    if detdb_filename is not None:
+        dump_DetDb(SMURF, detdb_filename)
 
+
+def get_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('config', help="g3tsmurf db configuration file")
+    parser.add_argument('--detdb-filename', help="File for dumping the context detector database")
+    parser.add_argument('--update-delay', help="Days to subtract from now to set as minimum ctime",
+                        default=2, type=float)
+    parser.add_argument('--from-scratch', help="Builds or updates database from scratch",
+                        action="store_true")
+    parser.add_argument("--verbosity", help="increase output verbosity. 0:Error, 1:Warning, 2:Info(default), 3:Debug",
+                       default=2, type=int)
+    return parser
+
+if __name__ == '__main__':
+    parser = get_parser()
+    args = parser.parse_args()
+    update_g3tsmurf_db(**args)

--- a/sotodlib/site_pipeline/update_g3tsmurf_database.py
+++ b/sotodlib/site_pipeline/update_g3tsmurf_database.py
@@ -43,14 +43,7 @@ def update_g3tsmurf_db(config=None, update_delay=2, from_scratch=False,
     monitor = None
     if "monitor" in cfgs:
         logger.info("Will send monitor information to Influx")
-        monitor = Monitor(
-            host=cfgs["monitor"]["host"],
-            port=cfgs["monitor"]["port"],
-            username = cfgs["monitor"]["username"],
-            password = cfgs["monitor"]["password"],
-            path = cfgs["monitor"]["path"],
-            ssl = cfgs["monitor"]["ssl"],
-        )
+        monitor = Monitor.from_configs(cfgs["monitor"]["connect_configs"])
         
     SMURF.index_archive(min_ctime=min_time.timestamp(), show_pb=show_pb)
     SMURF.index_metadata(min_ctime=min_time.timestamp())


### PR DESCRIPTION
This has been rebased off of #392  and #390  so we need to wait for these two to merge here. I would also like to wait until [this PR](https://github.com/simonsobs/smurf-streamer/pull/38) has started running at UCSD because I'd prefer to not need to repair the UCSD databases more than once (and this should technically be tested on "good" files). 

This PR adds a timing tracking column to the Files and Observation tables in G3tSmurf. It also adds our first example of the QDS monitor into the update-g3tsmurf-db script which will let us set up a grafana alter if the timing information dies at some point. 

Merging this PR will come with the need to run some table updates on the existing databases. I have scripts for these but @guanyilun  we'll need to coordinate running those scripts on the prefect managed databases. 

* Scripts to Update the databases / repair timing columns are here: https://github.com/simonsobs/pwg-scripts/tree/master/pwg-duf/g3tsmurf_timing 
* Monitor config files for this example are here: https://github.com/simonsobs/site-pipeline-configs 