### PR TITLE
Bookbinder: Fill in missing samples

### DIFF
--- a/sotodlib/io/bookbinder.py
+++ b/sotodlib/io/bookbinder.py
@@ -493,10 +493,12 @@ class FrameProcessor(object):
             # Use estimated sample interval to fill until end_time. Not using fill_time_gaps because
             # end_time is externally determined and does not usually line up with sample interval
             ts = np.append(ts, np.arange(data.times[-1].time+dt, end_time, dt))
+            # for consistency with smurf_timestamps
+            ts /= core.G3Units.s
 
         # Create new G3SuperTimestream with filled-in samples
         if len(data.times) < len(ts):
-            i_missing, _ = find_missing_samples(ts, np.array(data.times))
+            i_missing, _ = find_missing_samples(ts, np.array(data.times)/core.G3Units.s)
             m = np.ones(len(ts), dtype=bool)
             m[i_missing] = False
             assert np.sum(m) == len(data.times)

--- a/sotodlib/io/bookbinder.py
+++ b/sotodlib/io/bookbinder.py
@@ -473,7 +473,7 @@ class FrameProcessor(object):
         # Obtain list of filled-in timestamps, whether from provided list or estimate with fill_time_gaps
         if self._smurf_timestamps is not None:
             # trim the list of timestamps to the current frame
-            m_ = np.logical_and(self._smurf_timestamps < end_time, self._smurf_timestamps > prev_frame_end)
+            m_ = np.logical_and(self._smurf_timestamps <= end_time, self._smurf_timestamps >= prev_frame_end)
             ts = self._smurf_timestamps[m_]
         else:
             # fallback when no timestamp is provided. We switch to estimate sample interval based on data
@@ -493,13 +493,11 @@ class FrameProcessor(object):
             # Use estimated sample interval to fill until end_time. Not using fill_time_gaps because
             # end_time is externally determined and does not usually line up with sample interval
             ts = np.append(ts, np.arange(data.times[-1].time+dt, end_time, dt))
-            # for consistency with smurf_timestamps
-            ts /= core.G3Units.s
 
         # Create new G3SuperTimestream with filled-in samples
         if len(data.times) < len(ts):
             dt = np.median(np.diff(ts))
-            i_missing, _ = find_missing_samples(ts, np.array(data.times)/core.G3Units.s, atol=dt/2)
+            i_missing, _ = find_missing_samples(ts, np.array(data.times), atol=dt/2)
             m = np.ones(len(ts), dtype=bool)
             m[i_missing] = False
             assert np.sum(m) == len(data.times)
@@ -1212,3 +1210,4 @@ def find_missing_samples(refs, vs, atol=0.5):
     idx -= refs - left < right - refs
     missing = np.where(np.abs(vs[idx] - refs) > atol)[0]
     return missing, refs[missing]
+

--- a/sotodlib/io/bookbinder.py
+++ b/sotodlib/io/bookbinder.py
@@ -496,8 +496,9 @@ class FrameProcessor(object):
 
         # Create new G3SuperTimestream with filled-in samples
         if len(data.times) < len(ts):
-            t_missing = find_missing_samples(ts, np.array(data.times))
-            m = np.isin(ts, t_missing, assume_unique=True, invert=True)
+            i_missing, _ = find_missing_samples(ts, np.array(data.times))
+            m = np.ones(len(ts), dtype=bool)
+            m[i_missing] = False
             assert np.sum(m) == len(data.times)
             new_data = np.full((data.data.shape[0], len(ts)), self.FLAGGED_SAMPLE_VALUE)
             new_data[:,m] = data.data
@@ -1193,8 +1194,10 @@ def find_missing_samples(refs, vs, atol=0.5):
 
     Returns
     -------
-    missing : array_like
-        List of missing samples in the list of timestamps (vs)
+    i_missing : array_like
+        indices (in refs) of the missing samples in vs
+    t_missing : array_like
+        values (in refs) of the missing samples in vs
     """
     # Find the indices of the samples in the list of timestamps (vs)
     # that are closest to the reference timestamps
@@ -1205,4 +1208,4 @@ def find_missing_samples(refs, vs, atol=0.5):
     right = vs[idx]
     idx -= refs - left < right - refs
     missing = np.where(np.abs(vs[idx] - refs) > atol)[0]
-    return refs[missing]
+    return missing, refs[missing]

--- a/sotodlib/io/bookbinder.py
+++ b/sotodlib/io/bookbinder.py
@@ -484,7 +484,7 @@ class FrameProcessor(object):
             if self._prev_smurf_sample is None:
                 # Use estimated sample interval to fill backward to prev_frame_end = book start time - 1
                 # since book start time does not usually line up with sample interval
-                ts = np.append(np.flip(np.arange(data.times[0].time-dt, prev_frame_end, -dt)), data.times)
+                ts = np.append(np.flip(np.arange(data.times[0].time-dt, prev_frame_end, -dt, dtype=int)), data.times)
                 ts = fill_time_gaps(ts)
             elif (data.times[0].time - prev_frame_end)/dt > 0.5:
                 ts = fill_time_gaps(np.insert(data.times, 0, prev_frame_end))[1:]
@@ -492,7 +492,7 @@ class FrameProcessor(object):
                 ts = fill_time_gaps(data.times)
             # Use estimated sample interval to fill until end_time. Not using fill_time_gaps because
             # end_time is externally determined and does not usually line up with sample interval
-            ts = np.append(ts, np.arange(data.times[-1].time+dt, end_time, dt))
+            ts = np.append(ts, np.arange(data.times[-1].time+dt, end_time, dt, dtype=int))
 
         # Create new G3SuperTimestream with filled-in samples
         if len(data.times) < len(ts):
@@ -1161,7 +1161,7 @@ def fill_time_gaps(ts):
     total_missing = int(np.sum(missing))
 
     # Create new  array with the correct number of samples
-    new_ts = np.full(len(ts) + total_missing, np.nan)
+    new_ts = np.full(len(ts) + total_missing, np.nan, dtype=ts.dtype)
 
     # Insert old timestamps into new array with offsets that account for gaps
     offsets = np.concatenate([[0], np.cumsum(missing)])

--- a/sotodlib/io/bookbinder.py
+++ b/sotodlib/io/bookbinder.py
@@ -466,7 +466,7 @@ class FrameProcessor(object):
         if self.BOOK_END_TIME is not None:
             end_time = min(flush_time.time, self.BOOK_END_TIME.time)
         elif self._smurf_timestamps is not None:
-            end_time = min(flush_time.time, self._smurf_timestamps[-1].time + 1)
+            end_time = min(flush_time.time, self._smurf_timestamps[-1] + 1)
         else:
             end_time = min(flush_time.time, data.times[-1].time + 1)
 

--- a/sotodlib/io/bookbinder.py
+++ b/sotodlib/io/bookbinder.py
@@ -602,7 +602,7 @@ class FrameProcessor(object):
         # Update (local) flush time if necessary
         if data_excess is not None:
             flush_time = f['signal'].times[-1] + 1
-            self._frame_splits.append(flush_time)
+            self._frame_splits[-1] = flush_time  # update the most recently added split time
         # Update last sample
         self._prev_smurf_sample = f['signal'].times[-1]
 
@@ -716,6 +716,7 @@ class FrameProcessor(object):
             # If the existing data exceeds the specified maximum length
             while len(self.smbundle.times) >= self.maxlength:
                 split_time = self.smbundle.times[self.maxlength-1] + 1
+                self._frame_splits.append(split_time)
                 output += self.flush(split_time)
                 if self.flush_time is not None and split_time >= self.flush_time:
                     return output

--- a/sotodlib/io/bookbinder.py
+++ b/sotodlib/io/bookbinder.py
@@ -473,7 +473,7 @@ class FrameProcessor(object):
         # Obtain list of filled-in timestamps, whether from provided list or estimate with fill_time_gaps
         if self._smurf_timestamps is not None:
             # trim the list of timestamps to the current frame
-            m_ = np.logical_and(self._smurf_timestamps <= end_time, self._smurf_timestamps >= prev_frame_end)
+            m_ = np.logical_and(self._smurf_timestamps < end_time, self._smurf_timestamps > prev_frame_end)
             ts = self._smurf_timestamps[m_]
         else:
             # fallback when no timestamp is provided. We switch to estimate sample interval based on data

--- a/sotodlib/io/bookbinder.py
+++ b/sotodlib/io/bookbinder.py
@@ -8,7 +8,7 @@ import itertools
 import yaml
 from scipy.interpolate import interp1d
 from .load_smurf import split_ts_bits
-# 
+#
 class HWPFlags:
     # STATIONARY is used to flag samples where data is being received by IRIG
     # and the HWP agent, however the angle cannot be reconstructed because the HWP
@@ -737,7 +737,7 @@ class Bookbinder(object):
     """
     def __init__(self, smurf_files, hk_files=None, out_root='.', book_id=None,
                  session_id=None, stream_id=None, start_time=None, end_time=None,
-                 smurf_timestamps=None, timing_system=False, verbose=True, 
+                 smurf_timestamps=None, timing_system=False, verbose=True,
                  hwp_root=None, **config):
         self._smurf_files = smurf_files
         self._hk_files = hk_files
@@ -1033,7 +1033,7 @@ class Bookbinder(object):
         """
         # Determine if HK files contain az/el encoder data and find any gaps between HK frames
         self.process_HK_files()
-            
+
         if self._hwp_root is not None:
             self.hwp_loader = HWPLoader(self._hwp_root)
             self.hwp_loader.load_data(self._start_time.time / core.G3Units.s, self._end_time.time / core.G3Units.s)
@@ -1340,7 +1340,7 @@ class HWPLoader:
         self.root_dir = root_dir
         self.files = []
         self.data = {}
-        self.times = {} 
+        self.times = {}
 
         self.hwp_angle_interp = None
         self.locked_interp = None
@@ -1423,7 +1423,7 @@ class HWPLoader:
         self.times = times
         if len(data) != 0:
             self.hwp_angle_interp = interp1d(
-                times['fast'], np.unwrap(data['fast']['hwp_angle']), 
+                times['fast'], np.unwrap(data['fast']['hwp_angle']),
                 bounds_error=False)
             self.locked_interp = interp1d(
                 times['slow'], data['slow']['locked'], bounds_error=False)
@@ -1440,7 +1440,7 @@ class HWPLoader:
     def get_interpolated_data(self, times):
         if self.hwp_angle_interp is None:
             return np.full(len(times), -HWPFlags.NO_DATA)
-            
+
         hwp_angle = self.hwp_angle_interp(times)
         hwp_angle = np.mod(hwp_angle, 2*np.pi)
 

--- a/sotodlib/io/bookbinder.py
+++ b/sotodlib/io/bookbinder.py
@@ -498,7 +498,8 @@ class FrameProcessor(object):
 
         # Create new G3SuperTimestream with filled-in samples
         if len(data.times) < len(ts):
-            i_missing, _ = find_missing_samples(ts, np.array(data.times)/core.G3Units.s)
+            dt = np.median(np.diff(ts))
+            i_missing, _ = find_missing_samples(ts, np.array(data.times)/core.G3Units.s, atol=dt/2)
             m = np.ones(len(ts), dtype=bool)
             m[i_missing] = False
             assert np.sum(m) == len(data.times)

--- a/sotodlib/io/imprinter.py
+++ b/sotodlib/io/imprinter.py
@@ -382,7 +382,7 @@ class Imprinter:
             if isinstance(e, TimingSystemError):
                 book.timing = False
             book.message = message
-    
+
             if not test_mode:
                 session.commit()
             else:
@@ -728,7 +728,7 @@ class Imprinter:
 
         meta_files = {}
         for f in files:
-            basename = os.path.basename(f) 
+            basename = os.path.basename(f)
             dest = os.path.join(book_path, basename)
             shutil.copyfile(f, dest)
 
@@ -846,10 +846,10 @@ def get_smurf_files(obs, meta_path, all_files=False):
     files = []
 
     # check adjacent folders in case action falls on a boundary
-    for tc in [tscode-1, tscode, tscode + 1]:  
+    for tc in [tscode-1, tscode, tscode + 1]:
         action_dir = os.path.join(
             meta_path,
-            str(tc), 
+            str(tc),
             obs.stream_id,
             f'{obs.action_ctime}_{obs.action_name}'
         )
@@ -859,7 +859,7 @@ def get_smurf_files(obs, meta_path, all_files=False):
 
         for root, _, fs in os.walk(action_dir):
             files.extend([os.path.join(root, f) for f in fs])
-    
+
     return [f for f in files if copy_to_book(f)]
 
 _primary_idx_map = {}

--- a/sotodlib/io/imprinter.py
+++ b/sotodlib/io/imprinter.py
@@ -753,7 +753,7 @@ def get_frame_times(frame):
         software timestamps
 
     timestamps : np.ndarray
-        Array of timestamps (sec) for samples in the frame
+        Array of timestamps for samples in the frame, in G3Time units (1e-8 sec)
 
     """
     if len(_primary_idx_map) == 0:

--- a/sotodlib/io/imprinter.py
+++ b/sotodlib/io/imprinter.py
@@ -764,9 +764,9 @@ def get_frame_times(frame):
     c2 = frame['primary'].data[_primary_idx_map['Counter2']]
 
     if np.any(c0):
-        return True, counters_to_timestamps(c0, c2)
+        return True, counters_to_timestamps(c0, c2) * core.G3Units.s
     else:
-        return False, np.array(frame['data'].times) / core.G3Units.s
+        return False, np.array(frame['data'].times)
 
 def get_start_and_end(files):
     """

--- a/sotodlib/io/imprinter.py
+++ b/sotodlib/io/imprinter.py
@@ -722,7 +722,7 @@ class Imprinter:
                         continue
 
                     ts.append(get_frame_times(frame)[1])
-                ts = fill_time_gaps(np.hstack(ts))
+                ts = fill_time_gaps(np.hstack(ts)).astype(int)
                 t0, t1 = ts[[0, -1]]
             else:
                 _t0, _t1 = get_start_and_end(_files)

--- a/tests/test_bookbinder.py
+++ b/tests/test_bookbinder.py
@@ -280,8 +280,12 @@ def test_find_missing_samples():
 
     ref = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
     vs = np.array([1, 1.9, 3, 4.1, 6, 7.1, 8, 10])
-    assert np.array_equal(bb.find_missing_samples(ref, vs), [5, 9])
+    i_missing, t_missing = bb.find_missing_samples(ref, vs)
+    assert np.array_equal(i_missing, [4, 8])
+    assert np.array_equal(t_missing, [5, 9])
 
     ref = np.array([1, 2.1, 3, 4, 5.1, 6, 7, 8, 9, 10])
     vs = np.array([1.9, 3, 4.1, 6, 7.1, 8, 9.1])
-    assert np.array_equal(bb.find_missing_samples(ref, vs), [1, 5.1, 10])
+    i_missing, t_missing = bb.find_missing_samples(ref, vs)
+    assert np.array_equal(i_missing, [0,4,9])
+    assert np.array_equal(t_missing, [1, 5.1, 10])

--- a/tests/test_bookbinder.py
+++ b/tests/test_bookbinder.py
@@ -139,7 +139,7 @@ def test_fill_missing_samples():
     last_samples = [t[-1], t[-1]+3*dt]
     for start_time, end_time in zip(first_samples, last_samples):
         end_time += 1  # to ensure last sample gets included since flush_time is excluded from output frame
-        ref_timestamps = range(start_time, end_time, dt)  # reference timestamps to check against
+        ref_timestamps = np.arange(start_time, end_time, dt)  # reference timestamps to check against
         true_timestamps = ref_timestamps  # for this test, they are the same
 
         # Book start/end times don't have to line up with first/last samples
@@ -273,3 +273,15 @@ def test_smurf_gaps():
                                                               np.full(5, B.frameproc.FLAGGED_SAMPLE_VALUE),
                                                               np.ones(15))))
         np.testing.assert_array_equal(output[0]['signal'].data[0], expected_output, verbose=True)
+
+
+def test_find_missing_samples():
+    import sotodlib.io.bookbinder as bb
+
+    ref = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+    vs = np.array([1, 1.9, 3, 4.1, 6, 7.1, 8, 10])
+    assert np.array_equal(bb.find_missing_samples(ref, vs), [5, 9])
+
+    ref = np.array([1, 2.1, 3, 4, 5.1, 6, 7, 8, 9, 10])
+    vs = np.array([1.9, 3, 4.1, 6, 7.1, 8, 9.1])
+    assert np.array_equal(bb.find_missing_samples(ref, vs), [1, 5.1, 10])

--- a/tests/test_bookbinder.py
+++ b/tests/test_bookbinder.py
@@ -132,7 +132,7 @@ def test_fill_missing_samples():
     # - If a list of ref timestamps is provided or not
     ##################################################
     # Create input data frame with missing samples
-    t = np.concatenate((np.arange(10), np.arange(20,30), np.arange(35,40)))*dt
+    t = np.concatenate((np.arange(10), np.arange(20,30), np.arange(35,40)))*dt + 1e8  # need a large +ve offset to avoid -ve times
     s = generate_smurf_frame(core.G3VectorTime(t))
     # First/last samples correspond to those in data or there are missing samples at beginning/end
     first_samples = [t[0], t[0]-3*dt]
@@ -195,7 +195,7 @@ def test_hk_gaps():
     #          ends in 2nd gap
     ##################################################
     for smurf_frame, expected_output in zip(smurf_frames, expected_outputs):
-        B = bb.Bookbinder(smurf_files=None, book_id='test', start_time=t0[0]*core.G3Units.s,
+        B = bb.Bookbinder(smurf_files=None, book_id='test', start_time=smurf_frame['data'].times[0],
                           end_time=smurf_frame['data'].times[-1].time+1)
         B._hk_files = []
         B.hk_iter = acu_frames


### PR DESCRIPTION
This improves the Bookbinder’s missing-sample checker. Rather than only checking for gaps between input frames when inputting data, it is better to just look for missing samples in the output frame that will be written to a book. This would also catch missing samples that were in the middle of frames, instead of only between frames.

Like before, two methods to check for missing samples are provided: matching with a provided reference timestamp list or using an estimate of the sampling interval to look for gaps. The missing timestamps are filled in using the `fill_time_gaps` function written by jlashner in #405; the samples are assigned the value of FLAGGED_SAMPLE_VALUE (default: -1) and flagged in the output as before.