### PR TITLE
fix tunes name parsing

### DIFF
--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -2019,7 +2019,7 @@ def _get_tuneset_channel_names(status, ch_map, archive):
 
     # tune file in status
     if status.tune is not None and len(status.tune) > 0:
-        tune_file = status.tune.split("/")[-1]
+        tune_file = Tunes.get_name_from_status(status)
         tune = session.query(Tunes).filter(
             Tunes.name == tune_file,
             Tunes.stream_id == status.stream_id,


### PR DESCRIPTION
when tunes.name naming convention is changed, this is one compatibility change that's missed in previous PR. 