### PR TITLE
Add file transfer finalization tracking to data packaging

### DIFF
--- a/sotodlib/io/g3thk_utils.py
+++ b/sotodlib/io/g3thk_utils.py
@@ -1,0 +1,121 @@
+""" Utility functions for querying and/or working with the G3tHK databases
+"""
+
+import numpy as np
+import logging
+
+from sotodlib.io.g3thk_db import G3tHk, HKFiles, HKAgents, HKFields
+
+logger = logging.getLogger(__name__)
+
+def pysmurf_monitor_control_list( agent, start=None, stop=None, HK=None ):
+    """Return list of stream_ids controlled by a pysmurf-monitor agent
+    
+    Arguments
+    ----------
+    agent: HKAgent instance or instance_id
+    start: timestamp
+        if agent is instance_id, used to find relevant agent instance
+    stop: timestamp
+        if agent is instance_id, used to find relevant agent instance
+    HK: G3tHK Archive
+        if agent is instance_id, used to find relevant agent instance
+    
+    Returns
+    -------
+    stream_ids: list of stream_ids monitored by agent
+    """
+    if isinstance(agent, str):
+        if start is None or stop is None:
+            raise ValueError("start and stop are required when agent is the"
+                             " instance id")
+        if HK is None:
+            raise ValueError("need database to search if agent is instance id")
+        agent_list = HK.get_db_agents(agent, start, stop)
+        return np.unique(
+            [pysmurf_monitor_control_list(agent) for agent in agent_list]
+        )
+    stream_ids = []
+    for field in agent.fields:
+        if not "_meta" in field.field:
+            continue
+        splits = field.field.split('.')
+        sid = [x for x in splits if "_meta" in x][0].strip("_meta")
+        stream_ids.append(sid)
+    return np.unique(stream_ids)
+
+def check_was_streaming(stream_id, start, stop, cfgs=None, HK=None, servers=None):
+    """ Query the HK database to see if a specific stream_id was
+    streaming during a time range. 
+    
+    Arguments
+    ----------
+    stream_id: string
+    start: timestamp
+    stop: timestamp
+    cfgs: configuration dictionary with finalization information
+    HK: optional, G3tHK instance 
+
+    Returns
+    -------
+    check: boolean
+        if true, pysmurf-monitor has recorded the g3 stream was open 
+        during the time between start and stop.
+        
+    Raises
+    ------
+    ValueError if stream_id is found in multiple pysmurf-monitors
+    """
+    
+    if HK is None:
+        HK = G3tHk.from_configs(cfgs)
+    if servers is None:
+        servers = cfgs["finalization"]["servers"]
+    assert HK.get_last_update() >= stop
+    
+    agents = None
+    
+    for server in servers:
+        pm = server.get("pysmurf-monitor")
+        if pm is None:
+            continue
+        alist = HK.get_db_agents(pm, start, stop)
+        sids = np.unique([
+            pysmurf_monitor_control_list(agent) for agent in alist
+        ])
+        if np.any([stream_id == s for s in sids]):
+            if agents is not None:
+                logger.error(f"found {stream_id} in multiple pysmurf-montiors")
+                raise ValueError(f"found {stream_id} in multiple "
+                                 f"pysmurf-montiors, do not know which one to "
+                                  "use")
+            agents = alist
+    
+    if agents is None:
+        ## found no agents, either not streaming or db not updated
+        logger.warning(f"Found no pysmurf monitor agents monitoring {stream_id}"
+                       " during this time")
+        return False
+    
+    fields = []
+    search = f"{stream_id}_meta.AMCcSmurfProcessorSOStreamopen_g3stream"
+    
+    for agent in agents:
+        idx = np.where( [search in field.field for field in agent.fields] )[0]
+        if len(idx) == 0:
+            continue
+        fields.append(agent.fields[idx[0]])
+        
+    if len(fields) == 0:
+        logger.warning(f"Found no fields with key {search}. Was metadata" 
+                        "reading out correctly?")
+        return False
+    
+    data = HK.load_data( fields )
+    if len(data) != 1:
+        logger.error("Data returned from field list has more than one key")
+        
+    k, val = data.popitem()
+    msk = np.all( [val[0] >= start, val[0] <= stop], axis=0 )
+    
+    return np.any( val[1][msk] )

--- a/sotodlib/io/g3tsmurf_db.py
+++ b/sotodlib/io/g3tsmurf_db.py
@@ -1,6 +1,7 @@
 """ This module includes all the database definitions used with G3tSmurf, broken out 
 here to reduce the overall number of lines in each module. 
 """
+from enum import Enum
 import sqlalchemy as db
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker, relationship, backref
@@ -21,6 +22,45 @@ association_table_dets = db.Table('detsets', Base.metadata,
     db.Column('name', db.Integer, db.ForeignKey('tunesets.name')),
     db.Column('det', db.Integer, db.ForeignKey('channels.name'))
 )
+
+class Finalized(Base):
+    """Table for tracking if files and metadata are ready for bookbinding. Built
+    to work off of the suprsync finalization files.
+
+    Attributes
+    ----------
+    """
+    __tablename__ = 'finalize'
+
+    stream_id = db.Column(db.String, primary_key=True)
+    files_until = db.Column(db.Float)
+    meta_until = db.Column(db.Float)
+
+class SupRsyncType(Enum):
+    FILES = 0
+    META = 1
+
+class StreamIDs(Base):
+    """Table for tracking stream_ids in the databases and what Suprsync agents
+    are in charge of transferring data for each stream_id as a function of time.
+    We are assuming a stream_id can be moved from one computer to another at
+    some point in time
+
+    Attributes
+    ----------
+    """
+    __table_name__ = "stream_ids"
+    
+    id = db.Column(db.Integer, primary_key=True)
+    stream_id = db.Column(db.String)
+
+    agent = db.Column(db.String)
+    # a SupRsyncType
+    agent_type = db.Column(db.Integer)
+
+    # timestamps
+    start = db.Column(db.Float)
+    stop = db.Column(db.Float)
 
 class Observations(Base):
     """Times of continuous detector readout. This table is named obs and serves

--- a/sotodlib/io/g3tsmurf_db.py
+++ b/sotodlib/io/g3tsmurf_db.py
@@ -23,6 +23,7 @@ association_table_dets = db.Table('detsets', Base.metadata,
     db.Column('det', db.Integer, db.ForeignKey('channels.name'))
 )
 
+
 class Finalized(Base):
     """Table for tracking if files and metadata are ready for bookbinding. Built
     to work off of the suprsync finalization files.
@@ -49,7 +50,7 @@ class StreamIDs(Base):
     Attributes
     ----------
     """
-    __table_name__ = "stream_ids"
+    __tablename__ = "stream_ids"
     
     id = db.Column(db.Integer, primary_key=True)
     stream_id = db.Column(db.String)

--- a/sotodlib/io/g3tsmurf_utils.py
+++ b/sotodlib/io/g3tsmurf_utils.py
@@ -254,44 +254,6 @@ def check_timecodes(stream_id, start, stop, SMURF):
 
     return False
 
-def check_stream_ids(stream_ids, start, stop, cfgs, SMURF=None, HK=None):
-    """Validate that a list of stream_ids are able to be bookbound for a
-    specific time range.
-
-    Arguments
-    ---------
-    stream_id: string
-        stream_id to check
-    start: float
-        start ctime
-    stop: float
-        stop ctime 
-    cfgs: string
-
-    Returns
-    -------
-    True if we can say for sure the list of stream_ids is complete
-    """
-    assert start < stop
-    if SMURF is None:
-        SMURF = G3tSmurf.from_configs(cfgs)
-    if HK is None:
-        HK = G3tHk.from_configs(cfgs)
-
-    have_tcodes = np.all([
-        check_timecodes(stream_id, start, stop, SMURF) for stream_id in stream_ids
-    ])
-    if have_tcodes:
-        return True
-    
-        
-    
-    ## check if g3tsmurf thinks it's updated here?    
-    ## check if pysmurf-monitor thinks it's streaming
-    ## check if suprsync agents think they're good
-
-    pass
-
 
 def get_batch(
     obs_id,

--- a/sotodlib/site_pipeline/update_book_plan.py
+++ b/sotodlib/site_pipeline/update_book_plan.py
@@ -2,7 +2,7 @@ import datetime as dt
 from typing import Optional
 import typer
 
-from ..io.imprinter import Imprinter
+from sotodlib.io.imprinter import Imprinter
 
 
 def main(

--- a/sotodlib/site_pipeline/update_g3tsmurf_database.py
+++ b/sotodlib/site_pipeline/update_g3tsmurf_database.py
@@ -48,10 +48,14 @@ def update_g3tsmurf_db(config=None, update_delay=2, from_scratch=False,
         except Exception as e:
             logger.error(f"Monitor connectioned failed {e}")
             monitor = None
-        
+    updates_start = dt.datetime.now().timestamp()
+
     SMURF.index_metadata(min_ctime=min_time.timestamp())
     SMURF.index_archive(min_ctime=min_time.timestamp(), show_pb=show_pb)
     SMURF.index_action_observations(min_ctime=min_time.timestamp())    
+    SMURF.index_timecodes(min_ctime=min_time.timestamp())
+    SMURF.update_finalization(update_time=updates_start)
+    SMURF.last_update = updates_start
 
     session = SMURF.Session()
 


### PR DESCRIPTION
This builds off changes to the suprsync agents in this PR: 

We need to make sure that final transfers between all the level 1 servers and the level 2 DAQ node are complete before we can begin bookbinding. This PR implements many changes to make this possible. 

One of the aspects that makes this setup a bit difficult is that we need to introduce the concept of "servers" into the system because we have 1 pysmurf-monitor and 1 suprsync agent of each type (smurf/timestamps) per server. But, for the SATs we have 2 servers per 7 stream ids / 1 book. For the LATs we have servers running ~6 stream_ids but I book binding 3 stream_ids per book.  Another complication is that we know and expect we will be swapping UFMs (stream_ids) between servers and/or smurf slots during operation enough times that we do not want to have to keep a running list of stream_ids vs server in an actively managed configuration file. 

Because of this, the logic here is as follows:

1. We make a rule that the mapping between `stream_id` <--> `UFM` <--> `wafer_slot` will remain constant throughout at cooldown / cryostat build. This does require care in setting up the system configurations on the smurf server but this rule has been defacto behavior for the last ~2 years of testing.
2. Each suprsync agent now reports a "finalization timestamp" to the house keeping feeds and writes a "finalization file" [from  an update to socs](https://github.com/simonsobs/socs/pull/467). 
3.  We add entries to the `g3tsmurf_hwp_config.yaml` files to track which agents are connected to which servers in the form (note that we expect these instance ids to be constant/permanent): 
```
finalization:
    servers:
    - smurf-suprsync: "smurf_id_1" ## instance-id for smur suprsync
      timestream-suprsync: "timestream_id_1" ## instance id for timestamps suprsync
      pysmurf-monitor:  "monitor_id_1" ## instance id for pysmurf_monitor
    - smurf-suprsync: "smurf_id_2" ## instance-id for smur suprsync
      timestream-suprsync: "timestream_id_2" ## instance id for timestamps suprsync
      pysmurf-monitor:  "monitor_id_2" ## instance id for pysmurf_monitor
```
4. We use the suprsync outputs, the HK database, and the server matching in the config to populate two new G3tSmurf tables, `Finalize` and `TimeCodes`. `Finalize` has one entry per agent_id and is updated to have the last finalization time when the last G3tSmurf update was run. `Finalize` is used know when to build `oper` and `obs` books.  `TimeCodes` has an entry per 5-digit-ctime folder per stream_id and is built off the finalization files. TimeCodes will be used to build our `stray` and `smurf` books. 

5. Obs/Oper Making: 
* Largest changes to imprinter are in the [`update_bookdb_from_g3tsmurf` function](https://github.com/simonsobs/sotodlib/blob/g3_finalize/sotodlib/io/imprinter.py#L591)
* Imprinter now specifically tracks which `stream_ids` go into which books. Those were already in the config files but now the requirement that they are in there is "harder" in that it will not look for `stream_ids` outside that list.  
* Imprinter asks G3tSmurf what the combined minimum finalization time is for the list of `stream_ids` and will not make books with any observations that overlap this time. It will also look for obviously incomplete observations (stop == None) and will not make books with any observation that overlaps the incomplete observation. 
* If present, G3tSmurf uses pysmurf-monitor outputs to determine which stream_ids were controlled by which servers during the update time. Otherwise it defaults to making sure they're all updated. This feature will be important for the LAT but the E2E system isn't awesome for testing this one (no pysmurf-monitors). 

6. smurf / stray books making:
* will be based on timecode entries. still todo. 


PR also includes:
* logic updates for some G3tSmurf entry creation
* more QOL updating functions for G3tHk
* 