### PR TITLE
Bookbinder: Backward compatibility with Python 3.7

### DIFF
--- a/sotodlib/io/bookbinder.py
+++ b/sotodlib/io/bookbinder.py
@@ -265,19 +265,19 @@ class _SmurfBundle():
 
         # Since G3SuperTimestreams cannot be shortened, the data must be copied to
         # a new instance for rebundling of the buffer
-        signalstack = np.hstack(self.signal['data'], dtype=self.dtypes['data'])
+        signalstack = np.hstack(self.signal['data'])
         signalout = so3g.G3SuperTimestream(self.signal['names'], tout, signalstack[:,:len(tout)])
         self.signal = {'names': self.signal['names'], 'times': [self.times], 'data': [signalstack[:,len(tout):]]}
 
         if self.biases is not None:
-            biasstack = np.hstack(self.biases['data'], dtype=self.dtypes['tes_biases'])
+            biasstack = np.hstack(self.biases['data'])
             biasout = so3g.G3SuperTimestream(self.biases['names'], tout, biasstack[:,:len(tout)])
             self.biases = {'names': self.biases['names'], 'times': [self.times], 'data': [biasstack[:,len(tout):]]}
         else:
             biasout = None
 
         if self.primary is not None:
-            primstack = np.hstack(self.primary['data'], dtype=self.dtypes['primary'])
+            primstack = np.hstack(self.primary['data'])
             primout = so3g.G3SuperTimestream(self.primary['names'], tout, primstack[:,:len(tout)])
             self.primout = {'names': self.primary['names'], 'times': [self.times], 'data': [primstack[:,len(tout):]]}
         else:


### PR DESCRIPTION
This reverts commit 75dafd8. The Python 3.7 version of Numpy doesn’t include dtype as an option for `hstack`. Since it was only put in to satisfy my paranoia, we remove it here to ensure continued compatibility.

@jlashner can you check that this works?