### PR TITLE
Add options to make the planets polarized

### DIFF
--- a/sotodlib/toast/ops/sim_source.py
+++ b/sotodlib/toast/ops/sim_source.py
@@ -688,7 +688,7 @@ class SimSource(Operator):
             )
 
             sig *= weights_I + pfrac * (
-                np.cos(angle) * weights_Q + np.sin(angle) * weights_U
+                np.cos(2 * angle) * weights_Q + np.sin(2 * angle) * weights_U
             )
 
             signal[good] += sig

--- a/sotodlib/toast/ops/sim_sso.py
+++ b/sotodlib/toast/ops/sim_sso.py
@@ -481,7 +481,7 @@ class SimSSO(Operator):
         angle = self.polarization_angle.to_value(u.radian)
 
         sig *= weights_I + pfrac * (
-            np.cos(angle) * weights_Q + np.sin(angle) * weights_U
+            np.cos(2 * angle) * weights_Q + np.sin(2 * angle) * weights_U
         )
         return
 

--- a/workflows/toast_so_sim.py
+++ b/workflows/toast_so_sim.py
@@ -459,6 +459,7 @@ def simulate_data(job, args, toast_comm, telescope, schedule):
     # Simulate Solar System Objects
 
     ops.sim_sso.detector_pointing = ops.det_pointing_azel
+    ops.sim_sso.detector_weights = ops.weights_radec
     ops.sim_sso.apply(data)
     log.info_rank(
         "Simulated and observed solar system objects",


### PR DESCRIPTION
This PR extends the planetary emission models to include linear polarization.  The user sets the polarization fraction and angle that get applied to all planetary observations and all planets. The reference frame is set by the workflow and is currently set to be the Celestial system.