### PR TITLE
Make HK Amans Cosampled with Detector Timestreams

### DIFF
--- a/sotodlib/io/hk_utils.py
+++ b/sotodlib/io/hk_utils.py
@@ -249,4 +249,33 @@ def get_hkaman(start, stop, config):
     data = get_grouped_hkdata(start, stop, config)
     hk_amans = make_hkaman(data)
     return hk_amans
+
+def get_detcosamp_hkaman(config, det_aman):
+    """
+    Wrapper to combine get_grouped_hkdata() and make_hkaman() to output one
+    axismanager of HK axismanagers that are cosampled to detector timestreams.
+
+    Parameters:
+        config (str): Filename of a .yaml file for loading HK fields and aliases.
+            Required for get_grouped_hkdata().
+        det_aman (AxisManager): detector data AxisManager from load_smurf().
+
+    Notes
+    -----
+
+    An example config file looks like:
+
+        data_dir: '/mnt/so1/data/chicago-latrt/hk/'
+
+        field_list:
+            'bf_4k' : 'observatory.LSA22HG.feeds.temperatures.Channel_06_T'
+            'xy_stage_x': 'observatory.XYWing.feeds.positions.x'
+            'xy_stage_y': 'observatory.XYWing.feeds.positions.y'
+    """
+    start = det_aman.timestamps[0]
+    stop = det_aman.timestamps[1]
+    data = get_grouped_hkdata(start, stop, config)
+
+    hkamans_detcosamp = make_hkaman(data, det_cosampled=True, det_aman=det_aman)
+    return hkamans_detcosamp
 # TODO: insert a progress bar for get_grouped_hkdata

--- a/sotodlib/io/hk_utils.py
+++ b/sotodlib/io/hk_utils.py
@@ -102,7 +102,7 @@ def get_grouped_hkdata(start, stop, config):
     return grouped_data
 
 
-def make_hkaman(grouped_data):
+def make_hkaman(grouped_data, det_cosamped=False, det_aman=None):
     """
     Takes data from get_grouped_hkdata(), tests whether feed/device is
     cosampled, outputs axismanager(s) for either case.
@@ -110,20 +110,29 @@ def make_hkaman(grouped_data):
     Parameters:
         grouped_data (list): grouped list of data per HK feed/device; output
             from get_grouped_hkdata()
+        det_cosampled (bool): decides how to organize HK data into an AxisManager
+            depending on user preference. Default set to False means HK data is
+            output to an AxisManager per cosampled device, as well as 1 AxisManager
+            per 'channel' for a non-cosampled device. If set to True, all HK data
+            will be interpolated against detector timestreams.
+        det_aman (NoneType): AxisManager of detector data from load_smurf().
+            Only required if det_cosampled is True.
 
     Returns:
-        merged_amans (AxisManager): AxisManager of HK AxisManagers. It can
-            contain 1 axismanager per cosmapled device, as well as 1 axismanger
-            per 'channel' for a non-cosampled device. All HK AxisManagers are
-            wrapped in 1 ultimate axismanager to streamline data analysis, and
-            make it easier to explore axismanager/device keys.
+        merged_amans (AxisManager): AxisManager of HK AxisManagers. For HK
+            cosampled data, it can contain 1 axismanager per cosmapled device,
+            and 1 axismanger per 'channel' for a non-cosampled device.
+            HK data that are cosampled to detector timestreams contain 1
+            axismanager per HK device. All HK axismanagers are wrapped in 1 ultimate
+            axismanager to streamline data analysis.
     """
     amans = []
     device_names = []
     for group in grouped_data:
         data = {}
         aliases = []
-        times = []
+        times_hk = []
+        times_det = {}
         for field in group:
             # arrange data per device to input into aman
             alias = group[field][0]
@@ -132,48 +141,78 @@ def make_hkaman(grouped_data):
             time = group[field][1]
             times.append(time)
 
+            time_info = {alias: time}
+            times_det.update(time_info)
+
             device_data = group[field][2]
 
             info = {alias: device_data}
             data.update(info)
+        
+        # only want HK data, checking for cases where HK data is cosampled
+        if det_cosamped == False:
+            try:
+                # check for cosampled HK devices
+                assert np.all([len(t) == len(times_hk[0]) for t in times_hk])
+                # TODO: diff of times, if less than say 10%??, treat as cosampled
+            except AssertionError:
+                # if device not cosampled, make aman for each field in device/feed
+                logger.debug("{} is not cosampled. Making separate axis managers \
+                             for this case".format('.'.join(field.split('.')[0:3])))
+                for field in group:
+                    alias = group[field][0]
+                    time = group[field][1]
+                    data = group[field][2]
 
-        try:
-            # check whether hk device is cosampled
-            assert np.all([len(t) == len(times[0]) for t in times])
-            # TODO: diff of times, if less than say 10%??, treat as cosampled
-        except AssertionError:
-            # if not cosampled, make aman for each field in device/feed
-            logger.debug("{} is not cosampled. Making separate axis managers \
-                         for this case".format('.'.join(field.split('.')[0:3])))
-            for field in group:
-                alias = group[field][0]
-                time = group[field][1]
-                data = group[field][2]
+                    device_name = field.split('.')[1] + '_' + alias
+                    device_names.append(device_name)
 
-                device_name = field.split('.')[1] + '_' + alias
+                    device_axis = 'hklabels_' + device_name
+                    samps_axis = 'hksamps_' + device_name
+
+                    hkaman = core.AxisManager(core.LabelAxis(alias, [alias]),
+                                              core.OffsetAxis(samps_axis, len(time)))
+                    hkaman.wrap('timestamps', time, [(0, samps_axis)])
+                    hkaman.wrap(device_name, np.array([data]),
+                                [(0, alias), (1, samps_axis)])
+                    amans.append(hkaman)
+            else:
+                # if device cosampled, make 1 aman per device
+                device_name = field.split('.')[1]
                 device_names.append(device_name)
-
                 device_axis = 'hklabels_' + device_name
                 samps_axis = 'hksamps_' + device_name
 
-                hkaman = core.AxisManager(core.LabelAxis(alias, [alias]),
-                                          core.OffsetAxis(samps_axis, len(time)))
-                hkaman.wrap('timestamps', time, [(0, samps_axis)])
-                hkaman.wrap(device_name, np.array([data]),
-                            [(0, alias), (1, samps_axis)])
-                amans.append(hkaman)
+                hkaman_cos = core.AxisManager(core.LabelAxis(device_axis, aliases),
+                                              core.OffsetAxis(samps_axis, len(time)))
+                hkaman_cos.wrap('timestamps', time, [(0, samps_axis)])
+                hkaman_cos.wrap(device_name, np.array([data[alias] for alias in aliases]),
+                                [(0, device_axis), (1, samps_axis)])
+                amans.append(hkaman_cos)
+        
+        # want HK data cosampled to detector timestreams
+        # not concerned with cosampeld HK devices here
         else:
-            # if yes, make one aman per device
+            assert det_aman is not None, "Did not input a detector axis manager as an arg"
+
             device_name = field.split('.')[1]
             device_names.append(device_name)
             device_axis = 'hklabels_' + device_name
-            samps_axis = 'hksamps_' + device_name
 
-            hkaman_cos = core.AxisManager(core.LabelAxis(device_axis, aliases),
-                                          core.OffsetAxis(samps_axis, len(time)))
-            hkaman_cos.wrap('timestamps', time, [(0, samps_axis)])
-            hkaman_cos.wrap(device_name, np.array([data[alias] for alias in aliases]), [(0, device_axis), (1, samps_axis)])
-            amans.append(hkaman_cos)
+            data_interp = {}
+            for alias in times_det:
+                f_hkvals = interp1d(times_det[alias], data[alias], fill_value='extrapolate')
+                hkdata_interp = f_hkvals(det_aman.timestamps)
+
+                info = {alias: hkdata_interp}
+                data_interp.update(info)
+
+            hkaman = core.AxisManager(core.LabelAxis(device_axis, aliases),
+                                      core.OffsetAxis('detector_timestamps', len(det_aman.timestamps)))
+            hkaman.wrap('timestamps', det_aman.timestamps, [(0, 'detector_timestamps')])
+            hkaman.wrap(device_name, np.array([data_interp[alias] for alias in aliases]),
+                        [(0, device_axis), (1, 'detector_timestamps')])
+            amans.append(hkaman)
 
     # make an aman of amans
     merged_amans = core.AxisManager()
@@ -210,78 +249,4 @@ def get_hkaman(start, stop, config):
     data = get_grouped_hkdata(start, stop, config)
     hk_amans = make_hkaman(data)
     return hk_amans
-
-
-def detcosample_hkamans(hkconfig, detconfig, obs_id):
-    """
-    Given a detector observation, output an HK axismanager that cosampled
-    with detector timestreams.
-
-    Parameters:
-        hkconfig (str): The.yaml filename for loading HK fields and aliases.
-        detconfig (str): The .yaml config file matching readout id and detector ids.
-        obs_id (str): The observation id for a detector UFM. Helps determine
-                      the detector start and stop times needed for interpolation.
-
-    Notes
-    -----
-
-    An example detconfig file looks like:
-
-        data_prefix : "/mnt/so1/data/chicago-latrt"
-        hwp_prefix : "/mnt/so1/shared/site-pipeline/data_pkg/chicago-latrt/hwp/"
-        g3tsmurf_db: "/mnt/so1/shared/site-pipeline/data_pkg/chicago-latrt/g3tsmurf.db"
-    """
-    # load detector timestamps
-    SMURF = ls.G3tSmurf.from_configs(detconfig)
-    session = SMURF.Session()
-    obs = session.query(Observations).filter(Observations.obs_id == obs_id).one()
-    det_aman = ls.load_file([f.name for f in obs.files], archive=SMURF)
-
-    grouped_data = get_grouped_hkdata(obs.start, obs.stop, hkconfig)
-
-    amans = []
-    device_names = []
-    for group in grouped_data:
-        data = {}
-        aliases = []
-        times = {}
-        for field in group:
-            # arrange data per device for making an aman per hk device
-            alias = group[field][0]
-            aliases.append(alias)
-
-            time = group[field][1]
-            time_info = {alias: time}
-            times.update(time_info)
-
-            device_data = group[field][2]
-
-            info = {alias: device_data}
-            data.update(info)
-
-        # make an aman per device
-        device_name = field.split('.')[1]
-        device_names.append(device_name)
-        device_axis = 'hklabels_' + device_name
-
-        data_interp = {}
-        for alias in times:
-            f_hkvals = interp1d(times[alias], data[alias], fill_value='extrapolate')
-            hkdata_interp = f_hkvals(det_aman.timestamps)
-
-            info = {alias: hkdata_interp}
-            data_interp.update(info)
-
-        hkaman = core.AxisManager(core.LabelAxis(device_axis, aliases),
-                                  core.OffsetAxis('detector_timestamps', len(det_aman.timestamps)))
-        hkaman.wrap('timestamps', det_aman.timestamps, [(0, 'detector_timestamps')])
-        hkaman.wrap(device_name, np.array([data_interp[alias] for alias in aliases]),
-                    [(0, device_axis), (1, 'detector_timestamps')])
-        amans.append(hkaman)
-
-    merged_detcos_hkamans = core.AxisManager()
-    [merged_detcos_hkamans.wrap(name, a) for (name, a) in zip(device_names, amans)]
-
-    return merged_detcos_hkamans
 # TODO: insert a progress bar for get_grouped_hkdata

--- a/sotodlib/io/hk_utils.py
+++ b/sotodlib/io/hk_utils.py
@@ -5,8 +5,6 @@ import logging
 
 from so3g.hk import load_range
 from sotodlib import core
-import sotodlib.io.load_smurf as ls
-from sotodlib.io.load_smurf import Observations
 
 from scipy.interpolate import interp1d
 
@@ -102,7 +100,7 @@ def get_grouped_hkdata(start, stop, config):
     return grouped_data
 
 
-def make_hkaman(grouped_data, det_cosamped=False, det_aman=None):
+def make_hkaman(grouped_data, det_cosampled=False, det_aman=None):
     """
     Takes data from get_grouped_hkdata(), tests whether feed/device is
     cosampled, outputs axismanager(s) for either case.
@@ -139,7 +137,7 @@ def make_hkaman(grouped_data, det_cosamped=False, det_aman=None):
             aliases.append(alias)
 
             time = group[field][1]
-            times.append(time)
+            times_hk.append(time)
 
             time_info = {alias: time}
             times_det.update(time_info)
@@ -148,9 +146,9 @@ def make_hkaman(grouped_data, det_cosamped=False, det_aman=None):
 
             info = {alias: device_data}
             data.update(info)
-        
+
         # only want HK data, checking for cases where HK data is cosampled
-        if det_cosamped == False:
+        if det_cosampled is False:
             try:
                 # check for cosampled HK devices
                 assert np.all([len(t) == len(times_hk[0]) for t in times_hk])
@@ -189,7 +187,7 @@ def make_hkaman(grouped_data, det_cosamped=False, det_aman=None):
                 hkaman_cos.wrap(device_name, np.array([data[alias] for alias in aliases]),
                                 [(0, device_axis), (1, samps_axis)])
                 amans.append(hkaman_cos)
-        
+
         # want HK data cosampled to detector timestreams
         # not concerned with cosampeld HK devices here
         else:
@@ -250,6 +248,7 @@ def get_hkaman(start, stop, config):
     hk_amans = make_hkaman(data)
     return hk_amans
 
+
 def get_detcosamp_hkaman(config, det_aman):
     """
     Wrapper to combine get_grouped_hkdata() and make_hkaman() to output one
@@ -272,8 +271,8 @@ def get_detcosamp_hkaman(config, det_aman):
             'xy_stage_x': 'observatory.XYWing.feeds.positions.x'
             'xy_stage_y': 'observatory.XYWing.feeds.positions.y'
     """
-    start = det_aman.timestamps[0]
-    stop = det_aman.timestamps[1]
+    start = float(det_aman.timestamps[0])
+    stop = float(det_aman.timestamps[-1])
     data = get_grouped_hkdata(start, stop, config)
 
     hkamans_detcosamp = make_hkaman(data, det_cosampled=True, det_aman=det_aman)


### PR DESCRIPTION
Adding an extra function to `hkutils` that takes in an hkconfig file, a detconfig file, and an obs.id to output an HK axis manager that's cosampled with detector time streams.

Incorporates #404 

Things to note:

- could expand it to make it more general outside of detector timestamps but may need a bit more thinking
- assumes the start and stop times of an `obs.id` is all the start and stop time you need
- probably a better way to do this: right now, it takes in the detector timestamps and adds it as an axis to each individual HK axis manager. Likely, we want just one timestamps axis and need the HK axis manager's to have only interpolated data.
- it'll be good for me to add documentation to the readthedocs on using `hkutils` 