### PR TITLE
load_smurf: reduce RAM footprint when loading a few detectors

### DIFF
--- a/sotodlib/io/load.py
+++ b/sotodlib/io/load.py
@@ -77,7 +77,7 @@ class FieldGroup(list):
 
     """
     def __init__(self, name, items=None, timestamp_field=None,
-                 compression=False):
+                 compression=False, refs_ok=True):
         """Arguments:
           name (str): The key in the parent G3FrameObject at which to
             find the specified items.
@@ -88,12 +88,20 @@ class FieldGroup(list):
           compression (bool): If the requested item is a
             G3TimestreamMap with offset+gain compression implemented,
             then say so here.
+          refs_ok (bool): If True, then extraction code will be
+            instructed that it is ok to collect a bunch of 1-d
+            references to the same large 2-d array, rather than
+            copying out the 1-d subarrays of interest so big 2-d
+            FrameObjects can be freed.  If False, copies will be
+            forced (this is efficient in the limit that small number
+            of available channels is being collected).
 
         """
         super().__init__()
         self.name = name
         self.compression = compression
         self.timestamp_field = timestamp_field
+        self.refs_ok = refs_ok
         if items is not None:
             self.extend(items)
 
@@ -180,7 +188,7 @@ class Field:
 
 
 def unpack_frame_object(fo, field_request, streams, compression_info=None,
-                        offset=0, max_count=None):
+                        offset=0, max_count=None, refs_ok=True):
     """Unpack requested fields from a G3FrameObject, and update a data structure.
     
     Arguments:
@@ -236,7 +244,8 @@ def unpack_frame_object(fo, field_request, streams, compression_info=None,
                 comp_info = None
             target = fo[item.name]
             _consumed = unpack_frame_object(target, item, streams[item.name], comp_info,
-                                            offset=offset, max_count=max_count)
+                                            offset=offset, max_count=max_count,
+                                            refs_ok=item.refs_ok)
             _n, sl = our_slice(_consumed, 1)
             # Check and slice timestamp field independently -- must
             # work even if no dets requested led to _n=0 above.
@@ -274,7 +283,10 @@ def unpack_frame_object(fo, field_request, streams, compression_info=None,
         _n, sl = our_slice(_consumed, item.oversample)
 
         if _n:
-            streams[key].append(v[sl])
+            if refs_ok:
+                streams[key].append(v[sl])
+            else:
+                streams[key].append(np.copy(v[sl]))
     return _consumed
 
 def unpack_frames(filename, field_request, streams, samples=None):

--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -2294,8 +2294,10 @@ def load_file(
             obsfiledb=obsfiledb,
             ignore_missing=ignore_missing,
         )
+        is_many_channels = ch_mask.sum() >= len(ch_mask) * 0.5
     else:
         ch_mask = None
+        is_many_channels = True
 
     ch_info = get_channel_info(
         status,
@@ -2338,7 +2340,8 @@ def load_file(
         ]
     else:
         subreq = [
-            io_load.FieldGroup("data", ch_info.rchannel, timestamp_field="time")
+            io_load.FieldGroup("data", ch_info.rchannel, timestamp_field="time",
+                               refs_ok=is_many_channels)
         ]
     if load_primary:
         subreq.extend(


### PR DESCRIPTION
load_file will take copies, instead of refs, when pulling a ~small number of dets out of a frame stream.