### PR TITLE
Fourier filter default behavior is no detrending

### DIFF
--- a/sotodlib/tod_ops/filters.py
+++ b/sotodlib/tod_ops/filters.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 def fourier_filter(tod, filt_function,
-                   detrend='linear', resize='zero_pad',
+                   detrend=None, resize='zero_pad',
                    axis_name='samps', signal_name='signal', 
                    time_name='timestamps',
                    **kwargs):


### PR DESCRIPTION
@tterasaki found that the default fourier filter behavior to apply a linear detrend was screwing up some of the demodulation operations. After discussion with @kmharrington and @mhasself on slack we agreed the right solution for now is to set the default behavior to be no detrending.