### PR TITLE
Adds smurf data to oper books

### DIFF
--- a/sotodlib/io/imprinter.py
+++ b/sotodlib/io/imprinter.py
@@ -269,7 +269,8 @@ class Imprinter:
             self.register_book(session, bid, obs_list, commit=False)
         if commit: session.commit()
 
-    def bind_book(self, book, session=None, output_root="out", message=""):
+    def bind_book(self, book, session=None, output_root="out", message="",
+                  test_mode=False):
         """Bind book using bookbinder
 
         Parameters
@@ -281,6 +282,10 @@ class Imprinter:
             output root directory
         message: string
             message to be added to the book
+        test_mode : bool
+            If in test_mode, this function will still run on already copied
+            books, and will not update any db fields in the db. This is useful
+            for testing purposes.
         """
         if session is None: session = self.get_session()
         # get book id and book object, depending on whether book id is given or not
@@ -295,13 +300,8 @@ class Imprinter:
         if not self.book_exists(bid, session=session):
             raise BookExistsError(f"Book {bid} does not exist in the database")
         # check whether book is already bound
-        if book.status == BOUND:
+        if (book.status == BOUND) and (not test_mode):
             raise BookBoundError(f"Book {bid} is already bound")
-
-        g3tsmurf_path = self.sources[book.tel_tube]['g3tsmurf']
-        with open(g3tsmurf_path, 'r') as f:
-            g3tsmurf_cfg = yaml.safe_load(f)
-        hwp_root = g3tsmurf_cfg.get('hwp_prefix')
 
         # after sanity checks, now we proceed to bind the book.
         # get files associated with this book, in the form of
@@ -321,6 +321,11 @@ class Imprinter:
 
         # it's possible that timing field could be none when no timing information is found
         timing_system = book.timing if book.timing is not None else False
+
+        book_path = os.path.join(odir, book.bid)
+        if book.type == 'oper':
+            self.copy_smurf_files_to_book(book, book_path)
+
         # bind book using bookbinder library
         try:
             readout_ids = self.get_readout_ids_for_book(book)
@@ -334,7 +339,7 @@ class Imprinter:
                 Bookbinder(smurf_files, hk_files=hkfiles, out_root=odir,
                            stream_id=stream_id, session_id=int(session_id),
                            book_id=book.bid, start_time=start_t, end_time=stop_t,
-                           max_nchannels=book.max_channels, hwp_root=hwp_root,
+                           max_nchannels=book.max_channels,
                            timing_system=timing_system,
                            frameproc_config={"readout_ids": rids})()
             # not sure if this is the best place to update
@@ -342,7 +347,10 @@ class Imprinter:
             book.path = op.abspath(op.join(odir, book.bid))
             self.logger.info("Book {} bound".format(book.bid))
             book.message = message
-            session.commit()
+            if not test_mode:
+                session.commit()
+            else:
+                session.rollback()
         except Exception as e:
             session.rollback()
             book.status = FAILED
@@ -354,7 +362,12 @@ class Imprinter:
             if isinstance(e, TimingSystemError):
                 book.timing = False
             book.message = message
-            session.commit()
+    
+            if not test_mode:
+                session.commit()
+            else:
+                session.rollback()
+
             raise e
 
     def get_book(self, bid, session=None):
@@ -657,6 +670,40 @@ class Imprinter:
             out[obs_id] = ch_info.readout_id
         return out
 
+    def copy_smurf_files_to_book(self, book, book_path):
+        """
+        Copies smurf ancillary files to an operation book.
+
+        Parameters
+        -----------
+        book : Books
+            book object
+        book_path : path
+            Output path of book
+        """
+        if book.type != 'oper':
+            raise TypeError("Book must have type 'oper'")
+
+        session, arc = self.get_g3tsmurf_session(book.tel_tube, return_archive=True)
+
+        obs_ids = [o.obs_id for o in book.obs]
+        obs = session.query(G3tObservations) \
+                     .filter(G3tObservations.obs_id.in_(obs_ids)).all()
+
+        files = []
+        for ob in obs:
+            files.extend(get_smurf_files(ob, arc.meta_path))
+
+        dirname = os.path.join(book_path, 'smurf')
+        if not os.path.exists(dirname):
+            os.makedirs(dirname)
+
+        for f in files:
+            dest = os.path.join(dirname, os.path.basename(f))
+            shutil.copyfile(f, dest)
+
+        return files
+
     def get_g3tsmurf_obs_for_book(self, book):
         """
         Get all g3tsmurf observations for a book
@@ -726,6 +773,47 @@ class Imprinter:
 #####################
 # Utility functions #
 #####################
+
+def get_smurf_files(obs, meta_path):
+    """
+    Returns a list of smurf files that should be copied into a book.
+
+    Parameters
+    ------------
+    obs : G3tObservations
+        Observation to pull files from
+    meta_path : path
+        Smurf metadata path
+
+    Returns
+    -----------
+    files : List[path]
+        List of copyable files
+    """
+
+    def copy_to_book(file):
+        return file.endswith('npy')
+
+    tscode = int(obs.action_ctime//1e5)
+    files = []
+
+    # check adjacent folders in case action falls on a boundary
+    for tc in [tscode-1, tscode, tscode + 1]:  
+        action_dir = os.path.join(
+            meta_path,
+            str(tc), 
+            obs.stream_id,
+            f'{obs.action_ctime}_{obs.action_name}'
+        )
+
+        if not os.path.exists(action_dir):
+            continue
+
+        for root, _, fs in os.walk(action_dir):
+            files.extend([os.path.join(root, f) for f in fs])
+    
+    return [f for f in files if copy_to_book(f)]
+
 _primary_idx_map = {}
 def get_frame_times(frame):
     """


### PR DESCRIPTION
This PR adds smurf ancillary data to `oper` books. Currently this only copies files that have a `npy` suffix, which I believe captures everything we want to add, but we can easily change this if it doesn't. Files are currently copied to `book_output/smurf/<basename>`, but this can change. I was considering `book_folder/smurf/<stream_id>/<basename>`, but I don't think it matters since there will only be one stream-id per oper book.

A few other things this includes
- I added a test_mode kwarg to the `bind_book` function, since it is _really_ useful to be able to run that function to write an existing book to my local directory where I can check it. In test_mode, none of the changes to `book` will be committed, and it won't complain about the book already being bound.
- Removes the hwp binding option. This will definitely need to be merged in for the bookbinder to work properly, so if this PR takes too long we may want to separate it out into a separate PR.

Resolves #361 