### PR TITLE
Metadata Loading Changes

### DIFF
--- a/sotodlib/core/context.py
+++ b/sotodlib/core/context.py
@@ -177,6 +177,7 @@ class Context(odict):
                 detsets=None,
                 meta=None,
                 ignore_missing=None,
+                ignore_missing_dets=False,
                 free_tags=None,
                 no_signal=None,
                 loader_type=None,
@@ -211,6 +212,8 @@ class Context(odict):
             obs_colon_tags fields for detector restrictions.
           ignore_missing (bool): If True, don't fail when a metadata
             item can't be loaded, just try to proceed without it.
+          ignore_missing_dets (bool): If True, don't fail when metadata entries
+            are missing information for a subset of detectors.
           no_signal (bool): If True, the .signal will be set to None.
             This is a way to get the axes and pointing info without
             the (large) TOD blob.  Not all loaders may support this.
@@ -279,7 +282,8 @@ class Context(odict):
         """
         meta = self.get_meta(obs_id=obs_id, dets=dets, samples=samples,
                              filename=filename, detsets=detsets, meta=meta,
-                             free_tags=free_tags, ignore_missing=ignore_missing)
+                             free_tags=free_tags, ignore_missing=ignore_missing,
+                             ignore_missing_dets=ignore_missing_dets)
 
         # Use the obs_id, dets, and samples from meta.
         obs_id = meta['obs_info']['obs_id']
@@ -335,6 +339,7 @@ class Context(odict):
                  free_tags=None,
                  check=False,
                  ignore_missing=False,
+                 ignore_missing_dets=True,
                  det_info_scan=False):
         """Load supporting metadata for an observation and return it in an
         AxisManager.
@@ -446,11 +451,16 @@ class Context(odict):
         detsets_info = self.obsfiledb.get_det_table(obs_id)
         det_info = metadata.merge_det_info(det_info, detsets_info,
                                            ['readout_id'])
+        expected_dets = det_info.copy()
 
         # Make the request for SuperLoader
         request = {'obs:obs_id': obs_id}
         if detsets is not None:
             request['dets:detset'] = detsets
+            msk = np.where(
+                [x in detsets for x in expected_dets['dets:detset']]
+            )[0]
+            expected_dets = expected_dets.subset(rows=msk)
 
         # Convert dets argument to request entry(s)
         if isinstance(dets, dict):
@@ -468,11 +478,30 @@ class Context(odict):
         elif dets is not None:
             # Try a cast ...
             request['dets:readout_id'] = list(dets)
-
+        
+        if 'dets:readout_id' in request:
+            msk = np.where(
+                [x in request['dets:readout_id'] for x in
+                expected_dets['dets:readout_id']]
+            )[0]
+            expected_dets = expected_dets.subset(rows=msk)         
+            
         metadata_list = self._get_warn_missing('metadata', [])
         meta = self.loader.load(metadata_list, request, det_info=det_info, check=check,
                                 free_tags=free_tags, free_tag_fields=free_tag_fields,
                                 det_info_scan=det_info_scan, ignore_missing=ignore_missing)
+        
+        if meta.dets.count < len(expected_dets):
+            diff = len(expected_dets) - meta.dets.count
+            if ignore_missing_dets:
+                logger.warning(f"{diff} detectors did not have requested "
+                               f"metadata and are removed from loaded "
+                               f"AxisManager")
+            else:
+                raise ValueError(
+                    f"{diff} detectors missing requested metadata."
+                )
+
         if check:
             return meta
 

--- a/sotodlib/core/context.py
+++ b/sotodlib/core/context.py
@@ -300,7 +300,7 @@ class Context(odict):
         loader_func = OBSLOADER_REGISTRY[loader_type]  # Register your loader?
         aman = loader_func(self.obsfiledb, obs_id, dets=dets,
                            samples=samples, no_signal=no_signal)
- 
+
         if aman is None:
             return meta
         if meta is not None:
@@ -339,7 +339,7 @@ class Context(odict):
                  free_tags=None,
                  check=False,
                  ignore_missing=False,
-                 ignore_missing_dets=True,
+                 ignore_missing_dets=False,
                  det_info_scan=False):
         """Load supporting metadata for an observation and return it in an
         AxisManager.
@@ -451,16 +451,11 @@ class Context(odict):
         detsets_info = self.obsfiledb.get_det_table(obs_id)
         det_info = metadata.merge_det_info(det_info, detsets_info,
                                            ['readout_id'])
-        expected_dets = det_info.copy()
 
         # Make the request for SuperLoader
         request = {'obs:obs_id': obs_id}
         if detsets is not None:
             request['dets:detset'] = detsets
-            msk = np.where(
-                [x in detsets for x in expected_dets['dets:detset']]
-            )[0]
-            expected_dets = expected_dets.subset(rows=msk)
 
         # Convert dets argument to request entry(s)
         if isinstance(dets, dict):
@@ -478,30 +473,12 @@ class Context(odict):
         elif dets is not None:
             # Try a cast ...
             request['dets:readout_id'] = list(dets)
-        
-        if 'dets:readout_id' in request:
-            msk = np.where(
-                [x in request['dets:readout_id'] for x in
-                expected_dets['dets:readout_id']]
-            )[0]
-            expected_dets = expected_dets.subset(rows=msk)         
-            
+
         metadata_list = self._get_warn_missing('metadata', [])
         meta = self.loader.load(metadata_list, request, det_info=det_info, check=check,
                                 free_tags=free_tags, free_tag_fields=free_tag_fields,
-                                det_info_scan=det_info_scan, ignore_missing=ignore_missing)
-        
-        if meta.dets.count < len(expected_dets):
-            diff = len(expected_dets) - meta.dets.count
-            if ignore_missing_dets:
-                logger.warning(f"{diff} detectors did not have requested "
-                               f"metadata and are removed from loaded "
-                               f"AxisManager")
-            else:
-                raise ValueError(
-                    f"{diff} detectors missing requested metadata."
-                )
-
+                                det_info_scan=det_info_scan,ignore_missing=ignore_missing,
+                                ignore_missing_dets=ignore_missing_dets)
         if check:
             return meta
 

--- a/sotodlib/core/metadata/loader.py
+++ b/sotodlib/core/metadata/loader.py
@@ -297,7 +297,7 @@ class SuperLoader:
 
     def load(self, spec_list, request, det_info=None, free_tags=[],
              free_tag_fields=[], dest=None, check=False, det_info_scan=False,
-             ignore_missing=False):
+             ignore_missing=False, ignore_missing_dets=False):
         """Loads metadata objects and processes them into a single
         AxisManager.
 
@@ -319,7 +319,9 @@ class SuperLoader:
             directly update det_info.
           ignore_missing (bool): If True, don't fail when a metadata
             item can't be loaded, just try to proceed without it.
-
+          ignore_missing_dets (bool): If True, don't fail with a metadata
+            entry _that is not used for detector selection_ does not contain
+            information for any subset of detectors.
         Returns:
           In normal mode, an AxisManager containing the metadata
           (dest).  In check mode, a list of tuples (spec, exception).
@@ -337,6 +339,10 @@ class SuperLoader:
         # Augmented request -- note that dets:* restrictions from
         # request will be added back into this by check tags.
         aug_request = _filter_items('obs:', request, False)
+        # detector fields in request to know if data selection could be
+        # happening
+        det_request_fields = _filter_items('dets:', request.keys(), True)
+
         if self.obsdb is not None and 'obs:obs_id' in request:
             obs_info = self.obsdb.get(request['obs:obs_id'], add_prefix='obs:')
             if obs_info is not None:
@@ -348,7 +354,7 @@ class SuperLoader:
             for k, v in _filter_items('obs:', obs_info).items():
                 obs_man.wrap(k, v)
             dest.wrap('obs_info', obs_man)
-            
+
         def reraise(spec, e):
             logger.error(
                 f"An error occurred while processing a meta entry:\n\n"
@@ -403,8 +409,9 @@ class SuperLoader:
             return det_info, aug_request
 
         det_info, aug_request = check_tags(det_info, aug_request)
+        n_dets = len(det_info)
 
-        # Process each item.
+        # process each item
         items = []
         for spec in spec_list:
             if det_info_scan and not spec.get('det_info'):
@@ -426,11 +433,27 @@ class SuperLoader:
                     reraise(spec, e)
 
             if spec.get('det_info') and error is None:
+                item_keys = _filter_items('dets:', item.keys)
+                new_keys = [k for k in item_keys if k not in det_info.keys]
                 det_info = merge_det_info(
                     det_info, item, multi=spec.get('multi', False))
                 item = None
-
                 det_info, aug_request = check_tags(det_info, aug_request)
+                if (np.any([k in free_tag_fields for k in new_keys]) or
+                    np.any([k in det_request_fields for k in new_keys])):
+                    # free_tag_fields and det_request_fielsa are fields where
+                    # detector selection could be made. So we have to assume
+                    # THESE metadata are known to be complete
+                    n_dets = len(det_info)
+                if len(det_info) < n_dets:
+                    if ignore_missing_dets:
+                        logger.warning(f"{n_dets-len(det_info)} detectors are "
+                                       f"missing metadata information in "
+                                       f"spec={spec}. ")
+                    else:
+                        raise ValueError(f"{n_dets-len(det_info)} detectors are "
+                                         f"missing metadata information in "
+                                         f"spec={spec}. ")
 
             if check:
                 items.append((spec, error))
@@ -458,6 +481,16 @@ class SuperLoader:
                 reraise(spec, e)
 
             logger.debug(f'load(): dest now has shape {dest.shape}')
+
+            if dest.dets.count < n_dets:
+                if ignore_missing_dets:
+                    logger.warning(f"{n_dets-dest.dets.count} detectors are "
+                                   f"missing metadata information in "
+                                   f"spec={spec}. ")
+                else:
+                    raise ValueError(f"{n_dets-dest.dets.count} detectors are "
+                                     f"missing metadata information in "
+                                     f"spec={spec}. ")
 
         check_tags(det_info, aug_request, final=True)
 

--- a/sotodlib/core/metadata/loader.py
+++ b/sotodlib/core/metadata/loader.py
@@ -320,7 +320,7 @@ class SuperLoader:
           ignore_missing (bool): If True, don't fail when a metadata
             item can't be loaded, just try to proceed without it.
           ignore_missing_dets (bool): If True, don't fail with a metadata
-            entry _that is not used for detector selection_ does not contain
+            entry *that is not used for detector selection* does not contain
             information for any subset of detectors.
         Returns:
           In normal mode, an AxisManager containing the metadata

--- a/sotodlib/core/metadata/loader.py
+++ b/sotodlib/core/metadata/loader.py
@@ -448,8 +448,10 @@ class SuperLoader:
                 if len(det_info) < n_dets:
                     if ignore_missing_dets:
                         logger.warning(f"{n_dets-len(det_info)} detectors are "
-                                       f"missing metadata information in "
+                                       f"missing det_info information in "
                                        f"spec={spec}. ")
+                        # reset count so warning doesn't propagate
+                        n_dets = len(det_info) 
                     else:
                         raise ValueError(f"{n_dets-len(det_info)} detectors are "
                                          f"missing metadata information in "
@@ -487,6 +489,8 @@ class SuperLoader:
                     logger.warning(f"{n_dets-dest.dets.count} detectors are "
                                    f"missing metadata information in "
                                    f"spec={spec}. ")
+                    # reset count so warning doesn't propagate
+                    n_dets = dest.dets.count 
                 else:
                     raise ValueError(f"{n_dets-dest.dets.count} detectors are "
                                      f"missing metadata information in "

--- a/sotodlib/site_pipeline/preprocess_tod.py
+++ b/sotodlib/site_pipeline/preprocess_tod.py
@@ -96,7 +96,7 @@ def preprocess_tod(obs_id, configs, overwrite=False, logger=None):
                      "archive index.")
         scheme = core.metadata.ManifestScheme()
         scheme.add_exact_match('obs:obs_id')
-        scheme.add_data_field('dets:' + group_by)
+        scheme.add_exact_match('dets:' + group_by)
         scheme.add_data_field('dataset')
         db = core.metadata.ManifestDb(
             configs['archive']['index'],
@@ -117,14 +117,15 @@ def preprocess_tod(obs_id, configs, overwrite=False, logger=None):
             dest_dataset += '_' + group
         else:
             dest_dataset += "_" + group_by + "_" + str(group)
+        logger.info(f"Saving data to {dest_file}:{dest_dataset}")
         proc_aman.save(dest_file, dest_dataset, overwrite=overwrite)
 
-        logger.info("Saving to database")
         # Update the index.
         db_data = {'obs:obs_id': obs_id,
                    'dataset': dest_dataset}
         db_data['dets:'+group_by] = group
         
+        logger.info(f"Saving to database under {db_data}")
         if db.match(db_data) is None:
             db.add_entry(db_data, dest_file)
 

--- a/sotodlib/site_pipeline/preprocess_tod.py
+++ b/sotodlib/site_pipeline/preprocess_tod.py
@@ -63,7 +63,13 @@ def _get_groups(obs_id, configs, context):
         groups = det_info.subset(keys=[group_by]).distinct()[group_by]
     return group_by, groups
 
-def preprocess_tod(obs_id, configs, overwrite=False, logger=None):
+def preprocess_tod(
+    obs_id, 
+    configs, 
+    group_list=None, 
+    overwrite=False, 
+    logger=None
+):
     """Meant to be run as part of a batched script, this function calls the
     preprocessing pipeline a specific Observation ID and saves the results in
     the ManifestDb specified in the configs.   
@@ -74,6 +80,10 @@ def preprocess_tod(obs_id, configs, overwrite=False, logger=None):
         obs_id or obs entry that is passed to context.get_obs
     configs: string or dictionary
         config file or loaded config directory
+    group_list: None or list
+        list of groups to run if you only want to run a partial update
+    overwrite: bool
+        if True, overwrite existing entries in ManifestDb
     logger: logging instance
         the logger to print to
     """
@@ -87,6 +97,18 @@ def preprocess_tod(obs_id, configs, overwrite=False, logger=None):
     context = core.Context(configs["context_file"])
     group_by, groups = _get_groups(obs_id, configs, context)
 
+    all_groups = groups.copy()
+    if group_list is not None:
+        for g in all_groups:
+            if g not in group_list:
+                groups.remove(g)
+
+        if len(groups) == 0:
+            logger.warning(f"group_list:{group_list} contains no overlap with "
+                           f"groups in observation: {obs_id}:{all_groups}. "
+                           f"No analysis to run.")
+            return
+ 
     if os.path.exists(configs['archive']['index']):
         logger.info(f"Mapping {configs['archive']['index']} for the "
                     "archive index.")
@@ -104,7 +126,8 @@ def preprocess_tod(obs_id, configs, overwrite=False, logger=None):
         )
 
     pipe = _build_pipe_from_configs(configs)
-
+    
+    logger.info(f"{len(groups)} groups to run for {obs_id}")
     for group in groups:
         logger.info(f"Beginning run for {obs_id}:{group}")
 
@@ -269,21 +292,25 @@ def main(
         logger.warning(f"No observations returned from query: {query}")
     run_list = []
 
-    if not os.path.exists(configs['archive']['index']):
+    if overwrite or not os.path.exists(configs['archive']['index']):
         #run on all if database doesn't exist
-        run_list = obs_list
+        run_list = [ (o,None) for o in obs_list]
     else:
         db = core.metadata.ManifestDb(configs['archive']['index'])
         for obs in obs_list:
-            x = db.match({'obs:obs_id': obs["obs_id"]}, multi=True)
+            x = db.inspect({'obs:obs_id': obs["obs_id"]})
             group_by, groups = _get_groups(obs["obs_id"], configs, context)
-            if overwrite or (x is None or len(x) != len(groups)):
-                run_list.append(obs)
+            if x is None or len(x) == 0:
+                run_list.append( (obs, None) )
+            elif len(x) != len(groups):
+                [groups.remove(a['dets:detset']) for a in x]
+                run_list.append( (obs, groups) )
 
     logger.info(f"Beginning to run preprocessing on {len(run_list)} observations")
-    for obs in run_list:
+    for obs, groups in run_list:
         logger.info(f"Processing obs_id: {obs_id}")
-        preprocess_tod(obs["obs_id"], configs, overwrite=overwrite,logger=logger)
+        preprocess_tod(obs["obs_id"], configs, overwrite=overwrite,
+                       group_list=groups, logger=logger)
             
 
 if __name__ == '__main__':

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -171,6 +171,20 @@ class ContextTest(unittest.TestCase):
             ctx.get_meta(obs_id)
         ctx.get_meta(obs_id, ignore_missing=True)
 
+        # Check detector info with missing entries
+        ctx = dataset_sim.get_context(with_bad_det_info_data=True)
+        with self.assertRaises(Exception):
+            ctx.get_meta(obs_id)
+        ctx.get_meta(obs_id, ignore_missing_dets=True)
+
+        # Check missing metadata
+        ctx = dataset_sim.get_context(with_incomplete_metadata=True)
+        with self.assertRaises(Exception):
+            ctx.get_meta('obs_number_12')
+        ctx.get_meta('obs_number_13')
+        ctx.get_meta('obs_number_12', ignore_missing_dets=True)
+        ctx.get_meta('obs_number_13', ignore_missing_dets=True)
+
     def test_110_more_loads(self):
         dataset_sim = DatasetSim()
         n_det, n_samp = dataset_sim.det_count, dataset_sim.sample_count
@@ -258,7 +272,8 @@ class DatasetSim:
         metadata.SuperLoader.register_metadata('unittest_loader', _TestML)
 
     def get_context(self, with_detdb=True, with_metadata=True,
-                    with_bad_metadata=False):
+                    with_bad_metadata=False, with_bad_det_info_data=False,
+                    with_incomplete_metadata=False):
         detdb = metadata.DetDb()
         detdb.create_table('base', ['readout_id string',
                                     'pol_code string',
@@ -394,8 +409,48 @@ class DatasetSim:
                 'db': 'not-a-file.sqlite',
                 'name': 'important_info&',
             })
+        
+        if with_bad_det_info_data:
+            # metadata: incomplete_det_info.h5
+            ## This is an incomplete dataset.
+            _scheme = metadata.ManifestScheme() \
+                      .add_range_match('obs:timestamp') \
+                      .add_data_field('loader')
+            bad_det_info_db = metadata.ManifestDb(scheme=_scheme)
+            bad_det_info_db.add_entry(
+                {'obs:timestamp': [0, 2e9], 'loader': 'unittest_loader'},
+                 'incomplete_det_info.h5'
+            )
+            # This should cause metadata load error
+            ctx['metadata'].insert(0, {
+                'db': bad_det_info_db,
+                'det_info': True,
+                'name': 'newcal' 
+            })    
 
-        return ctx
+        if with_incomplete_metadata:
+            # metadata: incomplete_metadata.h5
+            ## This is an incomplete dataset.
+            _scheme = metadata.ManifestScheme() \
+                      .add_exact_match('obs:obs_id') \
+                      .add_data_field('loader')
+            bad_meta_db = metadata.ManifestDb(scheme=_scheme)
+            bad_meta_db.add_entry(
+                {'obs:obs_id': 'obs_number_12', 'loader': 'unittest_loader'},
+                 'incomplete_metadata.h5'
+            )
+            bad_meta_db.add_entry(
+                {'obs:obs_id': 'obs_number_13', 'loader': 'unittest_loader'},
+                 'incomplete_metadata.h5'
+            )
+            # This should cause metadata load error
+            ctx['metadata'].insert(0, {
+                'db': bad_meta_db,
+                'name': 'othercal'
+            })    
+
+        return ctx 
+
 
     def metadata_loader(self, kw):
         # For Superloader.
@@ -455,6 +510,29 @@ class DatasetSim:
             for row in self.dets.subset(rows=self.dets['detset'] == kw['dets:detset']):
                 rs.append({'dets:readout_id': row['readout_id'],
                            'x': 100., 'y': 102.})
+            return rs
+        elif filename == 'incomplete_det_info.h5':
+            rs = metadata.ResultSet(['dets:readout_id', 'dets:newcal'])
+            for row in self.dets.subset(rows=[0,1,2]):
+                rs.append({'dets:readout_id': row['readout_id'],
+                           'dets:newcal':20})
+            return rs
+        elif filename == 'incomplete_metadata.h5':
+            rs = metadata.ResultSet([
+                'obs:obs_id',
+                'dets:readout_id', 
+                'othercal'
+            ])
+            if kw['obs:obs_id']=='obs_number_12': 
+                for row in self.dets.subset(rows=[0,1,2]):
+                    rs.append({'obs:obs_id': 'obs_number_12',
+                               'dets:readout_id': row['readout_id'],
+                               'othercal':40})
+            elif kw['obs:obs_id'] =='obs_number_13': 
+                for row in self.dets:
+                    rs.append({'obs:obs_id': 'obs_number_13',
+                               'dets:readout_id': row['readout_id'],
+                               'othercal':40})
             return rs
         else:
             raise ValueError(f'metadata request for "{filename}"')


### PR DESCRIPTION
While working with a bunch of preprocessing metadata I was reminded that I dislike the current behavior of the metadata loader. Currently, if the loader encounters a ManifestDb with _missing_ information from some detectors, it just quietly drops those detectors from the returned metadata object. 

This is guaranteed to confuse folks at some point when we're going through pipeline-like processes where we're depending on something having been run before-hand. Especially if we load an observation, get a "partial" observation back, and then assume we're "done" with that observation.

This update should at least mostly fix this issue. As we're going through and loading the different ManifestDbs, if the newly added fields _are not_ options for data-selection but reduce the overall number of detectors, the code will throw an error unless `ignore_missing_dets` is set to True (where it will then give a warning instead). I would prefer having the default behavior be `ignore_missing_dets=False`, because I really do thing the `True` option will hide more problems then it helps. 

The code works, this is just a draft because the context tests were absolutely essential for getting this working correctly so that means I definitely need to add some for the new behavior. 