### PR TITLE
so-site-pipeline command line interface

### DIFF
--- a/docs/site_pipeline.rst
+++ b/docs/site_pipeline.rst
@@ -13,6 +13,14 @@ quick-turnaround data processing at the observatory.
   here will be on operation; command line parameters and config file
   syntax.
 
+
+Command line interface
+======================
+
+
+Usage
+-----
+
 To execute a pipeline element from the command line, use the
 ``so-site-pipeline`` command.  For example, ``make-source-flags`` can
 be invoked as::
@@ -22,6 +30,12 @@ be invoked as::
 To configure tab-completion of element names, in bash, run::
 
   eval `so-site-pipeline --bash-completion`
+
+
+Wrapping a pipeline script
+--------------------------
+
+.. automodule:: sotodlib.site_pipeline.cli
 
 
 Pipeline Elements

--- a/docs/site_pipeline.rst
+++ b/docs/site_pipeline.rst
@@ -19,6 +19,10 @@ be invoked as::
 
   so-site-pipeline make-source-flags [options]
 
+To configure tab-completion of element names, in bash, run::
+
+  eval `so-site-pipeline --bash-completion`
+
 
 Pipeline Elements
 =================

--- a/docs/site_pipeline.rst
+++ b/docs/site_pipeline.rst
@@ -13,6 +13,12 @@ quick-turnaround data processing at the observatory.
   here will be on operation; command line parameters and config file
   syntax.
 
+To execute a pipeline element from the command line, use the
+``so-site-pipeline`` command.  For example, ``make-source-flags`` can
+be invoked as::
+
+  so-site-pipeline make-source-flags [options]
+
 
 Pipeline Elements
 =================
@@ -134,6 +140,8 @@ Command line arguments
 .. argparse::
    :module: sotodlib.site_pipeline.make_source_flags
    :func: get_parser
+   :prog: make-source-flags
+
 
 Config file format
 ``````````````````
@@ -176,7 +184,7 @@ Command line arguments
 
 .. argparse::
    :module: sotodlib.site_pipeline.make_uncal_beam_map
-   :func: _get_parser
+   :func: get_parser
    :prog: make-uncal-beam-map
 
 Config file format

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup_opts["entry_points"] = {
         "so_hardware_trim = sotodlib.scripts.hardware_trim:main",
         "so_hardware_info = sotodlib.scripts.hardware_info:main",
         "so-metadata = sotodlib.core.metadata.manifest:main",
+        "so-site-pipeline = sotodlib.site_pipeline.cli:main",
     ]
 }
 

--- a/sotodlib/site_pipeline/cli.py
+++ b/sotodlib/site_pipeline/cli.py
@@ -1,35 +1,70 @@
+"""In order to plug in nicely to the command line wrapper, element
+submodules should expose functions called ``main()`` and
+``get_parser()``.
+
+The ``get_parser()`` function should look like this::
+
+  def get_parser(parser=None):
+    if parser is None:
+      parser = argparse.ArgumentParser()
+    # element-specific args:
+    parser.add_argument('obs_id', help="The obs_id to analyze.")
+    parser.add_arugment('--config-file', help="Config file.")
+    return parser
+
+When called by the ``so-site-pipeline`` wrapper, a parser will be
+passed in.
+
+The ``main()`` function is the entry point to be called from the CLI
+or from Prefect.  The arguments should include the arguments defined
+through the ArgumentParser, as well as any additional support for
+Prefect (such as a logger argument).  For example::
+
+  def main(obs_id=None, config_file=None, logger=None):
+    ...
+
+
+If you want the submodule to be executable directly as a script (or
+through ``python -m``), add a ``__main__`` handling block like this
+one::
+
+  if __name__ == '__main__':
+    util.main_launcher(main, get_parser)
+
+
+To register a properly organized submodule in the ``so-site-pipeline``
+command line wrapper, edit ``cli.py`` and see comments inline.
+
+"""
+
 import argparse
 
 from . import (
     make_source_flags,
     make_uncal_beam_map,
+    update_g3tsmurf_database,
 )
 
 # Dictionary matching element name to a submodule (which must have
 # been imported above).  Note for these to work, the submodule must
-# have defined a get_parser() and a main() function.
-#
-# Those functions should be set up like this:
-#
-#   def get_parser(parser=None):
-#       if parser is None:
-#           parser = argparse.ArgumentParser(...)
-#       ...
-#
-#   def main(args=None):
-#       args = util.get_args(args, get_parser)
-#
+# have defined a get_parser() and a main() function as described in
+# the module comments above.
 
 ELEMENTS = {
     'make-source-flags': make_source_flags,
     'make-uncal-beam-map': make_uncal_beam_map,
+    'update-g3tsmurf-database': update_g3tsmurf_database,
 }
 
 CLI_NAME = 'so-site-pipeline'
 
 def get_parser():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--bash-completion', action='store_true')
+    # Make sure all args here are redirected to vars starting with
+    # '_'.  We are going to clean those off before passing to the
+    # subcommand.
+    parser.add_argument('--bash-completion', action='store_true',
+                        dest='_bash_completion')
     sps = parser.add_subparsers(dest='_pipemod')
 
     for name, module in ELEMENTS.items():
@@ -41,10 +76,19 @@ def get_parser():
 def main():
     parser = get_parser()
     args = parser.parse_args()
-    if args.bash_completion:
+
+    # Extract top-level args ...
+    top_args = {k: v for k, v in vars(args).items()
+                if k[0] == '_'}
+    [delattr(args, k) for k in top_args]
+
+    if top_args._bash_completion:
         names = list(ELEMENTS.keys())
         print('complete -W "%s" %s' % (' '.join(names), CLI_NAME))
-    else:
-        module = ELEMENTS[args._pipemod]
-        module.main(args)
+        parser.exit()
     
+    if top_args._pipemod is None:
+        parser.error('First argument must be a sub-command.')
+
+    module = ELEMENTS[top_args._pipemod]
+    module.main(args)

--- a/sotodlib/site_pipeline/cli.py
+++ b/sotodlib/site_pipeline/cli.py
@@ -1,0 +1,50 @@
+import argparse
+
+from . import (
+    make_source_flags,
+    make_uncal_beam_map,
+)
+
+# Dictionary matching element name to a submodule (which must have
+# been imported above).  Note for these to work, the submodule must
+# have defined a get_parser() and a main() function.
+#
+# Those functions should be set up like this:
+#
+#   def get_parser(parser=None):
+#       if parser is None:
+#           parser = argparse.ArgumentParser(...)
+#       ...
+#
+#   def main(args=None):
+#       args = util.get_args(args, get_parser)
+#
+
+ELEMENTS = {
+    'make-source-flags': make_source_flags,
+    'make-uncal-beam-map': make_uncal_beam_map,
+}
+
+CLI_NAME = 'so-site-pipeline'
+
+def get_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--bash-completion', action='store_true')
+    sps = parser.add_subparsers(dest='_pipemod')
+
+    for name, module in ELEMENTS.items():
+        sp = sps.add_parser(name)
+        module.get_parser(sp)
+
+    return parser
+
+def main():
+    parser = get_parser()
+    args = parser.parse_args()
+    if args.bash_completion:
+        names = list(ELEMENTS.keys())
+        print('complete -W "%s" %s' % (' '.join(names), CLI_NAME))
+    else:
+        module = ELEMENTS[args._pipemod]
+        module.main(args)
+    

--- a/sotodlib/site_pipeline/cli.py
+++ b/sotodlib/site_pipeline/cli.py
@@ -81,6 +81,7 @@ def main():
     top_args = {k: v for k, v in vars(args).items()
                 if k[0] == '_'}
     [delattr(args, k) for k in top_args]
+    top_args = argparse.Namespace(**top_args)
 
     if top_args._bash_completion:
         names = list(ELEMENTS.keys())
@@ -91,4 +92,4 @@ def main():
         parser.error('First argument must be a sub-command.')
 
     module = ELEMENTS[top_args._pipemod]
-    module.main(args)
+    module.main(**vars(args))

--- a/sotodlib/site_pipeline/make_source_flags.py
+++ b/sotodlib/site_pipeline/make_source_flags.py
@@ -11,8 +11,9 @@ from . import util
 
 logger = logging.getLogger(__name__)
 
-def get_parser():
-    parser = ArgumentParser()
+def get_parser(parser=None):
+    if parser is None:
+        parser = ArgumentParser()
     parser.add_argument('obs_id',help=
                         "Observation for which to generate flags.")
     parser.add_argument('-c', '--config-file', help=
@@ -28,10 +29,8 @@ def get_config(args):
     return cfg
 
 def main(args=None):
-    if args is None:
-        args = sys.argv[1:]
-    parser = get_parser()
-    config = get_config(parser.parse_args(args))
+    args = util.get_args(args, get_parser)
+    config = get_config(args)
 
     if config['verbose'] >= 1:
         logger.setLevel('INFO')

--- a/sotodlib/site_pipeline/make_source_flags.py
+++ b/sotodlib/site_pipeline/make_source_flags.py
@@ -22,21 +22,20 @@ def get_parser(parser=None):
                         default=0, help="Pass multiple times to increase.")
     return parser
 
-def get_config(args):
-    cfg = yaml.safe_load(open(args.config_file, 'r'))
+def get_config(config_file, obs_id=None, verbose=None):
+    cfg = yaml.safe_load(open(config_file, 'r'))
     for k in ['obs_id', 'verbose']:
         cfg[k] = getattr(args, k)
     return cfg
 
-def main(args=None):
-    args = util.get_args(args, get_parser)
-    config = get_config(args)
+def main(config_file=None, verbose=0, obs_id=None):
+    config = get_config(config_file)
 
-    if config['verbose'] >= 1:
+    if verbose >= 1:
         logger.setLevel('INFO')
-    if config['verbose'] >= 2:
+    if verbose >= 2:
         sotodlib.logger.setLevel('INFO')
-    if config['verbose'] >= 3:
+    if verbose >= 3:
         sotodlib.logger.setLevel('DEBUG')
 
     ctx = core.Context(config['context_file'])
@@ -64,11 +63,11 @@ def main(args=None):
     # correspondence to the output index values.
     index_map = {}
 
-    detsets = ctx.obsfiledb.get_detsets(config['obs_id'])
+    detsets = ctx.obsfiledb.get_detsets(obs_id)
     for detset in detsets:
         logger.info(f'Loading {config["obs_id"]}:detset={detset}')
         # Load pointing and dets axis; we don't need signal though.
-        tod = ctx.get_obs(config['obs_id'], detsets=[detset],
+        tod = ctx.get_obs(obs_id, detsets=[detset],
                           no_signal=True)
 
         # Figure out the indexing info for this.
@@ -117,14 +116,17 @@ def main(args=None):
 
         # Get file + dataset from policy.
         policy = util.ArchivePolicy.from_params(config['archive']['policy'])
-        dest_file, dest_dataset = policy.get_dest(config['obs_id'])
+        dest_file, dest_dataset = policy.get_dest(obs_id)
         aman.save(dest_file, dest_dataset, overwrite=True)
 
         # Update the index.
-        db_data = {'obs:obs_id': config['obs_id'],
+        db_data = {'obs:obs_id': obs_id,
                    'dataset': dest_dataset,
                    f'dets:{group_by}': this_index}
         db.add_entry(db_data, dest_file, replace=True)
 
     # Return something?
     return tod, aman
+
+if __name__ == '__main__':
+    util.main_launcher(main, get_parser)

--- a/sotodlib/site_pipeline/make_uncal_beam_map.py
+++ b/sotodlib/site_pipeline/make_uncal_beam_map.py
@@ -201,7 +201,7 @@ def _adjust_focal_plane(tod, focal_plane=None, boresight_offset=None):
     fp.eta[:] = eta
     fp.gamma[:] = gamma
 
-def main(config_file=None, obs_id=None, verbose=0):
+def main(config_file=None, obs_id=None, verbose=0, test=False):
     """Entry point."""
     config = _get_config(config_file)
 
@@ -258,7 +258,7 @@ def main(config_file=None, obs_id=None, verbose=0):
             continue
 
         # Modify dets axis for testing
-        if config['_args'].test:
+        if test:
             logger.warning(f'Decimating focal plane (--test).')
             dets = tod.dets.vals[::10]
             tod.restrict('dets', dets)

--- a/sotodlib/site_pipeline/make_uncal_beam_map.py
+++ b/sotodlib/site_pipeline/make_uncal_beam_map.py
@@ -38,12 +38,8 @@ def get_parser(parser=None):
 
     return parser
 
-def _get_config(args):
-    cfg = yaml.safe_load(open(args.config_file, 'r'))
-    for k in ['obs_id', 'verbose']:
-        cfg[k] = getattr(args, k)
-    cfg['_args'] = args
-    return cfg
+def _get_config(config_file):
+    return yaml.safe_load(open(config_file, 'r'))
 
 def _clip_map(m, mask=None, edges=[0.05, 0.95]):
     if mask is None:
@@ -205,17 +201,16 @@ def _adjust_focal_plane(tod, focal_plane=None, boresight_offset=None):
     fp.eta[:] = eta
     fp.gamma[:] = gamma
 
-def main(args=None):
+def main(config_file=None, obs_id=None, verbose=0):
     """Entry point."""
-    args = util.get_args(args, get_parser)
-    config = _get_config(args)
+    config = _get_config(config_file)
 
     logger = util.init_logger(__name__, 'make_uncal_beam_map: ')
-    if config['verbose'] >= 1:
+    if verbose >= 1:
         logger.setLevel('INFO')
-    if config['verbose'] >= 2:
+    if verbose >= 2:
         sotodlib.logger.setLevel('INFO')
-    if config['verbose'] >= 3:
+    if verbose >= 3:
         sotodlib.logger.setLevel('DEBUG')
 
     ctx = core.Context(config['context_file'])
@@ -225,16 +220,16 @@ def main(args=None):
         group_by = group_by.split(':',1)[1]
 
     if group_by == 'detset':
-        groups = ctx.obsfiledb.get_detsets(config['obs_id'])
+        groups = ctx.obsfiledb.get_detsets(obs_id)
     else:
-        det_info = ctx.get_det_info(config['obs_id'])
+        det_info = ctx.get_det_info(obs_id)
         groups = det_info.subset(keys=[group_by]).distinct()[group_by]
 
     # Ignore some values?
     groups = [g for g in groups if g not in config['subobs'].get('ignore_vals', [])]
 
     if len(groups) == 0:
-        logger.warning(f'No map groups found for obs_id={config["obs_id"]}')
+        logger.warning(f'No map groups found for obs_id={obs_id}')
 
     if os.path.exists(config['archive']['index']):
         logger.info(f'Mapping {config["archive"]["index"]} for the archive index.')
@@ -248,17 +243,17 @@ def main(args=None):
         db = core.metadata.ManifestDb(config['archive']['index'], scheme=scheme)
 
     for group in groups:
-        logger.info(f'Loading {config["obs_id"]}:{group_by}={group}')
-        map_info = {'obs_id': config['obs_id'],
+        logger.info(f'Loading {obs_id}:{group_by}={group}')
+        map_info = {'obs_id': obs_id,
                     'group': group,
                     group_by: group,
         }
         map_info['product_id'] = '{obs_id}-{group}'.format(**map_info)
 
         # Read data.
-        tod = ctx.get_obs(config['obs_id'], dets={group_by: group})
+        tod = ctx.get_obs(obs_id, dets={group_by: group})
         if len(tod.signal) == 0:
-            logger.warning(f'No detectors loaded for obs_id={config["obs_id"]}, '
+            logger.warning(f'No detectors loaded for obs_id={obs_id}, '
                            f'group {group_by}={group}; skipping.')
             continue
 
@@ -374,7 +369,7 @@ def main(args=None):
                 used_names.append(filename)
                 if code == db_code:
                     # Index
-                    db_data = {'obs:obs_id': config['obs_id'],
+                    db_data = {'obs:obs_id': obs_id,
                                'group': group,
                                'split': key}
                     db.add_entry(db_data, filename, replace=True)
@@ -395,3 +390,7 @@ def main(args=None):
 
     # Return something?
     return True
+
+
+if __name__ == '__main__':
+    util.main_launcher(main, get_parser)

--- a/sotodlib/site_pipeline/make_uncal_beam_map.py
+++ b/sotodlib/site_pipeline/make_uncal_beam_map.py
@@ -21,11 +21,12 @@ from sotodlib import core, coords, site_pipeline, tod_ops
 
 from . import util
 
-logger = util.init_logger(__name__, 'make_uncal_beam_map: ')
+logger = None
 
 
-def _get_parser():
-    parser = ArgumentParser()
+def get_parser(parser=None):
+    if parser is None:
+        parser = ArgumentParser()
     parser.add_argument('-c', '--config-file', help=
                         "Configuration file.")
     parser.add_argument('-v', '--verbose', action='count',
@@ -206,11 +207,10 @@ def _adjust_focal_plane(tod, focal_plane=None, boresight_offset=None):
 
 def main(args=None):
     """Entry point."""
-    if args is None:
-        args = sys.argv[1:]
-    parser = _get_parser()
-    config = _get_config(parser.parse_args(args))
+    args = util.get_args(args, get_parser)
+    config = _get_config(args)
 
+    logger = util.init_logger(__name__, 'make_uncal_beam_map: ')
     if config['verbose'] >= 1:
         logger.setLevel('INFO')
     if config['verbose'] >= 2:

--- a/sotodlib/site_pipeline/update_g3tsmurf_database.py
+++ b/sotodlib/site_pipeline/update_g3tsmurf_database.py
@@ -109,8 +109,9 @@ def record_timing(monitor, obs, cfgs):
         )
         monitor.write()
 
-def get_parser():
-    parser = argparse.ArgumentParser()
+def get_parser(parser=None):
+    if parser is None:
+        parser = argparse.ArgumentParser()
     parser.add_argument('config', help="g3tsmurf db configuration file")
     parser.add_argument('--update-delay', help="Days to subtract from now to set as minimum ctime",
                         default=2, type=float)
@@ -120,7 +121,10 @@ def get_parser():
                        default=2, type=int)
     return parser
 
+def main(args):
+    update_g3tsmurf_db(**vars(args))
+
 if __name__ == '__main__':
-    parser = get_parser()
+    parser = get_parser(parser=None)
     args = parser.parse_args()
     update_g3tsmurf_db(**vars(args))

--- a/sotodlib/site_pipeline/update_g3tsmurf_database.py
+++ b/sotodlib/site_pipeline/update_g3tsmurf_database.py
@@ -121,8 +121,8 @@ def get_parser(parser=None):
                        default=2, type=int)
     return parser
 
-def main(args):
-    update_g3tsmurf_db(**vars(args))
+main = update_g3tsmurf_db
+
 
 if __name__ == '__main__':
     parser = get_parser(parser=None)

--- a/sotodlib/site_pipeline/util.py
+++ b/sotodlib/site_pipeline/util.py
@@ -268,16 +268,22 @@ def init_logger(name, announce=''):
 
     return logger
 
-def get_args(args=None, get_parser=None):
-    """Process args into an argparse.Namespace, using sys.argv and a
-    get_parser function if need be.
+def main_launcher(main_func, parser_func, args=None):
+    """Launch an element's main entry point function, after generating
+    a parser and executing it on the command line arguments (or args
+    if it is passed in).
 
-    This is a utility function for site_pipeline scripts so they can
-    be called from the wrapping cli or locally.
+    Args:
+      main_func: the main entry point for a pipeline element.
+      parser_func: the argument parser generation function for a pipeline
+        element.
+      args (list of str): arguments to parse (default is None, which
+        will lead to sys.argv[1:]).
+
+    Returns:
+      Whatever main_func returns.
 
     """
-    if isinstance(args, argparse.Namespace):
-        return args
     if args is None:
         args = sys.argv[1:]
-    return get_parser().parse_args(args)
+    return main_func(**vars(parser_func().parse_args(args=args)))

--- a/sotodlib/site_pipeline/util.py
+++ b/sotodlib/site_pipeline/util.py
@@ -4,6 +4,8 @@ import inspect
 import logging
 import time
 import sys
+import argparse
+
 from astropy import units as u
 
 from .. import core
@@ -265,3 +267,17 @@ def init_logger(name, announce=''):
     logger.info(f'{announce}Log timestamps are relative to {text}')
 
     return logger
+
+def get_args(args=None, get_parser=None):
+    """Process args into an argparse.Namespace, using sys.argv and a
+    get_parser function if need be.
+
+    This is a utility function for site_pipeline scripts so they can
+    be called from the wrapping cli or locally.
+
+    """
+    if isinstance(args, argparse.Namespace):
+        return args
+    if args is None:
+        args = sys.argv[1:]
+    return get_parser().parse_args(args)


### PR DESCRIPTION
This adds an entry point called so-site-pipeline, the purpose of which is to more easily access scripts in sotodlib.site_pipeline.

Only a couple of elements have been "registered" for now; a certain interface in the submodule is expected.

@guanyilun Since this requires formalizing entry points to site pipeline scripts, it is worth considering if it is also a good time to build in easier access from Prefect.  I forget what the exact requirements are there.
