### PR TITLE
Bookbinder HWP binding

### DIFF
--- a/sotodlib/io/imprinter.py
+++ b/sotodlib/io/imprinter.py
@@ -257,7 +257,7 @@ class Imprinter:
             self.register_book(session, bid, obs_list, commit=False)
         if commit: session.commit()
 
-    def bind_book(self, book, session=None, output_root="out", message=""):
+    def bind_book(self, book, session=None, output_root="out", message="", hwp_root=None):
         """Bind book using bookbinder
 
         Parameters
@@ -269,7 +269,8 @@ class Imprinter:
             output root directory
         message: string
             message to be added to the book
-
+        hwp_root: str
+            Root directory of processed hwp g3 files
         """
         if session is None: session = self.get_session()
         # get book id and book object, depending on whether book id is given or not
@@ -316,7 +317,7 @@ class Imprinter:
                 Bookbinder(smurf_files, hk_files=hkfiles, out_root=odir,
                            stream_id=stream_id, session_id=int(session_id),
                            book_id=book.bid, start_time=start_t, end_time=stop_t,
-                           max_nchannels=book.max_channels,
+                           max_nchannels=book.max_channels, hwp_root=hwp_root,
                            frameproc_config={"readout_ids": rids})()
             # not sure if this is the best place to update
             book.status = BOUND


### PR DESCRIPTION
This PR adds functionality to the bookbinder which adds processed HWP data to books.

If the `hwp_root` is passed, this will load in the processed HWP g3 files, and use it to fill out the ancillary data files in books.

This tries to replicate the format described in the tod_format doc as closely as possible. For the negative integer values that report HWP conditions, I use a bitmask with flags for when the hwp is stationary, stable, etc. based on what's in the processed data file. I assume this is something people have opinions about so we should probably discuss the correct flags for this.

This makes a few other small changes in the bookbinder that I came across when testing:
- the `ancil` field is now added to ancillary frames even if there's no data (Matthew also noticed this in #388)
- G3Files are now properly closed with EndProcessing frames

I've tested this on a few books on simons1, but probably needs to be tested with the whole p10r2 archive. What is the best way to do this?



