### PR TITLE
Add UFM mapping

### DIFF
--- a/sotodlib/core/hardware.py
+++ b/sotodlib/core/hardware.py
@@ -73,6 +73,28 @@ def parse_readout_id(readout_id):
     channel = smband * 8 + smchan
     return (wf, ct, channel)
 
+def sim_wafer_names( hw ):
+    """Adds SO generic UFM names to the hardware model based on the type of the wafer
+       Ex: Uv1, Mv4, Lv3, etc
+    """
+    c = [1,1,1]
+    for wafer in hw.data["wafer_slots"]:
+        wprops = hw.data["wafer_slots"][wafer]
+        if "UHF" in wprops["type"]:
+            pre = "Uv"
+            i = 0
+        elif "MF" in wprops["type"]:
+            pre = "Mv"
+            i = 1
+        elif "LF" in wprops["type"]:
+            pre = "Lv"
+            i = 2
+        else:
+            raise ValueError(f"Unknown band type {wprops['type']} for wafer {wafer}")
+
+        wprops["wafer_name"] = f"{pre}{c[i]}"
+        c[i] += 1
+
 
 class Hardware(object):
     """Class representing a specific hardware configuration.

--- a/sotodlib/sim_hardware.py
+++ b/sotodlib/sim_hardware.py
@@ -255,6 +255,22 @@ def sim_nominal():
     bnd["NET_corr"] = 1.00
     bands["SAT_f290"] = bnd
 
+    # Special "band" for dark bolometers
+
+    bnd = OrderedDict()
+    bnd["center"] = np.nan
+    bnd["low"] = np.nan
+    bnd["high"] = np.nan
+    bnd["bandpass"] = ""
+    bnd["NET"] = 1000.0
+    bnd["fknee"] = 50.0
+    bnd["fmin"] = 0.01
+    bnd["alpha"] = 1.0
+    bnd["A"] = np.nan
+    bnd["C"] = np.nan
+    bnd["NET_corr"] = 1.00
+    bands["NC"] = bnd
+
     cnf["bands"] = bands
 
     wafer_slots = OrderedDict()

--- a/sotodlib/site_pipeline/make_det_info_wafer.py
+++ b/sotodlib/site_pipeline/make_det_info_wafer.py
@@ -93,6 +93,11 @@ def main(args=None):
         # iterate over the ideal/design metadata for this array
         for tune in map_maker.grab_metadata():
             
+            if tune.bandpass is None or (type(tune.bandpass)==str and "NC" in tune.bandpass):
+                bp = "NC"    
+            else:
+                bp = f"f{str(tune.bandpass).rjust(3,'0')}" 
+
             # add detector name to database
             det_rs.append({
                 "dets:det_id": tune.detector_id,
@@ -105,7 +110,7 @@ def main(args=None):
                 w + "design_freq_mhz": replace_none(tune.design_freq_mhz),
                 w + "bias_line": replace_none(tune.bias_line, -1),
                 w + "pol": str(tune.pol),
-                w + "bandpass": f"f{tune.bandpass}" if tune.bandpass is not None else "NC",
+                w + "bandpass": bp,
                 w + "det_row": replace_none(tune.det_row, -1),
                 w + "det_col": replace_none(tune.det_col, -1),
                 w + "rhombus": str(tune.rhomb),

--- a/sotodlib/site_pipeline/make_det_info_wafer.py
+++ b/sotodlib/site_pipeline/make_det_info_wafer.py
@@ -74,6 +74,7 @@ def main(args=None):
         w + "det_x",
         w + "det_y",
         w + "angle",
+        w + "coax",
     ]
 
     for array_name in array_names:
@@ -118,6 +119,7 @@ def main(args=None):
                 w + "det_x": replace_none(tune.det_x),
                 w + "det_y": replace_none(tune.det_y),
                 w + "angle": np.radians(replace_none(tune.angle_actual_deg)),
+                w + "coax" : "N" if tune.is_north else "S",
             })
 
         det_rs.append({
@@ -139,6 +141,7 @@ def main(args=None):
                 w + "det_x": np.nan,
                 w + "det_y": np.nan,
                 w + "angle": np.nan,
+                w + "coax" : "X",
         })
             
         write_dataset(det_rs, configs["det_info"], array_name, args.overwrite)

--- a/sotodlib/site_pipeline/make_det_info_wafer.py
+++ b/sotodlib/site_pipeline/make_det_info_wafer.py
@@ -99,6 +99,12 @@ def main(args=None):
             else:
                 bp = f"f{str(tune.bandpass).rjust(3,'0')}" 
 
+            # some dark detectors are reporting non-nan angles            
+            if str(tune.det_type) == "OPTC":
+                angle = np.radians(replace_none(tune.angle_actual_deg))
+            else:
+                angle = np.nan
+
             # add detector name to database
             det_rs.append({
                 "dets:det_id": tune.detector_id,
@@ -118,7 +124,7 @@ def main(args=None):
                 w + "type": str(tune.det_type),
                 w + "det_x": replace_none(tune.det_x),
                 w + "det_y": replace_none(tune.det_y),
-                w + "angle": np.radians(replace_none(tune.angle_actual_deg)),
+                w + "angle": angle,
                 w + "coax" : "N" if tune.is_north else "S",
             })
 

--- a/sotodlib/toast/sim_focalplane.py
+++ b/sotodlib/toast/sim_focalplane.py
@@ -510,7 +510,11 @@ def load_wafer_detectors(
 
     dets = OrderedDict()
 
+    doff = 0
     for i, detname in enumerate(wafer.dets.vals):
+        if wafer.dets.vals[i] == 'NO_MATCH':
+            continue
+
         dprops = OrderedDict()
         dprops["wafer_slot"] = wafer_slot
         dprops["ID"] = toast.utils.name_UID("detname")
@@ -531,13 +535,16 @@ def load_wafer_detectors(
         dprops["pol_ang_wafer"] = wafer.angle[i] 
         ### angle I'll need help to calculate based on slot
         dprops["pol_orientation_wafer"] = np.nan
-        ### Need to figure out the channel ID, card slot, AMC
-        dprops["channel"] = i % cardprops["nchannel"]
-        dprops["card_slot"] = 0
-        dprops["AMC"] = 0
+        
+        ## channels aren't assigned until Tunes are made, so just ints
+        dprops["channel"] = doff
+        doff += 1
+        ## card slot will be the stream_id name for the wafer slot
+        dprops["card_slot"] = f"stream_id_{wafer_slot}"
 
         ## readout related info
         dprops["bias"] = wafer.bias_line[i]
+        dprops["AMC"] = 0 if wafer.coax[i] == "N" else "S"
         dprops["readout_freq_GHz"] = wafer.design_freq_mhz[i]/1000
         dprops["bondpad"] = wafer.bond_pad[i]
         dprops["mux_position"] = wafer.mux_position[i]

--- a/sotodlib/toast/sim_focalplane.py
+++ b/sotodlib/toast/sim_focalplane.py
@@ -510,7 +510,6 @@ def load_wafer_detectors(
 
     dets = OrderedDict()
 
-    doff = 0
     for i, detname in enumerate(wafer.dets.vals):
         if wafer.dets.vals[i] == 'NO_MATCH':
             continue
@@ -537,14 +536,15 @@ def load_wafer_detectors(
         dprops["pol_orientation_wafer"] = np.nan
         
         ## channels aren't assigned until Tunes are made, so just ints
-        dprops["channel"] = doff
-        doff += 1
+        ## with tunes this will be 512*smurf_band + smurf_channel. not available
+        ## with just hardware mapping files.
+        dprops["channel"] = i 
         ## card slot will be the stream_id name for the wafer slot
         dprops["card_slot"] = f"stream_id_{wafer_slot}"
 
         ## readout related info
         dprops["bias"] = wafer.bias_line[i]
-        dprops["AMC"] = 0 if wafer.coax[i] == "N" else "S"
+        dprops["AMC"] = 0 if wafer.coax[i] == "N" else 1
         dprops["readout_freq_GHz"] = wafer.design_freq_mhz[i]/1000
         dprops["bondpad"] = wafer.bond_pad[i]
         dprops["mux_position"] = wafer.mux_position[i]

--- a/sotodlib/toast/sim_focalplane.py
+++ b/sotodlib/toast/sim_focalplane.py
@@ -565,7 +565,7 @@ def load_wafer_detectors(
 
 
 
-def sim_telescope_detectors(hw, tele, tube_slots=None, det_info=None):
+def sim_telescope_detectors(hw, tele, tube_slots=None, det_info=None, no_darks=False):
     """Update hardware model with simulated or loaded detector positions.
 
     Given a Hardware model, generate all detector properties for the specified
@@ -630,7 +630,8 @@ def sim_telescope_detectors(hw, tele, tube_slots=None, det_info=None):
             if det_info is not None:
                 dets = load_wafer_detectors(
                     hw, wafer_slot, platescale, fwhm,
-                    det_info[0], det_info[1], center=centers[windx]
+                    det_info[0], det_info[1], center=centers[windx],
+                    no_darks=no_darks,
                 )
             else:
                 dets = sim_wafer_detectors(
@@ -668,11 +669,18 @@ def sim_telescope_detectors(hw, tele, tube_slots=None, det_info=None):
             location = tubeprops["toast_hex_pos"]
 
             wradius = 0.5 * (waferspace * platescale * np.pi / 180.0)
-            qwcenters = [
-                xieta_to_quat(-wradius, wradius / np.sqrt(3.0), thirty * 4),
-                xieta_to_quat(0.0, -2.0 * wradius / np.sqrt(3.0), 0.0),
-                xieta_to_quat(wradius, wradius / np.sqrt(3.0), -thirty * 4),
-            ]
+            if det_info is None:
+                qwcenters = [
+                    xieta_to_quat(-wradius, wradius / np.sqrt(3.0), thirty * 4),
+                    xieta_to_quat(0.0, -2.0 * wradius / np.sqrt(3.0), 0.0),
+                    xieta_to_quat(wradius, wradius / np.sqrt(3.0), -thirty * 4),
+                ]
+            else:
+                qwcenters = [
+                    xieta_to_quat(-wradius, wradius / np.sqrt(3.0), thirty * 5),
+                    xieta_to_quat(0.0, -2.0 * wradius / np.sqrt(3.0), thirty),
+                    xieta_to_quat(wradius, wradius / np.sqrt(3.0), -thirty * 3),
+                ]
 
             centers = list()
             for qwc in qwcenters:
@@ -683,7 +691,8 @@ def sim_telescope_detectors(hw, tele, tube_slots=None, det_info=None):
                 if det_info is not None:
                     dets = load_wafer_detectors(
                         hw, wafer_slot, platescale, fwhm,
-                        det_info[0], det_info[1], center=centers[windx]
+                        det_info[0], det_info[1], center=centers[windx],
+                        no_darks=no_darks,
                     )
                 else:
                     dets = sim_wafer_detectors(

--- a/sotodlib/toast/sim_focalplane.py
+++ b/sotodlib/toast/sim_focalplane.py
@@ -625,12 +625,14 @@ def sim_telescope_detectors(hw, tele, tube_slots=None, det_info=None, no_darks=F
             qrot = qa.from_axisangle(zaxis, -thirty)
         else:
             qrot = qa.from_axisangle(zaxis, thirty)
+            rots = [thirty, thirty, -thirty, -3*thirty, 5*thirty, 3*thirty, thirty]
+        
         for p, q in wcenters.items():
             quat = q["quat"]
             if det_info is not None:
                 # Add an additional rotation of the wafer before
                 # repositioning the wafer center
-                quat2 = qa.from_axisangle(zaxis, -thirty)
+                quat2 = qa.from_axisangle(zaxis, rots[int(p)])
                 quat = qa.mult(quat, quat2)
             centers[int(p), :] = qa.mult(qrot, quat)
 
@@ -686,9 +688,9 @@ def sim_telescope_detectors(hw, tele, tube_slots=None, det_info=None, no_darks=F
                 ]
             else:
                 qwcenters = [
-                    xieta_to_quat(-wradius, wradius / np.sqrt(3.0), thirty * 5),
-                    xieta_to_quat(0.0, -2.0 * wradius / np.sqrt(3.0), thirty),
-                    xieta_to_quat(wradius, wradius / np.sqrt(3.0), -thirty * 3),
+                    xieta_to_quat(-wradius, wradius / np.sqrt(3.0), 7*thirty),
+                    xieta_to_quat(0.0, -2.0 * wradius / np.sqrt(3.0), 3*thirty),
+                    xieta_to_quat(wradius, wradius / np.sqrt(3.0), -thirty ),
                 ]
 
             centers = list()

--- a/sotodlib/toast/sim_focalplane.py
+++ b/sotodlib/toast/sim_focalplane.py
@@ -19,6 +19,7 @@ from toast.instrument_sim import (
     rhomb_gamma_angles_qu,
 )
 import toast.qarray as qa
+import toast.utils
 
 from sotodlib.io.metadata import read_dataset
 import sotodlib.core.metadata.loader as loader
@@ -509,11 +510,11 @@ def load_wafer_detectors(
 
     dets = OrderedDict()
 
-    for i in range(wafer.dets.count):
+    for i, detname in enumerate(wafer.dets.vals):
         dprops = OrderedDict()
         dprops["wafer_slot"] = wafer_slot
-        dprops["ID"] = wafer.dets.vals[i]
-        dprops["pixel"] = wafer.dets.vals[i].split("_")[-1][:-1]
+        dprops["ID"] = toast.utils.name_UID("detname")
+        dprops["pixel"] = detname.split("_")[-1][:-1]
         dprops["band"] = f"{tele[:3]}_{wafer.bandpass[i]}" if wafer.bandpass[i] != "NC" else "NC"
 
         if dprops["band"] not in bands and dprops["band"] != "NC":
@@ -530,7 +531,10 @@ def load_wafer_detectors(
         dprops["pol_ang_wafer"] = wafer.angle[i] 
         ### angle I'll need help to calculate based on slot
         dprops["pol_orientation_wafer"] = np.nan
-
+        ### Need to figure out the channel ID, card slot, AMC
+        dprops["channel"] = i % cardprops["nchannel"]
+        dprops["card_slot"] = 0
+        dprops["AMC"] = 0
 
         ## readout related info
         dprops["bias"] = wafer.bias_line[i]
@@ -546,12 +550,12 @@ def load_wafer_detectors(
         )
 
         if center is not None:
-            dprops["quat"] = qa.mult( center, quant).flatten()
+            dprops["quat"] = qa.mult(center, quant).flatten()
         else:
             dprops["qant"] = quant.flatten()
 
-        dprops["detector_name"] = dprops["ID"]
-        dets[ dprops["detector_name"] ] = dprops
+        dprops["detector_name"] = detname
+        dets[dprops["detector_name"]] = dprops
         
     return dets
 

--- a/sotodlib/toast/sim_focalplane.py
+++ b/sotodlib/toast/sim_focalplane.py
@@ -550,16 +550,14 @@ def load_wafer_detectors(
         dprops["mux_position"] = wafer.mux_position[i]
 
         quat = xieta_to_quat(
-            wafer.det_x[i] * platescale,
-            wafer.det_y[i] * platescale,
-            wafer.angle[i]
+            wafer.det_x[i] * platescale *np.pi/180,
+            wafer.det_y[i] * platescale *np.pi/180,
+            wafer.angle[i],
         )
-
         if center is not None:
             dprops["quat"] = qa.mult(center, quat).flatten()
         else:
             dprops["quat"] = quat.flatten()
-
         dprops["detector_name"] = detname
         dets[dprops["detector_name"]] = dprops
 

--- a/sotodlib/vis_hardware.py
+++ b/sotodlib/vis_hardware.py
@@ -101,6 +101,19 @@ def plot_detectors(
         [dets[detnames[x]]["quat"] for x in range(n_det)], dtype=np.float64
     )
 
+    # Skip bolometers that do not have a proper quaternion
+    good = np.isfinite(quats[:, 0])
+    bad = np.logical_not(good)
+    nbad = np.sum(bad)
+    if nbad != 0:
+        print(f"Skipping {nbad} detectors without quaternions")
+        for detname, is_bad in zip(detnames, bad):
+            if is_bad:
+                del dets[detname]
+        detnames = list(dets.keys())
+        quats = quats[good]
+        n_det = len(dets)
+
     lat_rot = None
     lat_elstr = ""
 


### PR DESCRIPTION
Adding the ability to use actual UFM hardware information for the readout sims. The UFM rotations relative to each other look correct. Note: this DOES NOT work for LF detectors yet, the mappings between MF and UHF are similar enough that I can use existing MF mappings to spoof the UHF. The LF detector positions and setup will be totally different. There will be straightforward ways to build off this when we know which UFMs are installed in which wafer slots.

Example use for creating a hardware setup: 
```
lat_hw = sim_nominal()
core.hardware.sim_wafer_names(lat_hw)
sim_telescope_detectors(
    lat_hw, 
    "LAT", 
    tube_slots=["i1"],
    det_info=("/home/kmharrin/scratch/20230216_toast_scratch/det_info.h5","Cv4"),
)
```