### PR TITLE
Allow some buffer in update time checking

### DIFF
--- a/sotodlib/io/g3thk_utils.py
+++ b/sotodlib/io/g3thk_utils.py
@@ -34,7 +34,9 @@ def pysmurf_monitor_control_list(agent, start=None, stop=None, HK=None):
         if HK is None:
             raise ValueError("need database to search if agent is instance id")
         agent_list = HK.get_db_agents(agent, start, stop)
-        return np.unique([pysmurf_monitor_control_list(agent) for agent in agent_list])
+        return np.unique(
+                np.concatenate[pysmurf_monitor_control_list(agent) for agent in agent_list])
+        )
     stream_ids = []
     for field in agent.fields:
         if not "_meta" in field.field:

--- a/sotodlib/io/g3thk_utils.py
+++ b/sotodlib/io/g3thk_utils.py
@@ -35,7 +35,7 @@ def pysmurf_monitor_control_list(agent, start=None, stop=None, HK=None):
             raise ValueError("need database to search if agent is instance id")
         agent_list = HK.get_db_agents(agent, start, stop)
         return np.unique(
-                np.concatenate[pysmurf_monitor_control_list(agent) for agent in agent_list])
+                np.concatenate([pysmurf_monitor_control_list(agent) for agent in agent_list])
         )
     stream_ids = []
     for field in agent.fields:

--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -1424,6 +1424,14 @@ class G3tSmurf:
                 agent_list.append(server["smurf-suprsync"])
                 agent_list.append(server["timestream-suprsync"])
                 continue
+            if stop > HK.get_last_update():
+                if stop > HK.get_last_update()+3600:
+                    logger.error(f"HK database not updated recently enough to"
+                                  " check finalization time. Last update "
+                                 f"{HK.get_last_update}. Trying to check until"
+                                 f"{stop}")
+                else:
+                    stop = HK.get_last_update()
             sids = pysmurf_monitor_control_list(pm, start, stop, HK)
             if np.any([s in stream_ids for s in sids]):
                 agent_list.append(server["smurf-suprsync"])


### PR DESCRIPTION
Found synchronization issue while setting things up at the site. This adds some search buffer while looking for pysmurf monitor control information.