### PR TITLE
Detrend Speedup

### DIFF
--- a/sotodlib/flags.py
+++ b/sotodlib/flags.py
@@ -46,11 +46,20 @@ def get_turnaround_flags(tod, qlim=1, az=None, merge=True,
             tod.flags.wrap(name, flag)
     return flag
 
-
-def get_glitch_flags(aman, t_glitch=0.002, hp_fc=0.5, n_sig=10, buffer=200,
-                     signal=None, merge=True,
-                     overwrite=False, name='glitches',
-                     full_output=False):
+@profile
+def get_glitch_flags(
+    aman, 
+    t_glitch=0.002, 
+    hp_fc=0.5, 
+    n_sig=10, 
+    buffer=200,
+    detrend=None,
+    signal=None, 
+    merge=True,
+    overwrite=False, 
+    name='glitches',
+    full_output=False
+):
     """ Find glitches with fourier filtering
     Translation from moby2 as starting point
 
@@ -60,6 +69,7 @@ def get_glitch_flags(aman, t_glitch=0.002, hp_fc=0.5, n_sig=10, buffer=200,
         hp_fc: high pass filter cutoff
         n_sig (int or float): significance of detection
         buffer (int): amount to buffer flags around found location
+        detrend (str): detrend method to pass to fourier_filter
         signal (str): if None, defaults to 'signal'
         merge (bool): if true, add to aman.flags
         name (string): name of flag to add to aman.flags
@@ -76,7 +86,7 @@ def get_glitch_flags(aman, t_glitch=0.002, hp_fc=0.5, n_sig=10, buffer=200,
         signal = 'signal'
     # f-space filtering
     filt = filters.high_pass_sine2(cutoff=hp_fc) * filters.gaussian_filter(t_sigma=0.002)
-    fvec = fourier_filter(aman, filt, detrend='linear',
+    fvec = fourier_filter(aman, filt, detrend=detrend,
                           signal_name=signal, resize='zero_pad')
     # get the threshods based on n_sig x nlev = n_sig x iqu x 0.741
     fvec = np.abs(fvec)

--- a/sotodlib/flags.py
+++ b/sotodlib/flags.py
@@ -46,7 +46,6 @@ def get_turnaround_flags(tod, qlim=1, az=None, merge=True,
             tod.flags.wrap(name, flag)
     return flag
 
-@profile
 def get_glitch_flags(
     aman, 
     t_glitch=0.002, 

--- a/sotodlib/site_pipeline/preprocess_tod.py
+++ b/sotodlib/site_pipeline/preprocess_tod.py
@@ -106,6 +106,7 @@ def preprocess_tod(obs_id, configs, overwrite=False, logger=None):
     pipe = _build_pipe_from_configs(configs)
 
     for group in groups:
+        logger.info(f"Beginning run for {obs_id}:{group}")
 
         aman = context.get_obs(obs_id, dets={group_by:group})
         aman, proc_aman = run_preprocess(aman, pipe, logger=logger)
@@ -155,6 +156,8 @@ def run_preprocess(aman, pipe=None, configs=None, logger=None):
 
         process.process(aman, proc_aman) ## make changes to aman
         process.calc_and_save(aman, proc_aman) ## calculate data products
+    logger.info("Finished Processing")
+
     return aman, proc_aman
 
 def load_preprocess_det_select(obs_id, configs, context=None):
@@ -278,6 +281,7 @@ def main(
 
     logger.info(f"Beginning to run preprocessing on {len(run_list)} observations")
     for obs in run_list:
+        logger.info(f"Processing obs_id: {obs_id}")
         preprocess_tod(obs["obs_id"], configs, overwrite=overwrite,logger=logger)
             
 

--- a/sotodlib/tod_ops/__init__.py
+++ b/sotodlib/tod_ops/__init__.py
@@ -1,4 +1,4 @@
-from .detrend import detrend_data, detrend_tod
+from .detrend import detrend_tod
 from .fft_ops import rfft
 from .filters import fourier_filter, fft_trim
 from .gapfill import \

--- a/sotodlib/tod_ops/detrend.py
+++ b/sotodlib/tod_ops/detrend.py
@@ -1,50 +1,51 @@
 import numpy as np
 
+
 def detrend_tod(
-    tod, 
-    method='linear', 
-    axis_name='samps', 
-    signal_name='signal', 
+    tod,
+    method='linear',
+    axis_name='samps',
+    signal_name='signal',
     in_place=True,
     wrap_name=None,
     count=10
 ):
-    
     """Returns detrended data. Detrends data in place by default but pass
-        in_place=False if you would like a copied array (such as if you're just
-        looking to use this in an FFT).
+    in_place=False if you would like a copied array (such as if you're just
+    looking to use this in an FFT).
 
-        Using this with method ='mean' and axis_name='dets' will remove a 
-        common mode from the detectors
-        Using this with method ='median' and axis_name='dets' will remove a 
-        common mode from the detectors with the median rather than the mean
-    
-    Arguments:
-    
+    Using this with method ='mean' and axis_name='dets' will remove a
+    common mode from the detectors
+    Using this with method ='median' and axis_name='dets' will remove a
+    common mode from the detectors with the median rather than the mean
+
+    Arguments
+    ---------
         tod: axis manager
-    
-        method: method of detrending can be 'linear', 'mean', or median
-        
-        axis_name: the axis along which to detrend. default is 'samps'
-        
-        signal_name: the name of the signal to detrend. defaults to 'signal'.
-            Can have any shape as long as axis_name can be resolved.
-        
-        in_place: bool. if False it makes a copy of signal before detrending and
-            returns the copy
-    
-        wrap_name: str. or None. if not None, wrap the detrended data into tod
-            with this name.
+        method: str
+            method of detrending can be 'linear', 'mean', or median
+        axis_name: str
+            the axis along which to detrend. default is 'samps'
+        signal_name: str
+            the name of the signal to detrend. defaults to 'signal'. Can have
+            any shape as long as axis_name can be resolved.
+        in_place: bool.
+            If False it makes a copy of signal before detrending and returns
+            the copy.
+        wrap_name: str or None.
+            If not None, wrap the detrended data into tod with this name.
+        count: int
+            Number of samples to use, on each end, when measuring mean level
+            for 'linear' detrend.  Values larger than 1 suppress the influence
+            of white noise.
 
-        count: Number of samples to use, on each end, when measuring
-            mean level for 'linear' detrend.  Values larger than 1
-            suppress the influence of white noise.
-
-    Returns:
-        
-        detrended signal. Done in place or on a copy depend on in_place arg.
-
+    Returns
+    -------
+        signal: array of type tod[signal_name]
+            Detrended signal. Done in place or on a copy depend on in_place
+            argument.
     """
+
     signal = tod[signal_name]
     if not in_place:
         signal = signal.copy()
@@ -52,7 +53,7 @@ def detrend_tod(
 
     axis_idx = list(tod._assignments[signal_name]).index(axis_name)
     n_samps = signal.shape[axis_idx]
-    
+
     # Ensure last axis is the one to detrend.
     # note that any axis re-ordering is not the slow part of this function
     if axis_idx != signal.ndim - 1:
@@ -60,22 +61,24 @@ def detrend_tod(
         axis_reorder = list(range(signal.ndim))
         axis_reorder[axis_idx], axis_reorder[-1] = -1, axis_idx
         signal = signal.transpose(tuple(axis_reorder))
-        
+
     if method == 'mean':
-        signal = signal - np.mean(signal, axis=-1)[...,None]
+        signal = signal - np.mean(signal, axis=-1)[..., None]
     elif method == 'median':
-        signal = signal - np.median(signal, axis=-1)[...,None]
+        signal = signal - np.median(signal, axis=-1)[..., None]
     elif method == 'linear':
         x = np.linspace(0, 1, n_samps, dtype=dtype_in)
         count = max(1, min(count, signal.shape[-1] // 2))
-        slopes = signal[...,-count:].mean(axis=-1,dtype=dtype_in)-signal[...,:count].mean(axis=-1,dtype=dtype_in)
-        ## the 2d loop is significantly faster if possible
+        slopes = (signal[..., -count:].mean(axis=-1, dtype=dtype_in) -
+                  signal[..., :count].mean(axis=-1, dtype=dtype_in))
+
+        # the 2d loop is significantly faster if possible
         if len(signal.shape) == 2:
             for i in range(signal.shape[0]):
-                signal[i,:] -= slopes[i]*x
+                signal[i, :] -= slopes[i]*x
         else:
-            signal -= slopes[...,None] * x
-        signal -= np.mean(signal, axis=-1)[...,None]
+            signal -= slopes[..., None] * x
+        signal -= np.mean(signal, axis=-1)[..., None]
     else:
         raise ValueError("method flag must be linear, mean, or median")
 
@@ -83,9 +86,11 @@ def detrend_tod(
         signal = signal.transpose(tuple(axis_reorder))
 
     assert signal.dtype == dtype_in
-    
+
     if wrap_name is not None:
-        axis_map = [(i,x) for i,x in enumerate(tod._assignments[signal_name])] 
-        tod.wrap( wrap_name, signal, axis_map) 
+        axis_map = [(
+            i, x) for i, x in enumerate(tod._assignments[signal_name])
+        ]
+        tod.wrap(wrap_name, signal, axis_map)
 
     return signal

--- a/sotodlib/tod_ops/detrend.py
+++ b/sotodlib/tod_ops/detrend.py
@@ -53,12 +53,12 @@ def detrend_data(tod, method='linear', axis_name='samps',
         x = np.linspace(0, 1, n_samps)
         count = max(1, min(count, signal.shape[-1] // 2))
         slopes = signal[...,-count:].mean(axis=-1)-signal[...,:count].mean(axis=-1)
-        if len(signal.shape)>2:
-            signal -= slopes[...,None] * x
         ## the 2d loop is significantly faster if possible
-        else:
+        if len(signal.shape) == 2:
             for i in range(signal.shape[0]):
                 signal[i,:] -= slopes[i]*x
+        else:
+            signal -= slopes[...,None] * x
         signal -= np.mean(signal, axis=-1)[...,None]
     else:
         raise ValueError("method flag must be linear, mean, or median")

--- a/sotodlib/tod_ops/fft_ops.py
+++ b/sotodlib/tod_ops/fft_ops.py
@@ -8,7 +8,7 @@ from sotodlib import core
 import so3g
 
 from sotodlib import core
-from . import detrend_data
+from . import detrend_tod
 
 def _get_num_threads():
     # Guess how many threads we should be using in FFT ops...
@@ -24,7 +24,8 @@ def rfft(aman, detrend='linear', resize='zero_pad', window=np.hanning,
         aman: axis manager
         
         detrend: Method of detrending to be done before ffting. Can
-            be 'linear', 'mean', or None.
+            be 'linear', 'mean', or None. Note that detrending here can be slow
+            for large arrays.
             
         resize: How to resize the axis to increase fft speed. 'zero_pad' 
             will increase to the next 2**N. 'trim' will cut out so the 
@@ -68,8 +69,8 @@ def rfft(aman, detrend='linear', resize='zero_pad', window=np.hanning,
     if detrend is None:
         signal = np.atleast_2d(getattr(aman, signal_name))
     else:
-        signal = detrend_data(aman, detrend, axis_name=axis_name, 
-                             signal_name=signal_name)
+        signal = detrend_tod(aman, detrend, axis_name=axis_name, 
+                             signal_name=signal_name, in_place=True)
     
     if other_idx is not None and other_idx != 0:
         signal = signal.transpose()

--- a/sotodlib/tod_ops/filters.py
+++ b/sotodlib/tod_ops/filters.py
@@ -5,7 +5,7 @@ import scipy.signal as signal
 
 import logging
 
-from . import detrend_data
+from . import detrend_tod
 from . import fft_ops
 from sotodlib import core
 
@@ -29,7 +29,8 @@ def fourier_filter(tod, filt_function,
             fourier space
         
         detrend: Method of detrending to be done before ffting. Can
-            be 'linear', 'mean', or None.
+            be 'linear', 'mean', or None. Note that detrending here can be slow
+            for large arrays
             
         resize: How to resize the axis to increase fft
             speed. 'zero_pad' will increase to the next nice number (a
@@ -84,8 +85,8 @@ def fourier_filter(tod, filt_function,
 
     if detrend is not None:
         logger.info('fourier_filter: detrending.')
-        signal = detrend_data(tod, detrend, axis_name=axis_name,
-                             signal_name=signal_name)
+        signal = detrend_tod(tod, detrend, axis_name=axis_name,
+                             signal_name=signal_name, in_place=False)
     else:
         signal = tod[signal_name]
     signal = np.atleast_2d(signal)

--- a/tests/test_tod_ops.py
+++ b/tests/test_tod_ops.py
@@ -68,13 +68,19 @@ class PcaTest(unittest.TestCase):
         tod.wrap('sig1d', tod.signal[0], [(0, 'samps')])
         tod.wrap('sig1e', tod.signal[:,0], [(0, 'dets')])
         tod.wrap('sig3d', tod.signal[None], [(1, 'dets'), (2, 'samps')])
-        tod_ops.detrend_data(tod)
-        tod_ops.detrend_data(tod, signal_name='sig1d')
-        tod_ops.detrend_data(tod, signal_name='sig1e', axis_name='dets')
-        tod_ops.detrend_data(tod, signal_name='sig3d')
-        tod_ops.detrend_data(tod, signal_name='sig3d', axis_name='dets')
+        tod_ops.detrend_tod(tod, signal_name='signal', in_place=False, wrap_name='detrended')
+        self.assertTrue( np.all(np.mean(tod.signal,axis=-1) != np.mean(tod.detrended, axis=-1)))
+
+        dx = tod_ops.detrend_tod(tod, signal_name='signal', in_place=False, wrap_name=None)
+        self.assertTrue( np.all(np.mean(tod.detrended,axis=-1) == np.mean(dx,axis=-1)))
+        
+        tod_ops.detrend_tod(tod)
+        tod_ops.detrend_tod(tod, signal_name='sig1d')
+        tod_ops.detrend_tod(tod, signal_name='sig1e', axis_name='dets')
+        tod_ops.detrend_tod(tod, signal_name='sig3d')
+        tod_ops.detrend_tod(tod, signal_name='sig3d', axis_name='dets')
         with self.assertRaises(ValueError):
-            tod_ops.detrend_data(tod, signal_name='sig1e')
+            tod_ops.detrend_tod(tod, signal_name='sig1e')
 
 class GapFillTest(unittest.TestCase):
     def test_basic(self):


### PR DESCRIPTION
The hour+ SAT books are giving us a good opportunity to profile the `tod_ops` code. There are several we'll need to work on but this is the start. 

Detrend on 1 UFM x 1.2 hours of data was taking ~110 seconds on simons1. The longest parts were subtracting the slopes and recasting at then end (in case data types had changed). Moving to the `-=`, using the `for` loop if possible, and only recasting if the data type had changed got it down to ~6 seconds. Added some comments so we hopefully remember why it's done this way.

Also add another argument to `get_glitch_flags` which lets us speed that up a little bit but that one will take some more careful work to speed up in the future (it's currently at ~240 seconds). 

Edit: Added some quick changes to `calc_psd` to let us just reduce the samples we call for it. I'm not planning any other changes on this branch.