### PR TITLE
g3thwp: fix irig_quality check for irig_type=1, 10Hz

### DIFF
--- a/sotodlib/hwp/g3thwp.py
+++ b/sotodlib/hwp/g3thwp.py
@@ -279,8 +279,8 @@ class G3tHWP():
             return out
 
         if self._irig_type == 1:
-            out['irig_time'] = out['irig_synch_pulse_clock_time'+suffix][1]
-            out['rising_edge_count'] = out['irig_synch_pulse_clock_counts'+suffix][1]
+            out['irig_time'] = data['irig_synch_pulse_clock_time'+suffix][1]
+            out['rising_edge_count'] = data['irig_synch_pulse_clock_counts'+suffix][1]
 
         logger.info('IRIG timing quality check.')
         out['irig_time'], out['rising_edge_count'] = self._irig_quality_check(
@@ -448,7 +448,7 @@ class G3tHWP():
 
         return out
 
-    def eval_angle(self, solved):
+    def eval_angle(self, solved, poly_order=3):
         """
         Evaluate the non-uniformity of hwp angle timestamp and subtract
         The raw hwp angle timestamp is kept.
@@ -493,7 +493,7 @@ class G3tHWP():
         solved['angle_moving_ave'] = moving_average(
             solved['angle'], self._num_edges)
 
-        def detrend(array, deg=3):
+        def detrend(array, deg=poly_order):
             x = np.linspace(-1, 1, len(array))
             p = np.polyfit(x, array, deg=deg)
             pv = np.polyval(p, x)
@@ -937,6 +937,8 @@ class G3tHWP():
 
     def _irig_quality_check(self, irig_time, rising_edge):
         idx = np.where(np.diff(irig_time) == 1)[0]
+        if self._irig_type == 1:
+            idx = np.where(np.isclose(np.diff(irig_time), np.full(len(irig_time)-1, 0.1)))[0]
         if len(irig_time) - 1 == len(idx):
             return irig_time, rising_edge
         elif len(irig_time) > len(idx) and len(idx) > 0:


### PR DESCRIPTION
IRIG quality check was only working for 1Hz, so it was modified to work for irig_type=1 (10Hz).