### PR TITLE
G3tsmurf Updates 2023-04

### DIFF
--- a/docs/g3tsmurf.rst
+++ b/docs/g3tsmurf.rst
@@ -273,7 +273,7 @@ Loading long large observations into memory at once can cause issues with memory
 usage, especially on smaller computing facilities. This function is a generator
 than can be called to automatically split observations into smaller sections.
 
-.. autofuction:: sotodlib.io.g3tsmurf_utils.get_batch
+.. autofunction:: sotodlib.io.g3tsmurf_utils.get_batch
 
 Observation Files
 ==================

--- a/docs/g3tsmurf.rst
+++ b/docs/g3tsmurf.rst
@@ -299,13 +299,15 @@ In this setup, the main G3tSmurf database is both the ObsFileDb and the ObsDb.
 A minimal example context yaml file is::
 
     tags:
-    g3tsmurf_dir: '/path/to/things/smurf_context'
+        g3tsmurf_dir: '/path/to/things/smurf_context'
 
     obsfiledb: '{g3tsmurf_dir}/g3t_smurf_db.db'
     obsdb: '{g3tsmurf_dir}/g3t_smurf_db.db'
 
     imports:
     - sotodlib.io.load_smurf
+
+    context_hooks: 'obs_detdb_load'
 
     obs_loader_type: 'g3tsmurf'
 

--- a/docs/g3tsmurf.rst
+++ b/docs/g3tsmurf.rst
@@ -41,7 +41,20 @@ Loading with G3tSmurf
 =====================
 
 To load data with database information we first have to instantiate
-our G3tSmurf object:: 
+our G3tSmurf object. This is most easily done using a YAML configuration file
+because those are easily shared between people. The configuration file requires
+two keys::
+
+    data_prefix: "/path/to/data"
+    g3tsmurf_db: "/path/to/database.db"
+
+This configuration file is set up so that other keys, such as a HWP prefixes or
+HK prefixes could also be added. With a config file, you connect to the G3tSmurf
+database as::
+
+    SMURF = G3tSmurf.from_configs("configs.yaml")
+
+Without a configuration file, you can directly pass the required paths::
     
     SMURF = G3tSmurf(archive_path='/path/to/data/timestreams/',
                      meta_path='/path/to/data/smurf/,
@@ -53,33 +66,29 @@ Load a file with database information for the readout channel names::
 
     aman = load_file(filename, archive=SMURF)
     
-Load a specific time range, this will work whether or not the time range is
-considered an observation as defined by the ObsDb / Observation table::
 
-    aman = SMURF.load_data(start, stop, stream_id=None)
-    
-Start and stop can be ctimes or datetime objects. If multiple streams are
-running at the same time you have to specify which one you want.
+.. warning::
+    The SMURF.load_data function no longer has complete functionality 
+    compared to load_file. Use load_file where possible. The example below shows
+    how to use load_file to load a complete observation.
 
 To find a specific Observation, a time when data was just streaming with no
-other specific actions being run (ie: not an IV), we can search the Observation
+other specific actions being run, we can search the Observation
 table. Here is an example of finding the first Observation after a specific
 ctime::
 
     session = SMURF.Session()
-    obs = session.query(Observations).filter(Observations.timestamp > my_ctime)
+    obs = session.query(Observations).filter(
+        Observations.timestamp > my_ctime
+    )
     obs = obs.order_by(Observations.start).first()
-    aman = SMURF.load_data(obs.start, obs.stop)
+    aman = load_file( [f.name for f in obs.files], archive=SMURF )
     
 These queries are built using
 `SQLAlchemy <https://docs.sqlalchemy.org/en/14/orm/tutorial.html#querying>`_
 commands and can filter on any of the columns in the
 :ref:`Observations<g3tsmurf-tables-section>` table.
 
-
-.. autoclass:: G3tSmurf
-    :members: load_data
-    :noindex:
 
 Channel Masks on Load
 ======================
@@ -196,18 +205,22 @@ Database Creation and Update Script
 
 Keeping the databases updated requires a little care when we are building
 databases while data is actively being taken. To assist with this there is
-an **update_g3tsmurf_database.py** script saved within the
-**sotodlib.site_pipeline** folder. This script takes the *data_prefix* which is 
-the path to the main save folders and expects to find the *timestreams* and
-*smurf* folders at that path. The *db_path* is the path to the database to be
-created or updated. The user running this script must have read, write, and 
-execute permissions to that file.
+an **update_g3tsmurf_database.py** script saved within the 
+**sotodlib.site_pipeline** folder. This script requires config file that is the
+same as for connecting to the G3tSmurf database::
+
+    data_prefix: "/path/to/data"
+    g3tsmurf_db: "/path/to/database.db"
+
+The user running this script must have read, write, and execute permissions to
+the database file in order to perform updates.
 
 Here is the information for this script:
 
 .. argparse::
     :module: sotodlib.site_pipeline.update_g3tsmurf_database
     :func: get_parser
+
 
 Utilities with G3tSmurf
 ------------------------
@@ -234,6 +247,24 @@ files. For Example::
     
         return os.path.join(base_dir, 'outputs',info)
 
+Operation Searches
+====================
+
+Many types of sodetlib operations are saved in the G3tSmurf databases and we
+have many functions meant to be one-liner searches to help find sodetlib
+operations relative to observations. Note, these searches are based on automatic
+file tagging that was implemented in Oct. 2022. Operations from before that may
+not be found.
+
+
+.. autofunction:: sotodlib.io.g3tsmurf_utils.get_last_bg_map
+.. autofunction:: sotodlib.io.g3tsmurf_utils.get_last_bias_step
+.. autofunction:: sotodlib.io.g3tsmurf_utils.get_last_iv
+.. autofunction:: sotodlib.io.g3tsmurf_utils.get_next_bg_map
+.. autofunction:: sotodlib.io.g3tsmurf_utils.get_next_bias_step
+.. autofunction:: sotodlib.io.g3tsmurf_utils.get_next_iv
+
+
  
 Batched load of Observations
 ============================
@@ -242,9 +273,7 @@ Loading long large observations into memory at once can cause issues with memory
 usage, especially on smaller computing facilities. This function is a generator
 than can be called to automatically split observations into smaller sections.
 
-.. automodule:: sotodlib.io.g3tsmurf_utils
-    :special-members: get_batch
-    :noindex:
+.. autofuction:: sotodlib.io.g3tsmurf_utils.get_batch
 
 Observation Files
 ==================
@@ -253,9 +282,10 @@ There are many instances where we might want to load the SMuRF metadata
 associated with actions that have made it into the database. These function take
 an obs_id and a G3tSmurf instance and return paths or file lists. 
 
-.. automodule:: sotodlib.io.g3tsmurf_utils
-    :special-members: get_obs_folder, get_obs_outputs, get_obs_plots
-    :noindex:
+.. autofunction:: sotodlib.io.g3tsmurf_utils.get_obs_folder
+.. autofunction:: sotodlib.io.g3tsmurf_utils.get_obs_outputs 
+.. autofunction:: sotodlib.io.g3tsmurf_utils.get_obs_plots
+
 
 Usage with Context
 ------------------
@@ -263,24 +293,16 @@ Usage with Context
 .. py:module:: sotodlib.io.load_smurf
     :noindex:
 
-The G3tSmurf database can now be used with the larger `sotodlib` Context system.
+The G3tSmurf database can be used with the larger `sotodlib` Context system.
 In this setup, the main G3tSmurf database is both the ObsFileDb and the ObsDb.
-The DetDb needs to be created using the `dump_DetDb(SMURF, detdb_file)`. This
-function call can be added to the standard database update script to keep it up
-to date. 
 
-.. warning::
-    The DetDb setup is the least complete section of merging G3tSmurf into
-    Context and there are active plans to change this setup.
-
-Example context yaml file::
+A minimal example context yaml file is::
 
     tags:
     g3tsmurf_dir: '/path/to/things/smurf_context'
 
     obsfiledb: '{g3tsmurf_dir}/g3t_smurf_db.db'
     obsdb: '{g3tsmurf_dir}/g3t_smurf_db.db'
-    detdb: '{g3tsmurf_dir}/detdb.db'
 
     imports:
     - sotodlib.io.load_smurf

--- a/sotodlib/io/g3tsmurf_db.py
+++ b/sotodlib/io/g3tsmurf_db.py
@@ -32,11 +32,13 @@ class Observations(Base):
     
     Dec. 2021 -- The definitions of obs_id and timestamp changed to better 
     match the operation of the smurf-streamer / sodetlib / pysmurf.
+    Oct. 2022 -- The definition of obs_id changed again to include obs or oper
+    tags based on if the observation is an sodetlib operation or not.
     
     Attributes 
     -----------
     obs_id : string
-        <stream_id>_<session_id>. 
+        <obs|oper>_<stream_id>_<session_id>. 
     timestamp : integer
         The .g3 session_id, which is also the ctime the .g3 streaming started
         and the first part .g3 file name.

--- a/sotodlib/io/g3tsmurf_db.py
+++ b/sotodlib/io/g3tsmurf_db.py
@@ -247,7 +247,13 @@ class Tunes(Base):
     ## one to many
     tuneset_id = db.Column(db.Integer, db.ForeignKey('tunesets.id'))
     tuneset = relationship("TuneSets", back_populates='tunes')
-    
+   
+    @staticmethod
+    def get_name_from_status(status):
+        """Return the name format expected from SmurfStatus instance
+        """
+        return status.stream_id+"_"+status.tune.strip(".npy")
+ 
 class TuneSets(Base):
     """Indexing of 'tunes sets' available during observations. Should
     correspond to the tune files where new_master_assignment=True. TuneSets

--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -583,7 +583,7 @@ class G3tSmurf:
         session : SQLAlchemy Session
             The active session
         """
-        name = tune_path.split("/")[-1]
+        name = stream_id+"_"+tune_path.split("/")[-1].strip(".npy")
         tune = (
             session.query(Tunes)
             .filter(Tunes.name == name, Tunes.stream_id == stream_id)

--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -435,7 +435,9 @@ class G3tSmurf:
 
         logger.info(f"Indexing {len(files)} files...")
 
-        for f in tqdm(sorted(files)[::-1], disable=(not show_pb)):
+        ## files must be updated in sequencial order. otherwise we may end up
+        ## with more TuneSets than are necessary
+        for f in tqdm(sorted(files), disable=(not show_pb)):
             try:
                 self.add_file(os.path.join(root, f), session)
                 session.commit()
@@ -862,7 +864,7 @@ class G3tSmurf:
             obs.tag = ",".join(status.tags)
 
         # Add Tune and Tuneset information
-        if status.tune is not None:
+        if status.tune is not None and status.tune != "":
             tune = session.query(Tunes).filter(
                 Tunes.name == Tunes.get_name_from_status(status),
                 Tunes.stream_id == obs.stream_id,

--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -782,8 +782,8 @@ class G3tSmurf:
         if len(status.tags) > 0:
             for tag in status.tags:
                 new_tag = Tags(obs_id=obs.obs_id, tag=tag)
+                session.add(new_tag)
             obs.tag = ",".join(status.tags)
-            session.add(new_tag)
 
         # Add Tune and Tuneset information
         if status.tune is not None:

--- a/sotodlib/site_pipeline/update_g3tsmurf_database.py
+++ b/sotodlib/site_pipeline/update_g3tsmurf_database.py
@@ -43,7 +43,11 @@ def update_g3tsmurf_db(config=None, update_delay=2, from_scratch=False,
     monitor = None
     if "monitor" in cfgs:
         logger.info("Will send monitor information to Influx")
-        monitor = Monitor.from_configs(cfgs["monitor"]["connect_configs"])
+        try:
+            monitor = Monitor.from_configs(cfgs["monitor"]["connect_configs"])
+        except Exception as e:
+            logger.error(f"Monitor connectioned failed {e}")
+            monitor = None
         
     SMURF.index_metadata(min_ctime=min_time.timestamp())
     SMURF.index_archive(min_ctime=min_time.timestamp(), show_pb=show_pb)
@@ -63,8 +67,11 @@ def update_g3tsmurf_db(config=None, update_delay=2, from_scratch=False,
         
         if monitor is not None:
             if obs.stop is not None:
-                record_timing(monitor, obs, cfgs)
-                record_tuning(monitor, obs, cfgs)
+                try:
+                    record_timing(monitor, obs, cfgs)
+                    record_tuning(monitor, obs, cfgs)
+                except Exception as e:
+                    logger.error(f"Monitor Update failed for {obs.obs_id} with {e}")
 
 def _obs_tags(obs, cfgs):
     

--- a/sotodlib/site_pipeline/update_g3tsmurf_database.py
+++ b/sotodlib/site_pipeline/update_g3tsmurf_database.py
@@ -45,8 +45,9 @@ def update_g3tsmurf_db(config=None, update_delay=2, from_scratch=False,
         logger.info("Will send monitor information to Influx")
         monitor = Monitor.from_configs(cfgs["monitor"]["connect_configs"])
         
-    SMURF.index_archive(min_ctime=min_time.timestamp(), show_pb=show_pb)
     SMURF.index_metadata(min_ctime=min_time.timestamp())
+    SMURF.index_archive(min_ctime=min_time.timestamp(), show_pb=show_pb)
+    SMURF.index_action_observations(min_ctime=min_time.timestamp())    
 
     session = SMURF.Session()
 

--- a/sotodlib/site_pipeline/update_g3tsmurf_database.py
+++ b/sotodlib/site_pipeline/update_g3tsmurf_database.py
@@ -58,7 +58,7 @@ def update_g3tsmurf_db(config=None, update_delay=2, from_scratch=False,
     new_obs = session.query(Observations).filter(Observations.start >= min_time).all()
 
     for obs in new_obs:
-        if obs.stop is None:
+        if obs.stop is None or len(obs.tunesets)==0:
             SMURF.update_observation_files(
                 obs, 
                 session, 


### PR DESCRIPTION
Going through a bunch of g3tsmurf updates at once. Now ready for review!

Biggest part of this PR is re-ordering the database updating and reworking some of the logic based on existing issues. To test this I made a databases covering all of SAT1's P10R2 cooldown using both the current master branch and this branch. All the differences between the two databases are because of fixing existing issues. Making note of what I checked here because this really should go into a test structure somehow:

- Size Old: 126Mb, New: 112Mb
- Channels: Old: 42572. New: 42288.
- Channel Assignments: Old: 198, New: 198
- Tunes: Old: 197, New: 197
- TuneSets: Old: 197. New: 25 ( Expected because of #259 )
- Observations: Old 2010. New 2222 ( Expected, with caveats because of #304 )
- Tags: Old 2006. New. 6728 (Expected because of #218 )
- Stray Files: Old: 206, New: 0 (Expected because of #304 )
- There are 6 observations in the new database that are categorized as observations based on tag when they were previously categorized as operations based on action name. This is likely an issue with tagging in sodetlib but the re-categorization is correct based on what is in the files. 
- The first 7 observations in the new database are not the old database because of how I ran the updates
- All other new observations are recovered noise timestreams in other actions.
- There are 4 old observations that did not have a tuneset but now do have one in the new dataset. Every new observation has a tuneset if the old observations have them.
- All new observations have the same tuneset as their respective old observations 
- All new TuneSets have the same set of readout_ids as the old TuneSets

I've also gone back in time and looked at some LATRt databases that did not have the final tagging implemented and have verified these updates do not break backward compatibility.