### PR TITLE
t_glitch argument wasn't used

### DIFF
--- a/sotodlib/flags.py
+++ b/sotodlib/flags.py
@@ -84,7 +84,7 @@ def get_glitch_flags(
     if signal is None:
         signal = 'signal'
     # f-space filtering
-    filt = filters.high_pass_sine2(cutoff=hp_fc) * filters.gaussian_filter(t_sigma=0.002)
+    filt = filters.high_pass_sine2(cutoff=hp_fc) * filters.gaussian_filter(t_sigma=t_glitch)
     fvec = fourier_filter(aman, filt, detrend=detrend,
                           signal_name=signal, resize='zero_pad')
     # get the threshods based on n_sig x nlev = n_sig x iqu x 0.741


### PR DESCRIPTION
This is a simple 1-line change I found when reviewing how our glitch detection works for my thesis. In `flags.get_glitch_flags`, the `t_glitch` argument wasn't used, and 0.002 was hardcoded into the gaussian filter. 