### PR TITLE
Simulated focalplane spacing

### DIFF
--- a/sotodlib/scripts/hardware_plot.py
+++ b/sotodlib/scripts/hardware_plot.py
@@ -45,6 +45,11 @@ def main():
     )
 
     parser.add_argument(
+        "--show_centers", required=False, default=False, action="store_true",
+        help="Add labels with pixel center coordinates."
+    )
+
+    parser.add_argument(
         "--xieta", required=False, default=False, action="store_true",
         help="Plot in Xi / Eta coordinates."
     )
@@ -93,6 +98,7 @@ def main():
         xieta=args.xieta,
         lat_corotate=args.lat_corotate,
         lat_elevation=args.lat_elevation_deg * u.degree,
+        show_centers=args.show_centers
     )
 
     return

--- a/sotodlib/sim_hardware.py
+++ b/sotodlib/sim_hardware.py
@@ -366,15 +366,15 @@ def sim_nominal():
     ltube_cryonames=["c1", "i5", "i6", "i1", "i3", "i4", "o6"]
 
     lat_ufm_slot = [
-        2,
-        1,
         0,
+        1,
+        2,
     ]
 
     lat_ufm_thetarot = [
-        120.0,
-        0.0,
         240.0,
+        0.0,
+        120.0,
     ]
 
     for tindx in range(7):
@@ -405,6 +405,8 @@ def sim_nominal():
         tb["receiver_name"] = ""
         tube_slots[nm] = tb
 
+    # These are taken from:
+    # https://simonsobs.atlassian.net/wiki/spaces/PRO/pages/101974017/Focal+Plane+Coordinates#UFM-Layout.1
     hex_to_ufm_slot = [
         0,
         2,
@@ -444,8 +446,6 @@ def sim_nominal():
         tb["wafer_slot_angle"] = [
             hex_to_ufm_thetarot[tw] for tw in range(7)
         ] # Degrees
-        # These are taken from:
-        # https://simonsobs.atlassian.net/wiki/spaces/PRO/pages/101974017/Focal+Plane+Coordinates#UFM-Layout.1
         # The "slot" here is the relative slot (ws0 - ws6) within the tube.
         tb["wafer_ufm_slot"] = list()
         # The "loc" here is the compass direction name (e.g. NO, NE, SW, etc.)

--- a/sotodlib/sim_hardware.py
+++ b/sotodlib/sim_hardware.py
@@ -394,6 +394,7 @@ def sim_nominal():
             for w, props in cnf["wafer_slots"].items():
                 if props["type"] == ttyp:
                     if off == woff[ttyp]:
+                        props["tube_index"] = tw
                         tb["wafer_slots"].append(w)
                         tb["wafer_ufm_slot"].append(lat_ufm_slot[tw])
                         woff[ttyp] += 1
@@ -455,6 +456,7 @@ def sim_nominal():
             for w, props in cnf["wafer_slots"].items():
                 if props["type"] == ttyp:
                     if off == woff[ttyp]:
+                        props["tube_index"] = tw
                         tb["wafer_slots"].append(w)
                         tb["wafer_ufm_slot"].append(hex_to_ufm_slot[tw])
                         tb["wafer_ufm_loc"].append(hex_to_ufm_loc[tw])

--- a/sotodlib/sim_hardware.py
+++ b/sotodlib/sim_hardware.py
@@ -357,11 +357,25 @@ def sim_nominal():
     # TOAST hexagon layout positions in Xi/Eta coordinates
     ltube_toasthex_pos = [0, 1, 2, 3, 5, 6, 10]
 
-    # "Optics" locations as given in several SO slide decks
+    # "Optics" locations as given in several SO slide decks.  Note this is flipped in
+    # some figures.  See:
+    # https://simonsobs.atlassian.net/wiki/spaces/PRO/pages/101974017/Focal+Plane+Coordinates
     ltube_optics_pos = [1, 3, 5, 4, 8, 9, 12]
 
     # Cryo team names for these positions
     ltube_cryonames=["c1", "i5", "i6", "i1", "i3", "i4", "o6"]
+
+    lat_ufm_slot = [
+        2,
+        1,
+        0,
+    ]
+
+    lat_ufm_thetarot = [
+        120.0,
+        0.0,
+        240.0,
+    ]
 
     for tindx in range(7):
         nm = ltube_cryonames[tindx]
@@ -370,13 +384,18 @@ def sim_nominal():
         tb["type"] = ttyp
         tb["waferspace"] = 128.4
         tb["wafer_slots"] = list()
-        tb["wafer_slot_angle"] = [0.0 for tw in range(3)] # Degrees
+        tb["wafer_slot_angle"] = [
+            lat_ufm_thetarot[tw] for tw in range(3)
+        ] # Degrees
+        # The "slot" here is the relative slot (ws0 - ws2) within the tube.
+        tb["wafer_ufm_slot"] = list()
         for tw in range(3):
             off = 0
             for w, props in cnf["wafer_slots"].items():
                 if props["type"] == ttyp:
                     if off == woff[ttyp]:
                         tb["wafer_slots"].append(w)
+                        tb["wafer_ufm_slot"].append(lat_ufm_slot[tw])
                         woff[ttyp] += 1
                         break
                     off += 1
@@ -386,7 +405,35 @@ def sim_nominal():
         tb["receiver_name"] = ""
         tube_slots[nm] = tb
 
-    stubes = ["SAT_MF", "SAT_MF", "SAT_UHF","SAT_LF"]
+    hex_to_ufm_slot = [
+        0,
+        2,
+        1,
+        6,
+        5,
+        4,
+        3,
+    ]
+    hex_to_ufm_loc = [
+        "AX",
+        "NE",
+        "NO",
+        "NW",
+        "SW",
+        "SO",
+        "SE",
+    ]
+    hex_to_ufm_thetarot = [
+        240.0,
+        0.0,
+        300.0,
+        180.0,
+        120.0,
+        60.0,
+        60.0,
+    ]
+
+    stubes = ["SAT_MF", "SAT_MF", "SAT_UHF", "SAT_LF"]
     for tindx in range(4):
         nm = "ST{:d}".format(tindx+1)
         ttyp = stubes[tindx]
@@ -394,13 +441,23 @@ def sim_nominal():
         tb["type"] = ttyp
         tb["waferspace"] = 128.4
         tb["wafer_slots"] = list()
-        tb["wafer_slot_angle"] = [0.0 for tw in range(7)] # Degrees
+        tb["wafer_slot_angle"] = [
+            hex_to_ufm_thetarot[tw] for tw in range(7)
+        ] # Degrees
+        # These are taken from:
+        # https://simonsobs.atlassian.net/wiki/spaces/PRO/pages/101974017/Focal+Plane+Coordinates#UFM-Layout.1
+        # The "slot" here is the relative slot (ws0 - ws6) within the tube.
+        tb["wafer_ufm_slot"] = list()
+        # The "loc" here is the compass direction name (e.g. NO, NE, SW, etc.)
+        tb["wafer_ufm_loc"] = list()
         for tw in range(7):
             off = 0
             for w, props in cnf["wafer_slots"].items():
                 if props["type"] == ttyp:
                     if off == woff[ttyp]:
                         tb["wafer_slots"].append(w)
+                        tb["wafer_ufm_slot"].append(hex_to_ufm_slot[tw])
+                        tb["wafer_ufm_loc"].append(hex_to_ufm_loc[tw])
                         woff[ttyp] += 1
                         break
                     off += 1

--- a/sotodlib/sim_hardware.py
+++ b/sotodlib/sim_hardware.py
@@ -370,6 +370,7 @@ def sim_nominal():
         tb["type"] = ttyp
         tb["waferspace"] = 128.4
         tb["wafer_slots"] = list()
+        tb["wafer_slot_angle"] = [0.0 for tw in range(3)] # Degrees
         for tw in range(3):
             off = 0
             for w, props in cnf["wafer_slots"].items():
@@ -393,6 +394,7 @@ def sim_nominal():
         tb["type"] = ttyp
         tb["waferspace"] = 128.4
         tb["wafer_slots"] = list()
+        tb["wafer_slot_angle"] = [0.0 for tw in range(7)] # Degrees
         for tw in range(7):
             off = 0
             for w, props in cnf["wafer_slots"].items():

--- a/sotodlib/sim_hardware.py
+++ b/sotodlib/sim_hardware.py
@@ -91,7 +91,7 @@ def sim_nominal():
     bnd["NET"] = 435.1
     bnd["fknee"] = 50.0
     bnd["fmin"] = 0.01
-    bnd["alpha"] = 3.5
+    bnd["alpha"] = 1.0
     # Noise elevation scaling fits from Carlos Sierra
     # These numbers are for V3 LAT baseline
     bnd["A"] = 0.06
@@ -107,7 +107,7 @@ def sim_nominal():
     bnd["NET"] = 281.5
     bnd["fknee"] = 50.0
     bnd["fmin"] = 0.01
-    bnd["alpha"] = 3.5
+    bnd["alpha"] = 1.0
     bnd["A"] = 0.16
     bnd["C"] = 0.79
     bnd["NET_corr"] = 1.02
@@ -121,7 +121,7 @@ def sim_nominal():
     bnd["NET"] = 361.0
     bnd["fknee"] = 50.0
     bnd["fmin"] = 0.01
-    bnd["alpha"] = 3.5
+    bnd["alpha"] = 1.0
     bnd["A"] = 0.16
     bnd["C"] = 0.80
     bnd["NET_corr"] = 1.09
@@ -135,7 +135,7 @@ def sim_nominal():
     bnd["NET"] = 352.4
     bnd["fknee"] = 50.0
     bnd["fmin"] = 0.01
-    bnd["alpha"] = 3.5
+    bnd["alpha"] = 1.0
     bnd["A"] = 0.17
     bnd["C"] = 0.78
     bnd["NET_corr"] = 1.01
@@ -149,7 +149,7 @@ def sim_nominal():
     bnd["NET"] = 724.4
     bnd["fknee"] = 50.0
     bnd["fmin"] = 0.01
-    bnd["alpha"] = 3.5
+    bnd["alpha"] = 1.0
     bnd["A"] = 0.29
     bnd["C"] = 0.62
     bnd["NET_corr"] = 1.02
@@ -163,7 +163,7 @@ def sim_nominal():
     bnd["NET"] = 1803.9
     bnd["fknee"] = 50.0
     bnd["fmin"] = 0.01
-    bnd["alpha"] = 3.5
+    bnd["alpha"] = 1.0
     bnd["A"] = 0.36
     bnd["C"] = 0.53
     bnd["NET_corr"] = 1.00
@@ -177,7 +177,7 @@ def sim_nominal():
     bnd["NET"] = 314.1
     bnd["fknee"] = 50.0
     bnd["fmin"] = 0.01
-    bnd["alpha"] = 3.5
+    bnd["alpha"] = 1.0
     # Noise elevation scaling fits from Carlos Sierra
     # These numbers are for V3 SAT baseline
     bnd["A"] = 0.06
@@ -193,7 +193,7 @@ def sim_nominal():
     bnd["NET"] = 225.8
     bnd["fknee"] = 50.0
     bnd["fmin"] = 0.01
-    bnd["alpha"] = 3.5
+    bnd["alpha"] = 1.0
     bnd["A"] = 0.19
     bnd["C"] = 0.76
     bnd["NET_corr"] = 1.01
@@ -207,7 +207,7 @@ def sim_nominal():
     bnd["NET"] = 245.1
     bnd["fknee"] = 50.0
     bnd["fmin"] = 0.01
-    bnd["alpha"] = 3.5
+    bnd["alpha"] = 1.0
     bnd["A"] = 0.19
     bnd["C"] = 0.76
     bnd["NET_corr"] = 1.04
@@ -221,7 +221,7 @@ def sim_nominal():
     bnd["NET"] = 250.2
     bnd["fknee"] = 50.0
     bnd["fmin"] = 0.01
-    bnd["alpha"] = 3.5
+    bnd["alpha"] = 1.0
     bnd["A"] = 0.23
     bnd["C"] = 0.70
     bnd["NET_corr"] = 1.02
@@ -235,7 +235,7 @@ def sim_nominal():
     bnd["NET"] = 540.3
     bnd["fknee"] = 50.0
     bnd["fmin"] = 0.01
-    bnd["alpha"] = 3.5
+    bnd["alpha"] = 1.0
     bnd["A"] = 0.35
     bnd["C"] = 0.54
     bnd["NET_corr"] = 1.00
@@ -249,7 +249,7 @@ def sim_nominal():
     bnd["NET"] = 1397.5
     bnd["fknee"] = 50.0
     bnd["fmin"] = 0.01
-    bnd["alpha"] = 3.5
+    bnd["alpha"] = 1.0
     bnd["A"] = 0.42
     bnd["C"] = 0.45
     bnd["NET_corr"] = 1.00

--- a/sotodlib/toast/instrument.py
+++ b/sotodlib/toast/instrument.py
@@ -105,6 +105,26 @@ class SOFocalplane(Focalplane):
     This can be constructed in several ways:
         - From a file while applying selection criteria.
         - From an existing (pre-selected) Hardware instance.
+        - From a nominal sim on the fly with selections.
+
+    Note that to support serialization, the simulated hardware dictionary elements
+    have values in standard units.  When constructing our focalplane table we restore
+    those units and build Quantities.
+
+    Args:
+        hw (Hardware):  If specified, construct from a Hardware object in memory.
+        hwfile (str):  If specified, load this hardware model from disk.
+        det_info_file (str):  If simulating a Hardware model, optionally specify
+            a det_info format file to load
+        det_info_version (str):  The version of the det_info file format.
+        telescope (str):  If not None, select only detectors from this telescope.
+        sample_rate (Quantity):  Use this sample rate for all detectors.
+        bands (str):  Comma separated string of bands to use.
+        wafer_slots (str):  Comma separated string of wafers to use.
+        tube_slots (str):  Comma separated string of tubes to use.
+        thinfp (int):  The factor by which to reduce the number of detectors.
+        creation_time (float):  Optional timestamp to use when building readout_id.
+        comm (MPI.Comm):  Optional MPI communicator.
 
     """
 
@@ -222,6 +242,7 @@ class SOFocalplane(Focalplane):
             pol_angs,
             pol_angs_wafer,
             pol_orientations_wafer,
+            gamma,
             card_slots,
             channels,
             AMCs,
@@ -231,6 +252,7 @@ class SOFocalplane(Focalplane):
             mux_positions,
             tele_wf_band,
         ) = (
+            [],
             [],
             [],
             [],
@@ -279,9 +301,10 @@ class SOFocalplane(Focalplane):
             )
             fwhms.append(float(det_data["fwhm"]) * u.arcmin)
             pols.append(det_data["pol"])
-            pol_angs.append(det_data["pol_ang"])
-            pol_angs_wafer.append(det_data["pol_ang_wafer"])
-            pol_orientations_wafer.append(det_data["pol_orientation_wafer"])
+            pol_angs.append(det_data["pol_ang"] * u.degree)
+            pol_angs_wafer.append(det_data["pol_ang_wafer"] * u.degree)
+            pol_orientations_wafer.append(det_data["pol_orientation_wafer"] * u.degree)
+            gamma.append(det_data["pol_ang"] * u.degree)
             card_slots.append(det_data["card_slot"])
             channels.append(det_data["channel"])
             AMCs.append(det_data["AMC"])
@@ -317,8 +340,7 @@ class SOFocalplane(Focalplane):
             net_corrs.append(get_par_float(det_data, "NET_corr", band_data["NET_corr"]))
             fknees.append(get_par_float(det_data, "fknee", band_data["fknee"]) * u.mHz)
             fmins.append(get_par_float(det_data, "fmin", band_data["fmin"]) * u.mHz)
-            # alphas.append(get_par(det_data, "alpha", band_data["alpha"]))
-            alphas.append(1)  # hardwire a sensible number. 3.5 is not realistic.
+            alphas.append(get_par_float(det_data, "alpha", band_data["alpha"]))
             As.append(get_par_float(det_data, "A", band_data["A"]))
             Cs.append(get_par_float(det_data, "C", band_data["C"]))
             # bandpass
@@ -356,6 +378,7 @@ class SOFocalplane(Focalplane):
                 pol_angs,
                 pol_angs_wafer,
                 pol_orientations_wafer,
+                gamma,
                 channels,
                 AMCs,
                 biases,
@@ -388,6 +411,7 @@ class SOFocalplane(Focalplane):
                 "pol_ang",
                 "pol_ang_wafer",
                 "pol_orientation_wafer",
+                "gamma",
                 "channel",
                 "AMC",
                 "bias",

--- a/sotodlib/toast/sim_focalplane.py
+++ b/sotodlib/toast/sim_focalplane.py
@@ -567,6 +567,7 @@ def sim_telescope_detectors(hw, tele, tube_slots=None, det_info=None, no_darks=F
         # This is a SAT.  We have one tube at the center.
         tubeprops = hw.data["tube_slots"][tube_slots[0]]
         waferspace = tubeprops["waferspace"] * platescale
+        wafer_slot_ang_deg = tubeprops["wafer_slot_angle"]
 
         # Wafers are arranged in a rotated hexagon shape, however these
         # locations are rotated from a normal layout.
@@ -575,7 +576,7 @@ def sim_telescope_detectors(hw, tele, tube_slots=None, det_info=None, no_darks=F
             2 * waferspace * u.degree,
             "",
             "",
-            np.zeros(7) * u.degree,
+            u.Quantity(wafer_slot_ang_deg, u.degree),
         )
         centers = np.zeros((7, 4), dtype=np.float64)
         if det_info_file is None:
@@ -634,19 +635,33 @@ def sim_telescope_detectors(hw, tele, tube_slots=None, det_info=None, no_darks=F
             tubeprops = hw.data["tube_slots"][tube_slot]
             waferspace = tubeprops["waferspace"]
             location = tubeprops["toast_hex_pos"]
+            wafer_slot_ang_deg = tubeprops["wafer_slot_angle"]
+            wafer_slot_ang_rad = np.radians(wafer_slot_ang_deg)
 
             wradius = 0.5 * (waferspace * platescale * np.pi / 180.0)
             if det_info_file is None:
                 qwcenters = [
-                    xieta_to_quat(-wradius, wradius / np.sqrt(3.0), thirty * 4),
-                    xieta_to_quat(0.0, -2.0 * wradius / np.sqrt(3.0), 0.0),
-                    xieta_to_quat(wradius, wradius / np.sqrt(3.0), -thirty * 4),
+                    xieta_to_quat(
+                        -wradius, wradius / np.sqrt(3.0), thirty * 4 + wafer_slot_ang_rad[0]
+                    ),
+                    xieta_to_quat(
+                        0.0, -2.0 * wradius / np.sqrt(3.0), wafer_slot_ang_rad[1]
+                    ),
+                    xieta_to_quat(
+                        wradius, wradius / np.sqrt(3.0), -thirty * 4 + wafer_slot_ang_rad[2]
+                    ),
                 ]
             else:
                 qwcenters = [
-                    xieta_to_quat(-wradius, wradius / np.sqrt(3.0), 7*thirty),
-                    xieta_to_quat(0.0, -2.0 * wradius / np.sqrt(3.0), 3*thirty),
-                    xieta_to_quat(wradius, wradius / np.sqrt(3.0), -thirty ),
+                    xieta_to_quat(
+                        -wradius, wradius / np.sqrt(3.0), 7*thirty + wafer_slot_ang_rad[0]
+                    ),
+                    xieta_to_quat(
+                        0.0, -2.0 * wradius / np.sqrt(3.0), 3*thirty + wafer_slot_ang_rad[1]
+                    ),
+                    xieta_to_quat(
+                        wradius, wradius / np.sqrt(3.0), -thirty + wafer_slot_ang_rad[2]
+                    ),
                 ]
 
             centers = list()

--- a/sotodlib/toast/sim_focalplane.py
+++ b/sotodlib/toast/sim_focalplane.py
@@ -277,7 +277,7 @@ def sim_wafer_detectors(
                 dprops = OrderedDict()
                 dprops["wafer_slot"] = wafer_slot
                 dprops["ID"] = idoff + doff
-                dprops["pixel"] = pstr
+                dprops["pixel"] = pxstr
                 dprops["band"] = b
                 dprops["fwhm"] = fwhm[b]
                 dprops["pol"] = pl

--- a/sotodlib/toast/sim_focalplane.py
+++ b/sotodlib/toast/sim_focalplane.py
@@ -15,90 +15,13 @@ from toast.instrument_sim import (
     hex_layout,
     rhomb_dim,
     rhomb_xieta_row_col,
-    rhombus_layout,
-    rhomb_gamma_angles_qu,
+    rhombus_hex_layout,
 )
 import toast.qarray as qa
 import toast.utils
 
 from sotodlib.io.metadata import read_dataset
 import sotodlib.core.metadata.loader as loader
-
-
-def rhombus_hex_layout(rhombus_npos, rhombus_width, gap, pos_rotate=None, killpos=None):
-    """
-    Construct a hexagon from 3 rhombi.
-
-    Args:
-        rhombus_npos (int):  The number of positions in one rhombus.
-        rhombus_width (Quantity):  The angle subtended by the width of one rhombus
-            along the short dimension.
-        gap (Quantity):  The angular gap between the edges of the rhombi.
-        pos_rotate (array, Quantity): An additional angle rotation of each position
-            on each rhombus before the rhombus is rotated into place.
-        killpos (list, optional): Pixel indices to remove for mechanical
-            reasons.
-
-    Returns:
-        (array):  Quaternion array of pixel positions.
-
-    """
-    # width in radians
-    width_rad = rhombus_width.to_value(u.radian)
-
-    # Gap between rhombi in radians
-    gap_rad = gap.to_value(u.radian)
-
-    # Quaternion offsets of the 3 rhombi
-    centers = [
-        xieta_to_quat(
-            0.25 * np.sqrt(3.0) * width_rad + 0.5 * gap_rad,
-            -0.25 * width_rad - gap_rad / (2 * np.sqrt(3.0)),
-            np.pi / 6,
-        ),
-        xieta_to_quat(
-            0.0,
-            0.5 * width_rad + gap_rad / np.sqrt(3.0),
-            -0.5 * np.pi,
-        ),
-        xieta_to_quat(
-            -0.25 * np.sqrt(3.0) * width_rad - 0.5 * gap_rad,
-            -0.25 * width_rad - gap_rad / (2 * np.sqrt(3.0)),
-            5 * np.pi / 6,
-        ),
-    ]
-
-    # Quaternion array of outputs, without missing pixel locations.
-    nkill = len(killpos)
-    killset = set(killpos)
-    result = np.zeros((3 * rhombus_npos - nkill, 4), dtype=np.float64)
-
-    # Pre-rotation of all pixels
-    pos_ang = u.Quantity(np.zeros(rhombus_npos, dtype=np.float64), u.radian)
-    if pos_rotate is not None:
-        pos_ang = pos_rotate
-
-    all_quat = dict()
-    for irhomb, cent in enumerate(centers):
-        quat = rhombus_layout(
-            rhombus_npos,
-            rhombus_width,
-            "",
-            "",
-            pos_ang,
-            center=cent,
-            pos_offset=irhomb * rhombus_npos,
-        )
-        all_quat.update(quat)
-    pquat = {int(x): y["quat"] for x, y in all_quat.items()}
-
-    poff = 0
-    for p, q in pquat.items():
-        if p not in killset:
-            result[poff, :] = q
-            poff += 1
-
-    return result
 
 
 def sim_wafer_detectors(
@@ -113,6 +36,11 @@ def sim_wafer_detectors(
 
     Given a Hardware configuration, generate all detector properties for
     the specified wafer and optionally only the specified band.
+
+    By convention, polarization angle quantities are stored in degrees and
+    fwhm is stored in arcminutes.  These units are stripped to ease serialization
+    to TOML and JSON.  The units are restored when constructing focalplane tables
+    for TOAST.
 
     Args:
         hw (Hardware): The hardware properties.
@@ -151,14 +79,15 @@ def sim_wafer_detectors(
     # handedness for the Sinuous detectors.
 
     npix = wprops["npixel"]
-    pixsep = platescale * wprops["pixsize"]
-    layout_A = None
-    layout_B = None
+    pixsep = platescale * wprops["pixsize"] * u.degree
     handed = None
     kill = []
     if wprops["packing"] == "F":
         # Feedhorn (NIST style)
-        gap = platescale * wprops["rhombusgap"]
+        # The "gap" is the **additional** space beyond the normal pixel
+        # separation.  For S.O., we always have the gap equal to nominal
+        # pixel spacing.
+        gap = 0.0 * u.degree
         nrhombus = npix // 3
 
         # This dim is also the number of pixels along the short axis.
@@ -182,34 +111,31 @@ def sim_wafer_detectors(
             else:
                 pol_A[p] = 45.0 + poloff
             pol_B[p] = 90.0 + pol_A[p]
+        pol_A = u.Quantity(pol_A, u.degree)
+        pol_B = u.Quantity(pol_B, u.degree)
+
+        layout_A = rhombus_hex_layout(
+            nrhombus, width, "", "", gap=gap, pol=pol_A
+        )
+        layout_B = rhombus_hex_layout(
+            nrhombus, width, "", "", gap=gap, pol=pol_B
+        )
 
         # We are going to remove 2 pixels for mechanical reasons
         kf = dim * (dim - 1) // 2
         kill = [(dim * dim + kf), (dim * dim + kf) + dim - 2]
-        layout_A = rhombus_hex_layout(
-            nrhombus,
-            width * u.degree,
-            gap * u.degree,
-            pos_rotate=pol_A * u.degree,
-            killpos=kill,
-        )
-        layout_B = rhombus_hex_layout(
-            nrhombus,
-            width * u.degree,
-            gap * u.degree,
-            pos_rotate=pol_B * u.degree,
-            killpos=kill,
-        )
-        # Expand pol_A and pol_B to npix instead of nrhombus
-        pol_A = np.tile(pol_A, 3)
-        pol_B = np.tile(pol_B, 3)
+
+        # The orientation of the wafer with respect to the focalplane
+        wafer_rot_rad = 0.0
     elif wprops["packing"] == "S":
         # Sinuous (Berkeley style)
         # This is the center-center distance along the vertex-vertex axis
         width = (2 * (hex_nring(npix) - 1)) * pixsep
 
-        # We rotate the hex layout 30 degrees about the center
-        hex_cent = qa.from_axisangle(zaxis, np.pi / 6)
+        # The orientation of the wafer with respect to the focalplane.  This
+        # is 30 degrees.
+        wafer_rot_rad = np.pi / 6
+        hex_cent = qa.from_axisangle(zaxis, wafer_rot_rad)
 
         # The sinuous handedness is chosen so that A/B pairs of pixels have the
         # same nominal orientation but trail each other along the
@@ -313,22 +239,11 @@ def sim_wafer_detectors(
                 else:
                     pol_A[p] = 45.0
                 pol_B[p] = 90.0 + pol_A[p]
-        quat_A = hex_layout(
-            npix, width * u.degree, "", "", pol_A * u.degree, center=hex_cent
-        )
-        quat_B = hex_layout(
-            npix, width * u.degree, "", "", pol_B * u.degree, center=hex_cent
-        )
 
-        layout_A = np.zeros((len(quat_A), 4), dtype=np.float64)
-        pquat_A = {int(x): y["quat"] for x, y in quat_A.items()}
-        for p, q in pquat_A.items():
-            layout_A[p, :] = q
-
-        layout_B = np.zeros((len(quat_B), 4), dtype=np.float64)
-        pquat_B = {int(x): y["quat"] for x, y in quat_B.items()}
-        for p, q in pquat_B.items():
-            layout_B[p, :] = q
+        pol_A = u.Quantity(pol_A, u.degree)
+        pol_B = u.Quantity(pol_B, u.degree)
+        layout_A = hex_layout(npix, width, "", "", pol_A, center=hex_cent)
+        layout_B = hex_layout(npix, width, "", "", pol_B, center=hex_cent)
     else:
         raise RuntimeError("Unknown wafer packing '{}'".format(wprops["packing"]))
 
@@ -349,14 +264,16 @@ def sim_wafer_detectors(
     for px in range(npix):
         if px in kill:
             continue
-        pstr = "{:03d}".format(p)
+        if npix < 100:
+            pxstr = f"{px:02d}"
+        else:
+            pxstr = f"{px:03d}"
+        pstr = f"{p:03d}"
         for b in bands:
-            for pl, layout, pol in zip(
+            for pl, layout, in zip(
                 ["A", "B"],
                 [layout_A, layout_B],
-                [pol_A, pol_B],
             ):
-                poloff = np.amin(pol)  # Wafer polarization offset
                 dprops = OrderedDict()
                 dprops["wafer_slot"] = wafer_slot
                 dprops["ID"] = idoff + doff
@@ -364,14 +281,32 @@ def sim_wafer_detectors(
                 dprops["band"] = b
                 dprops["fwhm"] = fwhm[b]
                 dprops["pol"] = pl
-                # Polarization angle in focalplane basis
-                dprops["pol_ang"] = pol[p]
-                # Polarization angle in wafer basis
-                dprops["pol_ang_wafer"] = pol[p] - poloff
-                # Polarization orientation on wafer is always 0 or 45
-                dprops["pol_orientation_wafer"] = (pol[p] - poloff) % 90
+
+                # Polarization angle in wafer basis.  This is the gamma angle
+                # returned by the layout functions above, less the rotation
+                # of the wafer.
+                wafer_gamma = layout[pxstr]["gamma"]
+                dprops["pol_ang_wafer"] = np.degrees(wafer_gamma - wafer_rot_rad)
+
+                # Physical polarization orientation on wafer is always expressed
+                # as 0 or 45.
+                dprops["pol_orientation_wafer"] = dprops["pol_ang_wafer"] % 90
+
+                # Polarization angle in focalplane basis.  This is, by
+                # definition, equal to the gamma angle computed by the layout
+                # functions.  However, we must also account for the extra rotation
+                # of the center offset passed to this function.
+                if center is not None:
+                    dprops["quat"] = qa.mult(center, layout[pxstr]["quat"]).flatten()
+                    _, _, temp_gamma = quat_to_xieta(dprops["quat"])
+                    dprops["gamma"] = np.degrees(temp_gamma)
+                else:
+                    dprops["quat"] = layout[pxstr]["quat"].flatten()
+                    dprops["gamma"] = np.degrees(wafer_gamma)
+                dprops["pol_ang"] = dprops["gamma"]
+
                 if handed is not None:
-                    dprops["handed"] = handed[p]
+                    dprops["handed"] = handed[px]
                 # Made-up assignment to readout channels
                 dprops["card_slot"] = card_slot
                 dprops["channel"] = doff
@@ -380,12 +315,7 @@ def sim_wafer_detectors(
                 dprops["readout_freq_GHz"] = readout_freq[doff]
                 dprops["bondpad"] = doff - (doff // chan_per_mux) * chan_per_mux
                 dprops["mux_position"] = doff // chan_per_mux
-                # Layout quaternion offset is from the origin.  Now we apply
-                # the rotation of the wafer center.
-                if center is not None:
-                    dprops["quat"] = qa.mult(center, layout[p]).flatten()
-                else:
-                    dprops["quat"] = layout[p].flatten()
+
                 dprops["detector_name"] = ""
                 dname = "{}_p{}_{}_{}".format(wafer_slot, pstr, b, pl)
                 dets[dname] = dprops
@@ -514,6 +444,7 @@ def load_wafer_detectors(
 
     dets = OrderedDict()
     # FIXME: double check this
+    # FIXME: this seems REALLY fragile.  Can we do something better?
     poloff = np.degrees(np.nanmin(wafer.angle)) - 22.5
 
     for i, detname in enumerate(wafer.dets.vals):
@@ -537,10 +468,14 @@ def load_wafer_detectors(
         dprops["fwhm"] = fwhm[dprops["band"]] if dprops["band"] in fwhm else np.nan
         dprops["pol"] = wafer.pol[i]
 
-        # Full polarization angle
-        dprops["pol_ang"] = np.round(np.degrees(wafer.angle[i]), 2)
+        # This should be the same as the detector gamma angle relative to focalplane
+        # coordinates.
+        dprops["gamma"] = np.degrees(wafer.angle[i])
+        dprops["pol_ang"] = dprops["gamma"]
+
         # Polarization angle in the wafer coordinate system
         dprops["pol_ang_wafer"] = np.round(np.degrees(wafer.angle[i]) - poloff, 2)
+
         # This angle seems meaningless for wafers assembled out of rhomboids
         dprops["pol_orientation_wafer"] = dprops["pol_ang_wafer"] % 90
 
@@ -565,13 +500,16 @@ def load_wafer_detectors(
         )
         if center is not None:
             dprops["quat"] = qa.mult(center, quat).flatten()
+            # Update gamma angle to include the center rotation
+            _, _, temp_gamma = quat_to_xieta(dprops["quat"])
+            dprops["gamma"] = np.degrees(temp_gamma)
+            dprops["pol_ang"] = dprops["gamma"]
         else:
             dprops["quat"] = quat.flatten()
         dprops["detector_name"] = f"{wafer_slot}{detname}"
         dets[dprops["detector_name"]] = dprops
 
     return dets
-
 
 
 def sim_telescope_detectors(hw, tele, tube_slots=None, det_info=None, no_darks=False):
@@ -597,6 +535,17 @@ def sim_telescope_detectors(hw, tele, tube_slots=None, det_info=None, no_darks=F
 
     zaxis = np.array([0, 0, 1], dtype=np.float64)
     thirty = np.pi / 6.0
+    sixty = np.pi / 3.0
+
+    # det_info parameters
+    det_info_file = None
+    det_info_version = None
+    if det_info is not None:
+        if len(det_info) < 2:
+            raise RuntimeError("Expected at least 2 elements in det_info tuple")
+        det_info_file = det_info[0]
+        det_info_version = det_info[1]
+
     # The properties of this telescope
     teleprops = hw.data["telescopes"][tele]
     platescale = teleprops["platescale"]
@@ -623,13 +572,13 @@ def sim_telescope_detectors(hw, tele, tube_slots=None, det_info=None, no_darks=F
         # locations are rotated from a normal layout.
         wcenters = hex_layout(
             7,
-            (3.0 * np.sqrt(3.0) / 2) * waferspace * u.degree,
+            2 * waferspace * u.degree,
             "",
             "",
             np.zeros(7) * u.degree,
         )
         centers = np.zeros((7, 4), dtype=np.float64)
-        if det_info is None or det_info[0] is None:
+        if det_info_file is None:
             qrot = qa.from_axisangle(zaxis, -thirty)
         else:
             qrot = qa.from_axisangle(zaxis, thirty)
@@ -637,28 +586,30 @@ def sim_telescope_detectors(hw, tele, tube_slots=None, det_info=None, no_darks=F
         
         for p, q in wcenters.items():
             quat = q["quat"]
-            if det_info is not None and det_info[0] is not None:
+            if det_info_file is not None:
                 # Add an additional rotation of the wafer before
                 # repositioning the wafer center
                 quat2 = qa.from_axisangle(zaxis, rots[int(p)])
                 quat = qa.mult(quat, quat2)
             centers[int(p), :] = qa.mult(qrot, quat)
 
-        windx = 0
-        for wafer_slot in tubeprops["wafer_slots"]:
-            if det_info is not None and det_info[0] is not None:
+        for windx, wafer_slot in enumerate(tubeprops["wafer_slots"]):
+            if det_info_file is not None:
                 dets = load_wafer_detectors(
-                    hw, wafer_slot, platescale, fwhm,
-                    det_info[0], det_info[1], center=centers[windx],
+                    hw, 
+                    wafer_slot, 
+                    platescale, 
+                    fwhm,
+                    det_info_file, 
+                    det_info_version, 
+                    center=centers[windx],
                     no_darks=no_darks,
                 )
             else:
                 dets = sim_wafer_detectors(
                     hw, wafer_slot, platescale, fwhm, center=centers[windx]
                 )
-
             alldets.update(dets)
-            windx += 1
     else:
         # This is the LAT.  We layout detectors for the case of 30
         # degree elevation and no boresight rotation.  Compute the
@@ -667,29 +618,25 @@ def sim_telescope_detectors(hw, tele, tube_slots=None, det_info=None, no_darks=F
         # Inter-tube spacing
         tubespace = teleprops["tubespace"]
 
-        # Pre-rotation of the tube arrangement
-        tuberot = 0.0 * np.ones(19, dtype=np.float64)
-
         # Hexagon layout
         tube_quats = hex_layout(
             19,
             4 * (tubespace * platescale) * u.degree,
             "",
             "",
-            tuberot * u.degree,
+            np.zeros(19, dtype=np.float64) * u.degree,
         )
-        tcenters = np.zeros((19, 4), dtype=np.float64)
-        for p, q in tube_quats.items():
-            tcenters[int(p), :] = q["quat"]
+        tcenters = np.array(
+            [q["quat"] for p, q in tube_quats.items()]
+        )
 
-        tindx = 0
-        for tube_slot in tube_slots:
+        for tindx, tube_slot in enumerate(tube_slots):
             tubeprops = hw.data["tube_slots"][tube_slot]
             waferspace = tubeprops["waferspace"]
             location = tubeprops["toast_hex_pos"]
 
             wradius = 0.5 * (waferspace * platescale * np.pi / 180.0)
-            if det_info is None or det_info[0] is None:
+            if det_info_file is None:
                 qwcenters = [
                     xieta_to_quat(-wradius, wradius / np.sqrt(3.0), thirty * 4),
                     xieta_to_quat(0.0, -2.0 * wradius / np.sqrt(3.0), 0.0),
@@ -706,27 +653,33 @@ def sim_telescope_detectors(hw, tele, tube_slots=None, det_info=None, no_darks=F
             for qwc in qwcenters:
                 centers.append(qa.mult(tcenters[location], qwc))
 
-            windx = 0
-            for wafer_slot in tubeprops["wafer_slots"]:
-                if det_info is not None and det_info[0] is not None:
+            for windx, wafer_slot in enumerate(tubeprops["wafer_slots"]):
+                if det_info_file is not None:
                     dets = load_wafer_detectors(
-                        hw, wafer_slot, platescale, fwhm,
-                        det_info[0], det_info[1], center=centers[windx],
+                        hw,
+                        wafer_slot,
+                        platescale,
+                        fwhm,
+                        det_info_file,
+                        det_info_version,
+                        center=centers[windx],
                         no_darks=no_darks,
                     )
                 else:
                     dets = sim_wafer_detectors(
                         hw, wafer_slot, platescale, fwhm, center=centers[windx]
                     )
-
+                # Accumulate to the total
                 alldets.update(dets)
-                windx += 1
-            tindx += 1
 
-        # Rotate the focalplane to the nominal horizontal orientation
+        # Rotate the focalplane to the nominal horizontal orientation.
         fp_rot = qa.from_axisangle(zaxis, 0.5 * np.pi)
         for d, props in alldets.items():
             props["quat"] = qa.mult(fp_rot, props["quat"])
+            # Update gamma angle to include this rotation
+            _, _, temp_gamma = quat_to_xieta(props["quat"])
+            props["gamma"] = np.degrees(temp_gamma)
+            props["pol_ang"] = props["gamma"]
 
     if "detectors" in hw.data:
         hw.data["detectors"].update(alldets)

--- a/sotodlib/vis_hardware.py
+++ b/sotodlib/vis_hardware.py
@@ -56,6 +56,7 @@ def plot_detectors(
     xieta=False,
     lat_corotate=True,
     lat_elevation=None,
+    show_centers=False,
 ):
     """Visualize a dictionary of detectors.
 
@@ -73,6 +74,7 @@ def plot_detectors(
         bandcolor (dict, optional): Dictionary of color values for each band.
         xieta (bool):  If True, plot in Xi / Eta / Gamma coordinates rather
             than focalplane X / Y / Z.
+        show_centers (bool):  If True, label pixel centers.
 
     Returns:
         None
@@ -183,7 +185,7 @@ def plot_detectors(
         dir = qa.rotate(quats, zaxis)
         orient = qa.rotate(quats, xaxis)
 
-        small = np.fabs(1.0 - dir[:, 2]) < 1.0e-6
+        small = np.fabs(1.0 - dir[:, 2]) < 1.0e-12
         not_small = np.logical_not(small)
         xp = np.zeros(n_det, dtype=np.float64)
         yp = np.zeros(n_det, dtype=np.float64)
@@ -337,11 +339,27 @@ def plot_detectors(
             length_includes_head=True,
         )
 
+        # Compute the font size to use for detector labels
+        fontpix = 0.1 * detradius * hpixperdeg
+        if fontpix < 1.0:
+            fontpix = 1.0
+
+        if show_centers:
+            ysgn = -1.0
+            if dx < 0.0:
+                ysgn = 1.0
+            ax.text(
+                (xpos + 0.1 * dx),
+                (ypos + 0.1 * ysgn * dy),
+                f"({xpos:0.4f}, {ypos:0.4f})",
+                color="green",
+                fontsize=fontpix,
+                horizontalalignment="center",
+                verticalalignment="center",
+                bbox=dict(fc="w", ec="none", pad=1, alpha=0.0),
+            )
+
         if labels:
-            # Compute the font size to use for detector labels
-            fontpix = 0.1 * detradius * hpixperdeg
-            if fontpix < 1.0:
-                fontpix = 1.0
             ax.text(
                 xpos,
                 ypos,

--- a/tests/test_hardware.py
+++ b/tests/test_hardware.py
@@ -82,6 +82,8 @@ class HardwareTest(TestCase):
             print("TOAST cannot be imported- skipping unit test", flush=True)
             return
         fullhw = sim_nominal()
+
+        # SAT test
         toastsf.sim_telescope_detectors(fullhw, "SAT1")
         hw = fullhw.select(match={"wafer_slot": ["w25",],})
         outpath = os.path.join(self.outdir, "telescope_SAT1_w25.toml.gz")
@@ -89,6 +91,18 @@ class HardwareTest(TestCase):
         if not self.skip_plots:
             outpath = os.path.join(self.outdir, "telescope_SAT1_w25.pdf")
             plot_detectors(hw.data["detectors"], outpath, labels=False)
+
+        fullhw.data["detectors"] = OrderedDict()
+
+        # LAT test
+        toastsf.sim_telescope_detectors(fullhw, "LAT")
+        hw = fullhw.select(match={"tube_slots": ["c1",],})
+        outpath = os.path.join(self.outdir, "telescope_LAT_c1.toml.gz")
+        hw.dump(outpath, overwrite=True, compress=True)
+        if not self.skip_plots:
+            outpath = os.path.join(self.outdir, "telescope_LAT_c1.pdf")
+            plot_detectors(hw.data["detectors"], outpath, labels=False)
+
         return
 
     def test_sim_full(self):


### PR DESCRIPTION
This PR is the matching one for the [upstream PR in toast](https://github.com/hpc4cmb/toast/pull/674).  This ensures that focalplane layout widths are always given in terms of pixel centers rather than field of view.