### PR TITLE
g3tsmurf indexing deployment bugfix

### DIFF
--- a/sotodlib/site_pipeline/update_g3tsmurf_db.py
+++ b/sotodlib/site_pipeline/update_g3tsmurf_db.py
@@ -17,8 +17,8 @@ from sotodlib.io.load_smurf import G3tSmurf, Observations, logger as default_log
 
 
 def main(config: Optional[str] = None, update_delay: float = 2, 
-         from_scratch: bool = False, verbosity: int = 2, logger=None,
-         index_via_actions: bool =False):
+         from_scratch: bool = False, verbosity: int = 2,
+         index_via_actions: bool=False, logger=None):
     """
     Arguments
     ---------


### PR DESCRIPTION
`update_g3tsmurf_db` needs an argument reordering. I found this fixed the bug in prefect auto-deployment but I still need to understand why. It may have to do with how I modify function signature by hand. Before I figure out the reason, we should make sure that `logger` is always the last argument in each site-pipeline module script.