### PR TITLE
Book metadata improvements

### DIFF
--- a/sotodlib/io/bookbinder.py
+++ b/sotodlib/io/bookbinder.py
@@ -513,7 +513,7 @@ class FrameProcessor(object):
             prev_frame_end = self._prev_smurf_sample.time
         # Define a strict upper limit (exclusive) up until which to look/interpolate for missing samples
         if self.BOOK_END_TIME is not None:
-            end_time = min(flush_time.time, self.BOOK_END_TIME.time)
+            end_time = min(flush_time.time, self.BOOK_END_TIME.time + 1)
         elif self._smurf_timestamps is not None:
             end_time = min(flush_time.time, self._smurf_timestamps[-1] + 1)
         else:

--- a/sotodlib/io/bookbinder.py
+++ b/sotodlib/io/bookbinder.py
@@ -757,7 +757,7 @@ class Bookbinder(object):
         self.frame_num = 0
         self.file_sample_counter = 0
         self.prev_file_last_sample_num = 0
-        self.file_sample_ranges = [[0,0]]
+        self.file_sample_ranges = [[0, 0]]
         self.ofile_num = 0
         self.default_mode = True  # True: time-based split; False: scan-based split
         self.MAX_SAMPLES_TOTAL = int(config.get("max_samples_total", 1e9))
@@ -877,14 +877,14 @@ class Bookbinder(object):
                 nsamples = len(f['signal'].times)   # number of samples in current frame
                 # if cumulative sample number exceeds max allowed, create new file to
                 # store the current frame and restart the sample number counter
-                if self.file_sample_counter+nsamples > self.MAX_SAMPLES_PER_CHANNEL:
+                if self.file_sample_counter + nsamples > self.MAX_SAMPLES_PER_CHANNEL:
                     self.ofile_num += 1
-                    curr_file_last_sample_num = self.prev_file_last_sample_num+self.file_sample_counter
+                    curr_file_last_sample_num = self.prev_file_last_sample_num + self.file_sample_counter
                     self.prev_file_last_sample_num = curr_file_last_sample_num
                     self.file_sample_counter = nsamples      # reset sample number to length of current frame
                     self.file_sample_ranges.append([
                         curr_file_last_sample_num,
-                        curr_file_last_sample_num+self.file_sample_counter
+                        curr_file_last_sample_num + self.file_sample_counter
                     ])
                     self.frame_num = 0              # reset frame number to 0
                     self.create_file_writers()

--- a/sotodlib/io/bookbinder.py
+++ b/sotodlib/io/bookbinder.py
@@ -852,7 +852,9 @@ class Bookbinder(object):
         if self._stream_id is not None:
             oframe['stream_id'] = core.G3String(self._stream_id)
         if oframe.type == core.G3FrameType.Scan:
-            oframe['sample_range'] = core.G3VectorInt([self.file_sample_counter-len(f['signal'].times), self.file_sample_counter])
+            range_start = self.prev_file_last_sample_num + self.file_sample_counter - len(f['signal'].times)
+            range_stop  = self.prev_file_last_sample_num + self.file_sample_counter
+            oframe['sample_range'] = core.G3VectorInt([range_start, range_stop])
         return oframe
 
     def write_frames(self, frames_list):

--- a/sotodlib/io/bookbinder.py
+++ b/sotodlib/io/bookbinder.py
@@ -755,7 +755,9 @@ class Bookbinder(object):
         self._meta_file = op.join(out_root, book_id, f'M_index.yaml')
         self.metadata = []
         self.frame_num = 0
-        self.sample_num = 0
+        self.file_sample_counter = 0
+        self.prev_file_last_sample_num = 0
+        self.file_sample_ranges = []
         self.ofile_num = 0
         self.default_mode = True  # True: time-based split; False: scan-based split
         self.MAX_SAMPLES_TOTAL = int(config.get("max_samples_total", 1e9))
@@ -850,7 +852,7 @@ class Bookbinder(object):
         if self._stream_id is not None:
             oframe['stream_id'] = core.G3String(self._stream_id)
         if oframe.type == core.G3FrameType.Scan:
-            oframe['sample_range'] = core.G3VectorInt([self.sample_num-len(f['signal'].times), self.sample_num-1])
+            oframe['sample_range'] = core.G3VectorInt([self.file_sample_counter-len(f['signal'].times), self.file_sample_counter])
         return oframe
 
     def write_frames(self, frames_list):
@@ -871,11 +873,17 @@ class Bookbinder(object):
             # If the number of samples (per channel) exceeds the max allowed, create a new output file
             if f.type == core.G3FrameType.Scan:
                 nsamples = len(f['signal'].times)   # number of samples in current frame
-                self.sample_num += nsamples         # cumulative number of samples in current output file
-                if self.sample_num > self.MAX_SAMPLES_PER_CHANNEL:
+                # if cumulative sample number exceeds max allowed, create new file to
+                # store the current frame and restart the sample number counter
+                if self.file_sample_counter+nsamples > self.MAX_SAMPLES_PER_CHANNEL:
                     self.ofile_num += 1
+                    curr_file_last_sample_num = self.prev_file_last_sample_num+self.file_sample_counter
+                    self.file_sample_ranges.append(
+                        [self.prev_file_last_sample_num, curr_file_last_sample_num]
+                    )
+                    self.prev_file_last_sample_num = curr_file_last_sample_num
                     self.create_file_writers()
-                    self.sample_num = nsamples      # reset sample number to length of current frame
+                    self.file_sample_counter = nsamples      # reset sample number to length of current frame
                     self.frame_num = 0              # reset frame number to 0
             # add misc metadata to output frame and write it out
             oframe = self.add_misc_data(f)
@@ -1019,7 +1027,7 @@ class Bookbinder(object):
              'start_time': self._start_time.time/core.G3Units.s,
              'end_time':   self._end_time.time/core.G3Units.s,
              'n_frames':   self.frame_num,
-             'n_samples':  self.sample_num}
+             'n_samples':  self.file_sample_counter}
 
         if self.hwp_loader is not None:
             d.update(self.hwp_loader.get_metadata())

--- a/sotodlib/io/bookbinder.py
+++ b/sotodlib/io/bookbinder.py
@@ -885,6 +885,8 @@ class Bookbinder(object):
                     self.create_file_writers()
                     self.file_sample_counter = nsamples      # reset sample number to length of current frame
                     self.frame_num = 0              # reset frame number to 0
+                else:
+                    self.file_sample_counter += nsamples
             # add misc metadata to output frame and write it out
             oframe = self.add_misc_data(f)
             self.writer.Process(oframe)

--- a/sotodlib/io/imprinter.py
+++ b/sotodlib/io/imprinter.py
@@ -353,14 +353,22 @@ class Imprinter:
                            smurf_timestamps=timestamps,
                            frameproc_config={"readout_ids": rids})()
 
-            # Add meta files to M_index
+            # update metadata in M_index file
+            mfile = os.path.join(book_path, 'M_index.yaml')
+            with open(mfile, 'r') as f:
+                meta = yaml.safe_load(f)
+
+            meta['telescope'] = book.tel_tube
+            meta['book_type'] = book.type
+            meta['stream_ids'] = book.slots.split(',')
+
+            # add meta files
             if (book.type == 'oper') and meta_files:
-                mfile = os.path.join(book_path, 'M_index.yaml')
-                with open(mfile, 'r') as f:
-                    meta = yaml.safe_load(f)
                 meta['meta_files'] = meta_files
-                with open(mfile, 'w') as f:
-                    yaml.dump(meta, f)
+
+            # write back to M_index file
+            with open(mfile, 'w') as f:
+                yaml.dump(meta, f)
 
             # not sure if this is the best place to update
             book.status = BOUND

--- a/tests/test_bookbinder.py
+++ b/tests/test_bookbinder.py
@@ -112,12 +112,12 @@ def test_fill_missing_samples():
     s = generate_smurf_frame(core.G3VectorTime(t))
 
     start_time = t[0]
-    end_time = t[-1] + 1
+    end_time = t[-1]
     ref_timestamps = t
 
     for smts in [ref_timestamps, None]:
         F = bb.FrameProcessor(start_time=start_time, end_time=end_time, smurf_timestamps=ref_timestamps)
-        sout, flag_gap = F.fill_in_missing_samples(s['data'], F.BOOK_END_TIME, return_flags=True)
+        sout, flag_gap = F.fill_in_missing_samples(s['data'], flush_time=F.BOOK_END_TIME+1, return_flags=True)
 
         err_msg = f"Default test case failed. Output not equal to input. With ref timestamps: {smts!=None}"
         np.testing.assert_array_equal(sout.times, t, err_msg=err_msg)
@@ -138,8 +138,7 @@ def test_fill_missing_samples():
     first_samples = [t[0], t[0]-3*dt]
     last_samples = [t[-1], t[-1]+3*dt]
     for start_time, end_time in zip(first_samples, last_samples):
-        end_time += 1  # to ensure last sample gets included since flush_time is excluded from output frame
-        ref_timestamps = np.arange(start_time, end_time, dt)  # reference timestamps to check against
+        ref_timestamps = np.arange(start_time, end_time+1, dt)  # reference timestamps to check against
         true_timestamps = ref_timestamps  # for this test, they are the same
 
         # Book start/end times don't have to line up with first/last samples
@@ -152,7 +151,7 @@ def test_fill_missing_samples():
                 for smts in [ref_timestamps, None]:
                     F = bb.FrameProcessor(start_time=book_start, end_time=book_end, smurf_timestamps=smts)
                     F._prev_smurf_sample = prev_samp
-                    sout, flag_gap = F.fill_in_missing_samples(s['data'], F.BOOK_END_TIME, return_flags=True)
+                    sout, flag_gap = F.fill_in_missing_samples(s['data'], flush_time=F.BOOK_END_TIME+1, return_flags=True)
 
                     err_msg = f"Test failed with: First/last samples {start_time}, {end_time-1};\
                                 Book start/end: {book_start}, {book_end}; With prev frame: {prev_samp!=None};\

--- a/tests/test_imprinter.py
+++ b/tests/test_imprinter.py
@@ -42,10 +42,10 @@ def obsset():
     file.stop = dt_t1
     file.n_channels = 10
     obs1 = create_autospec(G3tObservations)
-    obs1.obs_id = f"slot1_{t0}"
+    obs1.obs_id = f"oper_slot1_{t0}"
     obs1.files = [file]*2
     obs2 = create_autospec(G3tObservations)
-    obs2.obs_id = f"slot2_{t0}"
+    obs2.obs_id = f"oper_slot2_{t0}"
     obs2.files = [file]*2
     obsset = ObsSet([obs1, obs2], mode="oper", slots=["slot1", "slot2", "slot3"], tel_tube="lat")
     return obsset
@@ -54,7 +54,7 @@ def test_ObsSet(obsset):
     assert obsset.mode == "oper"
     assert obsset.slots == ["slot1", "slot2", "slot3"]
     assert obsset.tel_tube == "lat"
-    assert obsset.obs_ids == ["slot1_1674090159", "slot2_1674090159"]
+    assert obsset.obs_ids == ["oper_slot1_1674090159", "oper_slot2_1674090159"]
     assert obsset.get_id() == "oper_1674090159_lat_110"
     assert obsset.contains_stream("slot1") == True
     assert obsset.contains_stream("slot2") == True
@@ -64,8 +64,8 @@ def test_register_book(imprinter, obsset):
     book = imprinter.register_book(obsset)
     assert book.bid == "oper_1674090159_lat_110"
     assert book.status == UNBOUND
-    assert book.obs[0].obs_id == "slot1_1674090159"
-    assert book.obs[1].obs_id == "slot2_1674090159"
+    assert book.obs[0].obs_id == "oper_slot1_1674090159"
+    assert book.obs[1].obs_id == "oper_slot2_1674090159"
     assert book.tel_tube == "lat"
     assert book.type == "oper"
     assert book.start == datetime.utcfromtimestamp(1674090159)
@@ -115,7 +115,7 @@ def test_book_bound(imprinter):
     assert imprinter.book_bound(books[0].bid) == False
 
 def test_stream_timestamp():
-    obs_id = 'stream1_1674090159'
+    obs_id = 'oper_stream1_1674090159'
     stream, timestamp = stream_timestamp(obs_id)
     assert stream == 'stream1'
     assert timestamp == '1674090159'


### PR DESCRIPTION
Fixed issues (1,3,5) with metadata found in #388.

An example M_index.yaml file from this PR:

```yaml
book_id: obs_1677794454_sat1_1111101
book_type: obs
end_time: 1677795650.3189769
n_frames: 38
n_samples: 239315
sample_ranges:
- - 0
  - 239315
session_id: 1677794454
start_time: 1677794453.7489772
stream_ids:
- ufm_mv14
- ufm_mv18
- ufm_mv19
- ufm_mv22
- ufm_mv6
- ufm_mv9
telescope: sat1
```
An example M_book.yaml from this PR:
```yaml
book:
  book_id: obs_1677794454_sat1_1111101
  finalized_at: '2023-03-18T17:14:16.597195'
  schema_version: 0
  type: obs
bookbinder:
  codebase: /home/yguan/software/sotodlib/sotodlib/__init__.py
  context: simons1-data-pkg-dev
  version: 0.4.0+1175.gf37013d.dirty
```

Also fixed an off-by-1 bug that came up during my local testing, and propagated the corresponding changes to the unit tests.

Edit: schema_version v0 -> 0