### PR TITLE
Resample aman

### DIFF
--- a/docs/tod_ops.rst
+++ b/docs/tod_ops.rst
@@ -172,3 +172,15 @@ an unit step, so it is acting as a matched filter.
 
 .. automodule:: sotodlib.tod_ops.jumps
    :members:
+
+tod_ops.resample
+================
+
+Support for resampling an axis manager to a new set of timestamps. Useful for downsampling
+or upsampling data. This does not include any filtering required to reduce aliasing in
+this step. Data must first be filtered with appropriate nyquist filter using the
+``sotodlib.tod_ops.fourier_filter`` module.
+
+.. automodule:: sotodlib.tod_ops.resample
+   :members:
+

--- a/sotodlib/tod_ops/resample.py
+++ b/sotodlib/tod_ops/resample.py
@@ -1,0 +1,126 @@
+import numpy as np
+from sotodlib import core
+from sotodlib.core import flagman as fm
+from so3g.proj.ranges import Ranges, RangesMatrix
+from scipy import interpolate
+
+try:
+    from scipy.sparse import csr_array
+except ImportError:
+    from scipy.sparse import csr_matrix as csr_array
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def spl_int(t1, t0, y):
+    """
+    Wrapper for scipy.interpolate spline interpolation to take the same
+    arguments as np.interp
+    Args:
+    -----
+    t1 (ndarray): Timestamps to interpolate onto.
+    t0 (ndarray): Timestamps of the data to interpolate.
+    y (ndarray): Data to interpolate
+
+    Returns:
+    --------
+    Interpolated values.
+    """
+    tck = interpolate.splrep(t0, y)
+    return interpolate.splev(t1, tck)
+
+
+def interp_aman(aman, t0, t1, axis='samps', interp_type='linear'):
+    """
+    Function for interpolating an axis manager to some new set of timesamples.
+    This is useful for upsampling, downsampling, or resampling between two
+    datasets taken at similar rates. It handles interpolating numpy arrays,
+    and RangesMatrices but currently does not interpolate csr matrices
+    (it just drops these).
+
+    Args:
+    -----
+    aman (AxisManager): Axis manager to interpolate
+    t0 (ndarray): Timestamps of axis manager.
+    t2 (ndarray): Timestamps to interpolate onto.
+    axis (str): Name of axis to interpolate along (defaults to samps).
+                I have not tested setting thing to something else!!!
+    interp_type (str): Either 'linear' or 'spline' type interpolation.
+
+    Returns:
+    --------
+    dest (AxisManager): New axis manager interpolated to t1 timestamps.
+    """
+    new_axes = []
+    for k, v in aman._axes.items():
+        if k == axis:
+            new_axes.append(core.OffsetAxis(axis, len(t1)))
+        else:
+            new_axes.append(v)
+    dest = core.AxisManager(*new_axes)
+
+    for k, assign in aman._assignments.items():
+        if axis in assign:
+            if isinstance(aman[k], core.AxisManager):
+                dest.wrap(k, interp_aman(aman[k], t0, t1, axis=axis,
+                          interp_type=interp_type))
+            elif isinstance(aman[k], RangesMatrix):
+                shape = list(aman[k].shape)
+                dest.wrap_new(k, shape=shape, dtype=type(aman[k]))
+                dest[k] = RangesMatrix([Ranges.from_mask(
+                                       np.round(np.interp(t1, t0,
+                                        aman[k][det].mask()), 0).astype(bool))\
+                                       for det in range(aman[k].shape[0])])
+            elif isinstance(aman[k], csr_array):
+                logger.warning('csr matrix is not supported in downsampling.' +
+                               f' {k} is a csr_matrix and is being dropped ' +
+                               'from the returned axis manager')
+                continue
+            elif isinstance(aman[k], np.ndarray):
+                shape = list(aman[k].shape)
+                for i, a in enumerate(assign):
+                    if a is not None:
+                        shape[i] = a
+                dest.wrap_new(k, shape=shape, dtype=aman[k].dtype)
+                if len(shape) == 1:
+                    if interp_type == 'linear':
+                        dest[k] = np.interp(t1, t0, aman[k])
+                    if interp_type == 'spline':
+                        dest[k] = spl_int(t1, t0, aman[k])
+                elif len(shape) == 2:
+                    if (shape[-1] != axis):
+                        logger.warning(f'dropping {k}')
+                        continue
+                    for i, y in enumerate(aman[k]):
+                        if interp_type == 'linear':
+                            dest[k][i, :] = np.interp(t1, t0, y)
+                        if interp_type == 'spline':
+                            dest[k][i, :] = spl_int(t1, t0, y)
+            else:
+                raise ValueError('Data type in axis manager not supported '+
+                                 'in interpolation')
+        else:
+            dest.wrap(k, aman[k])
+            dest._assignments[k] = aman._assignments[k]
+    return dest
+
+
+def decimate_aman(aman, fs_new):
+    """
+    Decimate axis manager to new sample rate.
+    
+    Args:
+    -----
+    aman (AxisManager): Axis manager to decimate.
+    fs_new (int): New sampling rate.
+
+    Returns:
+    --------
+    aman_new (AxisManager): Decimated axis manager.
+    """
+    ts_new = np.arange(aman.timestamps[0], aman.timestamps[-1], 1/fs_new)
+    aman_new = interp_aman(aman, aman.timestamps, ts_new)
+    return aman_new
+

--- a/sotodlib/tod_ops/resample.py
+++ b/sotodlib/tod_ops/resample.py
@@ -18,13 +18,17 @@ def spl_int(t1, t0, y):
     """
     Wrapper for scipy.interpolate spline interpolation to take the same
     arguments as np.interp
-    Args:
+    
+    Args
     -----
-    t1 (ndarray): Timestamps to interpolate onto.
-    t0 (ndarray): Timestamps of the data to interpolate.
-    y (ndarray): Data to interpolate
+    t1 : ndarray
+        Timestamps to interpolate onto.
+    t0 : ndarray
+        Timestamps of the data to interpolate.
+    y : ndarray
+        Data to interpolate
 
-    Returns:
+    Returns
     --------
     Interpolated values.
     """
@@ -40,18 +44,24 @@ def interp_aman(aman, t0, t1, axis='samps', interp_type='linear'):
     and RangesMatrices but currently does not interpolate csr matrices
     (it just drops these).
 
-    Args:
+    Args
     -----
-    aman (AxisManager): Axis manager to interpolate
-    t0 (ndarray): Timestamps of axis manager.
-    t2 (ndarray): Timestamps to interpolate onto.
-    axis (str): Name of axis to interpolate along (defaults to samps).
-                I have not tested setting thing to something else!!!
-    interp_type (str): Either 'linear' or 'spline' type interpolation.
+    aman : AxisManager
+        Axis manager to interpolate
+    t0 : ndarray
+        Timestamps of axis manager.
+    t2 : ndarray
+        Timestamps to interpolate onto.
+    axis : str
+        Name of axis to interpolate along (defaults to samps).
+        **Only tested on samps axis!!!**
+    interp_type : str
+        Either 'linear' or 'spline' type interpolation.
 
-    Returns:
+    Returns
     --------
-    dest (AxisManager): New axis manager interpolated to t1 timestamps.
+    dest : AxisManager
+        New axis manager interpolated to t1 timestamps.
     """
     new_axes = []
     for k, v in aman._axes.items():
@@ -111,14 +121,17 @@ def decimate_aman(aman, fs_new):
     """
     Decimate axis manager to new sample rate.
     
-    Args:
+    Args
     -----
-    aman (AxisManager): Axis manager to decimate.
-    fs_new (int): New sampling rate.
+    aman : AxisManager
+        Axis manager to decimate.
+    fs_new : int
+        New sampling rate.
 
-    Returns:
+    Returns
     --------
-    aman_new (AxisManager): Decimated axis manager.
+    aman_new : AxisManager
+        Decimated axis manager.
     """
     ts_new = np.arange(aman.timestamps[0], aman.timestamps[-1], 1/fs_new)
     aman_new = interp_aman(aman, aman.timestamps, ts_new)


### PR DESCRIPTION
Added in submodule to `tod_ops` for resampling axis manager onto a new set of timestamps. This does not necessarily cover all general cases since there are lots of different data types in an axis manager, so I assume there will be some discussion of how this could be expanded or restructured. My main use case, however has been downsampling after hwp demodulation. I've tested this the most and wanted it to be PR'd so we could start discussing what we'd want to add before merging.

So far I tested on a toast sim: obs_id: `1692085774_ST1_f090_1000000` from this context: `'/home/tterasaki/workspace/sat_mapmake_debug/run3/context-hwpss/context.yaml'` in @tterasaki's workspace which is a sim link to some of @mhasself 's planet sims. Since I don't have any filtering in this module I ran this TOD through the preprocess module to get out demodulated Q/U then ran this new resample module to downsample to 2x the LPF cutoff from the demodulation (8 Hz). You can see the results here:

<p align="center">
<img src="https://github.com/simonsobs/sotodlib/assets/25913911/9f223cc5-b400-4647-9f29-fb16fc23452b" width="500">
</p>

The plot was generated in this notebook on simons1: `/home/msilvafe/notebooks/flp_dev/20230523_TOD_Processing_Demo.ipynb`

I'm sure @kmharrington will have additional thoughts for things to test/expand but my initial ones are:

1. Adding + testing this in preprocess
2. Writing a unit test script (that catches the exceptions for unsupported data types)
3. Testing this with decimation on an axis that is not samps (i.e a binned samples axis)
4. Testing an up-sampling option
5. Closer attention to how csr_arrays and other non-array style data types are handled. They're currently dropped, or a ValueError is raised depending on if it's a known datatype we're intentionally dropping (csr_arrays) or something I haven't tested before.