### PR TITLE
check-book: settings to tolerate arbitrary extra files in book

### DIFF
--- a/sotodlib/site_pipeline/check_book.py
+++ b/sotodlib/site_pipeline/check_book.py
@@ -45,6 +45,10 @@ enabled:
     tolerate_missing_ancil_timestamps: True
     tolerate_timestamps_value_discrepancy: False
 
+    # Tolerate arbitrary extra files, except explicitly named ones
+    tolerate_stray_files: True
+    banned_files: ['frame_splits.txt']
+
     # If stream_ids are not provided in metadata, list them here.
     stream_ids:
       ufm_mv14


### PR DESCRIPTION
For oper books, especially, there will be ancillary files and sometimes analysis output that needs to be accepted.  You can still explicitly ban files that match some pattern, such as frame_splits.txt...
