### PR TITLE
Add stream_id to det_info

### DIFF
--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -2621,7 +2621,7 @@ def load_g3tsmurf_obs(
         samples=samples,
         obsfiledb=db,
         no_signal=no_signal,
-        merge_det_info=False
+        merge_det_info=True
     )
 
 

--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -2539,6 +2539,7 @@ def load_file(
         smurf.wrap("channel", ch_info.channel, [(0,det_axis)])
         smurf.wrap("res_frequency", ch_info.frequency, [(0,det_axis)])
         det_info.wrap("smurf", smurf)
+        det_info.wrap("stream_id", status.stream_id)
         aman.wrap("det_info", det_info)
 
 


### PR DESCRIPTION
This adds the current stream_id to det_info when loading from load_smurf tools. Also merges in det_info when loading via context.