### PR TITLE
fix bug in make_map function in coords/demod.py

### DIFF
--- a/sotodlib/coords/demod.py
+++ b/sotodlib/coords/demod.py
@@ -11,7 +11,7 @@ def make_map(tod,
              dsT=None, demodQ=None, demodU=None,
              cuts=None,
              det_weights=None, det_weights_demod=None,
-             wrong_definition=False):
+             wrong_definition=False, center_on=None):
     """
     Generates maps of temperature and polarization from a TOD.
 


### PR DESCRIPTION
The make_map function is missing a center_on=None parameter in the inputs. If center_on is not defined it fails at some point.