### PR TITLE
Improve so-metadata cli

### DIFF
--- a/docs/context.rst
+++ b/docs/context.rst
@@ -746,23 +746,6 @@ The context.yaml metadata entry would probably look like this::
 
 
 
-so-metadata tool
-----------------
-
-The ``so-metadata`` script is a tool for inspecting and manipulating
-ManifestDbs stored on disk.  For example, it can show you what files
-are referred to by the ManifestDb, and what kind of information is
-used to index the database.
-
-If you need to change the filenames in a ManifestDb, the "reroot" mode
-might be helpful.
-
-
-.. argparse::
-   :module: sotodlib.core.metadata.manifest
-   :func: get_parser
-
-
 ManifestDb reference
 --------------------
 
@@ -1563,6 +1546,30 @@ Here's the class documentation for ResultSetHdfLoader:
 -----------------
 Command Line Tool
 -----------------
+
+
+The `so-metadata` script is a tool that can be used to inspect and
+alter the contents of ObsFileDb, ObsDb, and ManifestDb ("metadata")
+sqlite3 databases.  In the case of ObsFileDb and ManifestDb, it can
+also be used to perform batch filename updates.
+
+To summarize a database, pass the db type and then the path to the db
+file.  It might be convenient to start by printing a summary of the
+context.yaml file, as this will give full paths to the various
+databases, that can be copied and pasted::
+
+  so-metadata context /path/to/context.yaml
+
+
+Analyzing individual databases::
+
+  so-metadata obsdb /path/to/context/obsdb.
+  so-metadata obsfiledb /path/to/context/obsfiledb.sqlite
+  so-metadata metadata /path/to/context/some_metadata.sqlite
+
+
+Usage
+=====
 
 .. argparse::
    :module: sotodlib.core.metadata.cli

--- a/docs/context.rst
+++ b/docs/context.rst
@@ -1559,3 +1559,14 @@ Here's the class documentation for ResultSetHdfLoader:
 .. autoclass:: sotodlib.io.metadata.ResultSetHdfLoader
    :inherited-members: __init__
    :members:
+
+-----------------
+Command Line Tool
+-----------------
+
+.. argparse::
+   :module: sotodlib.core.metadata.cli
+   :func: get_parser
+   :prog: so-metadata
+
+

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup_opts["entry_points"] = {
         "so_hardware_plot = sotodlib.scripts.hardware_plot:main",
         "so_hardware_trim = sotodlib.scripts.hardware_trim:main",
         "so_hardware_info = sotodlib.scripts.hardware_info:main",
-        "so-metadata = sotodlib.core.metadata.manifest:main",
+        "so-metadata = sotodlib.core.metadata.cli:main",
         "so-site-pipeline = sotodlib.site_pipeline.cli:main",
     ]
 }

--- a/sotodlib/core/metadata/__init__.py
+++ b/sotodlib/core/metadata/__init__.py
@@ -9,6 +9,7 @@ from .obsdb import ObsDb
 from .obsfiledb import ObsFileDb
 from .manifest import ManifestDb, ManifestScheme
 from .loader import SuperLoader, LoaderInterface, Unpacker, merge_det_info
+from . import cli
 
 def get_example(db_type, *args, **kwargs):
     if db_type == 'DetDb':

--- a/sotodlib/core/metadata/cli.py
+++ b/sotodlib/core/metadata/cli.py
@@ -20,6 +20,7 @@ import os
 from .. import Context
 from . import ObsDb
 from . import manifest
+from . import obsfiledb
 
 
 CLI_NAME = 'so-metadata'
@@ -57,6 +58,9 @@ def get_parser():
 
     sp = sps.add_parser('metadata', description="Inspect (or modify) a ManifestDb.")
     manifest.get_parser(sp)
+
+    sp = sps.add_parser('obsfiledb')
+    obsfiledb.get_parser(sp)
 
     return parser
 
@@ -130,6 +134,9 @@ def main():
 
     elif args._subcmd == 'metadata':
         manifest.main(args)
+
+    elif args._mode == 'obsfiledb':
+        obsfiledb.main(args, parser=parser)
 
     else:
         parser.error('Not implemented: {args._subcmd}')

--- a/sotodlib/core/metadata/cli.py
+++ b/sotodlib/core/metadata/cli.py
@@ -1,0 +1,139 @@
+"""Command-line interface for inspecting Context, obsdb and obsfiledb.
+
+This program can be used to inspect the contents of ObsFileDb, ObsDb,
+and ManifestDb ("metadata") sqlite3 databases.  In the case of
+ObsFileDb and ManifestDb, it can also be used to perform batch updates
+of filenames.
+
+To summarize a database, pass the db type and then either the path to
+the db file, or the path to the context.yaml file; some examples::
+
+  %(prog)s obsdb /path/to/context.yaml
+  %(prog)s obsfiledb /path/to/context/obsfiledb.sqlite
+
+
+"""
+
+import argparse
+import os
+
+from .. import Context
+from . import ObsDb
+from . import manifest
+
+
+CLI_NAME = 'so-metadata'
+HELP = """Read context / metadata databases and print summary or detailed
+information.  You have to pass a db type (obsdb, obsfiledb, ...)
+followed by the a db filename (or the path to a context.yaml, from
+which the relevant db will be loaded).
+
+"""
+
+USAGE = "%(prog)s [db_type] [filename]"
+
+
+def get_parser():
+    parser = argparse.ArgumentParser(description=HELP)
+
+    sps = parser.add_subparsers(dest='_subcmd')
+
+    sp = sps.add_parser('obsdb', description=
+                        'Inspect an ObsDb.  By default, prints out summary information.  '
+                        'Pass --list to see a list of all observations; or pass an obs_id '
+                        'to get detailed info about that obs.')
+    sp.add_argument('db_file', help='Path to database (or context.yaml).')
+    sp.add_argument('--type', choices=['context', 'db'], help=
+                    'Specifies how to interpret the file (to override guessing '
+                    'based on the filename extension.')
+    sp.add_argument('--list', '-l', action='store_true', help=
+                    'List all observations')
+    sp.add_argument('--query', '-q', default='1', help=
+                    'Restrict listed items with an ObsDb query string.')
+    sp.add_argument('--key', '-k', action='append', default=[], help=
+                    'If listing observations, also include the speficied db fields '
+                    'in addition to obs_id.')
+    sp.add_argument('obs_id', nargs='?')
+
+    sp = sps.add_parser('metadata', description="Inspect (or modify) a ManifestDb.")
+    manifest.get_parser(sp)
+
+    return parser
+
+
+def _set_type(args):
+    if args.type is None:
+        ext = os.path.splitext(args.db_file)[1]
+        if ext in ['.yaml', '.yml']:
+            args.type = 'context'
+        elif ext in ['.sqlite', '.db']:
+            args.type = 'db'
+        else:
+            parser.error(
+                f'Not sure how to decode file with extension "{ext}"; pass --type=...')
+    return args.type
+
+
+def main():
+    parser = get_parser()
+    args = parser.parse_args()
+
+    if args._subcmd == 'obsdb':
+        _set_type(args)
+
+        if args.type == 'context':
+            ctx = Context(args.db_file)
+            db = ctx.obsdb
+        elif args.type == 'db':
+            db = ObsDb(args.db_file)
+
+        # Summary mode?
+        if args.obs_id is None:
+            if args.list:
+                rows = db.query(args.query)
+
+                if args.list:
+                    fields = ['obs_id']
+                    for k in args.key:
+                        fields.extend([_k.strip() for _k in k.split(',')])
+                    for line in rows:
+                        print(' '.join([str(line[k]) for k in fields]))
+            else:
+                info = db.info()
+                print('  ObsDb summary')
+                print('=================')
+                print()
+                if args.query != '1':
+                    print('Note the "--query" argument is not applied to these results!')
+                    print()
+                print('There are %i observations' % info['count'])
+                print()
+                print(' Index fields (distinct values, examples)')
+                print('------------------------------------------')
+                for f, (count, eg_str) in info['fields'].items():
+                    print(f'  {f:<15} ({count:d} distinct), e.g.: {eg_str}')
+                print()
+                print(' Tags defined (incidence)')
+                print('--------------------------')
+                for t, count in info['tags'].items():
+                    print(f'  {t:<15} ({count:d} assignments)')
+                print()
+        else:
+            print(' Observation info')
+            print('-' * 60)
+            item = db.get(args.obs_id)
+            if item is None:
+                print(f'  "{args.obs_id}" not found!')
+            else:
+                for k, v in db.get(args.obs_id).items():
+                    print(f'  {k:<20}: {v}')
+
+    elif args._subcmd == 'metadata':
+        manifest.main(args)
+
+    else:
+        parser.error('Not implemented: {args._subcmd}')
+
+if __name__ == '__main__':
+    main()
+

--- a/sotodlib/core/metadata/cli.py
+++ b/sotodlib/core/metadata/cli.py
@@ -51,7 +51,9 @@ def get_parser():
     sp.add_argument('obs_id', nargs='?')
 
     # obsfiledb
-    sp = sps.add_parser('obsfiledb')
+    sp = sps.add_parser('obsfiledb', description=
+                        'Inspect an ObsFileDb.  This can be used to list all files, '
+                        'and to perform batch updates of filenames.')
     obsfiledb.get_parser(sp)
 
     # metadata

--- a/sotodlib/core/metadata/manifest.py
+++ b/sotodlib/core/metadata/manifest.py
@@ -649,10 +649,11 @@ class ManifestDb:
         return False
 
 
-def get_parser():
-    parser = argparse.ArgumentParser(
-        epilog="""For details of individual modes, pass a dummy database argument
-        followed by the mode and -h, e.g.: "%(prog)s x files -h" """)
+def get_parser(parser=None):
+    if parser is None:
+        parser = argparse.ArgumentParser(
+            epilog="""For details of individual modes, pass a dummy database argument
+            followed by the mode and -h, e.g.: "%(prog)s x files -h" """)
 
     parser.add_argument('filename', help="Path to a ManifestDb.",
                         metavar='my_db.sqlite')
@@ -763,8 +764,9 @@ def main(args=None):
     """Entry point for the so-metadata tool."""
     if args is None:
         args = sys.argv[1:]
-    parser = get_parser()
-    args = parser.parse_args(args)
+    if not isinstance(args, argparse.Namespace):
+        parser = get_parser()
+        args = parser.parse_args(args)
 
     if args.mode is None:
         args.mode = 'summary'

--- a/sotodlib/core/metadata/obsfiledb.py
+++ b/sotodlib/core/metadata/obsfiledb.py
@@ -1,5 +1,7 @@
 import sqlite3
 import os
+import sys
+import argparse
 from collections import OrderedDict
 import numpy as np
 
@@ -475,3 +477,156 @@ class ObsFileDb:
             for line in output:
                 fout.write(line+'\n')
         return output
+
+
+def get_parser(parser=None):
+    if parser is None:
+        parser = argparse.ArgumentParser(
+            epilog="""For details of individual modes, pass a dummy database argument
+            followed by the mode and -h, e.g.: "%(prog)s x files -h" """)
+
+    parser.add_argument('filename', help="Path to an ObsFileDb.",
+                        metavar='obsfiledb.sqlite')
+
+    cmdsubp = parser.add_subparsers(
+        dest='mode')
+
+    # "files"
+    p = cmdsubp.add_parser(
+        'files', usage="""Syntax:
+
+    %(prog)s
+    %(prog)s --all
+    %(prog)s --clean
+
+        This will print out a list of the files in the db,
+        along with obs_id and detset.  Only a few lines
+        will be shown, unless --all is passed.  To get a
+        simple list of all files (for rsync or something),
+        pass --clean.
+        """,
+        help="List the files referenced in the database.")
+
+    p.add_argument('--clean', action='store_true',
+                   help="Print a simple list of all files (for script digestion).")
+    p.add_argument('--all', action='store_true',
+                   help="Print all files, not an abbreviated list.")
+
+    # "reroot"
+    p = cmdsubp.add_parser(
+        'reroot', help=
+        "Batch change filenames (by prefix) in the database.",
+        usage="""Syntax:
+
+    %(prog)s old_prefix new_prefix [output options]
+
+Examples:
+
+    %(prog)s /path/on/system1 /path/on/system2 -o my_new_manifest.sqlite
+    %(prog)s /path/on/system1 /new_path/on/system1 --overwrite
+    %(prog)s ./result1/obs_12345.h5 ./result2/obs_12345.h5 --overwrite
+
+        These operations will create a duplicate of the source
+        ObsFileDb, with only the filenames (potentially) altered.  Any
+        filename that starts with the first argument will be changed,
+        in the output, to instead start with the second argument.
+        When you do this you must either say where to write the output
+        (-o) or give the program permission to overwrite your input
+        database file.  Note that the first argument need not match
+        all entries in the database; you can use it to pick out a
+        subset (even a single entry).  """)
+    p.add_argument('old_prefix', help=
+                   "Prefix to match in current database.")
+    p.add_argument('new_prefix', help=
+                   "Prefix to replace it with.")
+    p.add_argument('--overwrite', action='store_true', help=
+                   "Store modified database in the same file.")
+    p.add_argument('--output-db', '-o', help=
+                   "Store modified database in this file.")
+    p.add_argument('--dry-run', action='store_true', help=
+                   "Run the conversion steps but do not write the results anywhere.")
+
+    return parser
+
+def main(args=None, parser=None):
+    """Entry point for the so-metadata tool."""
+    if args is None:
+        args = sys.argv[1:]
+    elif not isinstance(args, argparse.Namespace):
+        parser = get_parser()
+        args = parser.parse_args(args)
+
+    if args.mode is None:
+        args.mode = 'summary'
+
+    db = ObsFileDb.from_file(args.filename, force_new_db=False)
+
+    if args.mode == 'files':
+        # Get all files.
+        rows = db.conn.execute(
+            'select obs_id, name, detset from files '
+            'order by obs_id, detset, name').fetchall()
+
+        if args.clean:
+            for obs_id, filename, detset in rows:
+                print(filename)
+        else:
+            fmt = '  {obs_id} {detset} {filename}'
+            hdr = fmt.format(obs_id="obs_id", detset="detset", filename="Filename")
+            print(hdr)
+            print('-' * (len(hdr) + 20))
+            n = len(rows)
+            if n > 20 and not args.all:
+                rows = rows[:10]
+            for obs_id, filename, detset in rows:
+                print(fmt.format(obs_id=obs_id, filename=filename, detset=detset))
+            if len(rows) < n:
+                print(fmt.format(obs_id='...', filename='+%i others' % (n - len(rows)), detset=''))
+                print('(Pass --all to show all results.)')
+            print()
+
+    elif args.mode == 'reroot':
+        # Reconnect with write?
+        if args.overwrite:
+            if args.output_db:
+                parser.error("Specify only one of --overwrite or --output-db.")
+            db = ObsFileDb.from_file(args.filename, force_new_db=True)
+            args.output_db = args.filename
+        else:
+            if args.output_db is None:
+                parser.error("Specify an output database name with --output-db, "
+                             "or pass --overwrite to clobber.")
+            db = ObsFileDb.from_file(args.filename, force_new_db=True)
+
+        # Get all files matching this prefix ...
+        c = db.conn.execute('select name from files '
+                            'where name like "%s%%"' % (args.old_prefix))
+        rows = c.fetchall()
+        print('Found %i records matching prefix ...'
+               % len(rows))
+
+        print('Converting to new prefix ...')
+        n_examples = 1
+
+        if not args.dry_run:
+            c = db.conn.cursor()
+
+        for (name, ) in rows:
+            new_name = args.new_prefix + name[len(args.old_prefix):]
+            if n_examples > 0:
+                print(f'  Example: converting filename\n'
+                      f'      "{name}"\n'
+                      f'    to\n'
+                      f'      "{new_name}"')
+                n_examples -= 1
+            if not args.dry_run:
+                c.execute('update files set name=? where name=?', (new_name, name))
+
+        print('Saving to %s' % args.output_db)
+        if not args.dry_run:
+            db.conn.commit()
+            c.execute('vacuum')
+            db.to_file(args.output_db)
+
+    else:
+        parser.error(f'Unimplemented mode, "{args.mode}".')

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -68,8 +68,31 @@ class ContextTest(unittest.TestCase):
             name, _ = self._open_new('db.sqlite', 'create')
             db.to_file(name)
             cd[key] = name
-            ctx = Context(self._write_context(cd))
+            ctx_file = self._write_context(cd)
+            ctx = Context(ctx_file)
             self.assertIsInstance(getattr(ctx, key), cls)
+            metadata.cli.main(args=['context', ctx_file])
+
+    def test_010_cli(self):
+        def save_db(src, k, suffix=''):
+            if src.get(k) is None:
+                return
+            if isinstance(src[k], str):
+                return
+            db_file, _ = self._open_new(k + suffix, 'create')
+            src[k].to_file(db_file)
+            src[k] = db_file
+
+        dataset_sim = DatasetSim()
+        ctx = dataset_sim.get_context()
+        for _db in ['obsfiledb', 'obsdb', 'detdb']:
+            print(ctx)
+            save_db(ctx, _db)
+        for i, entry in enumerate(ctx.get('metadata', [])):
+            save_db(entry, 'db', str(i))
+
+        ctx_file = self._write_context(dict(ctx))
+        metadata.cli.main(args=['context', ctx_file])
 
     def test_100_loads(self):
         dataset_sim = DatasetSim()

--- a/tests/test_obsdb.py
+++ b/tests/test_obsdb.py
@@ -78,6 +78,11 @@ class TestObsDb(unittest.TestCase):
             print('  -- removing.')
             os.remove(fn)
 
+    def test_info(self):
+        """Check the .info method."""
+        db0 = get_example()
+        db0.info()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_obsfiledb.py
+++ b/tests/test_obsfiledb.py
@@ -59,6 +59,10 @@ class TestObsFileDB(unittest.TestCase):
                     sorted(db2.get_detsets(obs_id)))
             assert (db.get_detsets('not an obs') == [])
 
+            # CLI
+            if fmt == 'sqlite':
+                metadata.obsfiledb.main([self.test_filename, 'files'])
+
     def test_010_remove(self):
         db = self.get_simple_db(4, 3)
         n0 = len(db.get_obs())


### PR DESCRIPTION
Enhancements to the `so-metadata` command line interface.

It is now possible to inspect Context yaml files, and ObsDb and ObsFileDb, in addition to ManifestDb.

This should make it easier to debug context / metadata configuration issues.