### PR TITLE
Preprocess debug

### DIFF
--- a/sotodlib/coords/demod.py
+++ b/sotodlib/coords/demod.py
@@ -7,7 +7,7 @@ from .. import core, tod_ops, coords
 
 def make_map(tod,
              P=None, wcs_kernel=None,
-             res=0.1 * coords.DEG,
+             res=0.1 * coords.DEG, center_on=None,
              dsT=None, demodQ=None, demodU=None,
              cuts=None,
              det_weights=None, det_weights_demod=None,

--- a/sotodlib/flag_utils.py
+++ b/sotodlib/flag_utils.py
@@ -5,7 +5,7 @@ import time
 from scipy import stats
 
 def plot_glitch_stats(tod, glitches=None, N_bins=30, save_path='./',
-                      save_name='glitch_flag_stats.png', save_plot=True):
+                      save_name='glitch_flag_stats.png', save_plot=False):
     """
     Function for plotting the glitch flags/cut statistics using the built in stats functions
     in the RangesMatrices class.
@@ -45,9 +45,6 @@ def plot_glitch_stats(tod, glitches=None, N_bins=30, save_path='./',
     ax[0].axvline(medsamps,color = 'C1', ls = ':', lw = 2, label=f'Median: {medsamps:.2f}%')
     meansamps = np.mean(frac_samp_glitches)
     ax[0].axvline(meansamps,color = 'C2', ls = ':', lw = 2, label=f'Mean: {meansamps:.2f}%')
-    modesamps = stats.mode(frac_samp_glitches)
-    ax[0].axvline(modesamps[0][0],color = 'C3', ls = ':', lw = 2, 
-                  label=f'Mode: {modesamps[0][0]:.2f}%, Counts: {modesamps[1][0]}')
     stdsamps = np.std(frac_samp_glitches)
     ax[0].axvspan(meansamps-stdsamps, meansamps+stdsamps, color = 'wheat', alpha = 0.2, 
                   label=f'$\sigma$: {stdsamps:.2f}%')
@@ -68,9 +65,6 @@ def plot_glitch_stats(tod, glitches=None, N_bins=30, save_path='./',
     meanints = np.mean(interval_glitches)
     ax[1].axvline(meanints,color = 'C2', ls = ':', lw = 2, 
                   label=f'Mean: {meanints:.2f} intervals')
-    modeints = stats.mode(interval_glitches)
-    ax[1].axvline(modeints[0][0],color = 'C3', ls = ':', lw = 2,
-                  label=f'Mode: {modeints[0][0]:.2f} intervals, Counts: {modeints[1][0]}')
     stdints = np.std(interval_glitches)
     ax[1].axvspan(meanints-stdints, meanints+stdints, color = 'wheat', alpha = 0.2,
                   label=f'$\sigma$: {stdints:.2f} intervals')

--- a/sotodlib/flag_utils.py
+++ b/sotodlib/flag_utils.py
@@ -4,7 +4,7 @@ import os
 import time
 from scipy import stats
 
-def plot_glitch_stats(tod, flags='flags', glitches='glitches', N_bins=30, save_path='./',
+def plot_glitch_stats(tod, glitches=None, N_bins=30, save_path='./',
                       save_name='glitch_flag_stats.png', save_plot=True):
     """
     Function for plotting the glitch flags/cut statistics using the built in stats functions
@@ -30,9 +30,11 @@ def plot_glitch_stats(tod, flags='flags', glitches='glitches', N_bins=30, save_p
     interval_glitches (ndarray, int): Array size 1 x N_dets with number flagged intervals per
                                       detectors.
     """
+    if glitches == None:
+        glitches = tod.flags.glitches
     fig, axes = plt.subplots(1,2,figsize = (15,5))
     ax = axes.flatten()
-    frac_samp_glitches = 100*np.asarray(tod[flags][glitches].get_stats()['samples'])/\
+    frac_samp_glitches = 100*np.asarray(glitches.get_stats()['samples'])/\
                          tod.samps.count
     glitchlog = np.log10(frac_samp_glitches[frac_samp_glitches > 0])
     binmin = int(np.floor(np.min(glitchlog)))
@@ -57,7 +59,7 @@ def plot_glitch_stats(tod, flags='flags', glitches='glitches', N_bins=30, save_p
     ax[0].set_title('Samples Flagged Stats\n$N_{\mathrm{dets}}$ = '+f'{tod.dets.count}'+
                     ' and $N_{\mathrm{samps}}$ = '+f'{tod.samps.count}', fontsize = 18)
 
-    interval_glitches = np.asarray(tod[flags][glitches].get_stats()['intervals'])
+    interval_glitches = np.asarray(glitches.get_stats()['intervals'])
     binlinmax = np.nanmax(interval_glitches)
     _ = ax[1].hist(interval_glitches, bins = np.linspace(0, binlinmax, N_bins))
     medints = np.median(interval_glitches)

--- a/sotodlib/hwp/hwp_utils.py
+++ b/sotodlib/hwp/hwp_utils.py
@@ -42,7 +42,48 @@ def plot_hwpss_fit_status(tod, hwpss_stats, plot_dets=None, plot_num_dets=3,
         plt.savefig(os.path.join(save_path, save_ts+'_'+save_name))
     return fig, ax
 
+def plot_preprocess_PSDs(aman, det=None, psd_before=None, psd_after=None, psd_dsT=None, psd_demodQ=None, psd_demodU=None,
+                        take_square_root=True, amplitude_unit='pA',
+                        save_plot=False, save_path='./', save_name='preprocess_PSDs.png'):
+    if psd_before is None: psd_before = aman.psd
+    if psd_after is None: psd_after = aman.psd_hwpss_remove
+    if psd_dsT is None: psd_dsT = aman.psd_dsT
+    if psd_demodQ is None: psd_demodQ = aman.psd_demodQ
+    if psd_demodU is None: psd_demodU = aman.psd_demodU
+    
+    psd_dict = {
+    'before': psd_before,
+    'after': psd_after,
+    'dsT': psd_dsT,
+    'demodQ': psd_demodQ,
+    'demodU': psd_demodU,
+           }
 
+    if take_square_root:
+        power = 0.5
+        ylabel = f'PSD [{amplitude_unit}/sqrt(Hz)]'
+    else:
+        power = 1
+        ylabel = f'PSD [{amplitude_unit}^2/Hz]'
+
+    if det is None:
+        det = aman.dets.vals[0]
+        
+    det_idx = np.where(aman.dets.vals == det)[0][0]
+    fig, ax = plt.subplots(1, 1, figsize=(7, 5))
+    for i, (psd_name, psd) in enumerate(psd_dict.items()):
+        ax.loglog(psd.freqs, psd.Pxx[det_idx]**power, label=psd_name, alpha=0.3)
+        if i == 0:
+            ax.set_ylim(np.nanmin(psd.Pxx[det_idx]**power), np.nanmax(psd.Pxx[det_idx]**power))
+
+    ax.legend()
+    ax.set_xlabel('freq [Hz]')
+    ax.set_ylabel(ylabel)
+    ax.set_title(f'Obs_timestamp:{aman.timestamps[0]:.0f}\ndet:{det}')
+    fig.tight_layout()
     
+    save_ts = str(int(time.time()))
+    if save_plot:
+        plt.savefig(os.path.join(save_path, save_ts+'_'+save_name))
     
-    
+    return fig, ax

--- a/sotodlib/hwp/hwp_utils.py
+++ b/sotodlib/hwp/hwp_utils.py
@@ -40,7 +40,9 @@ def plot_hwpss_fit_status(tod, hwpss_stats, plot_dets=None, plot_num_dets=3,
     plt.subplots_adjust(top=0.85, bottom=0.2)
     if save_plot:
         plt.savefig(os.path.join(save_path, save_ts+'_'+save_name))
-    return fig, ax, frac_samp_glitches, interval_glitches
+    return fig, ax
+
+
     
     
     

--- a/sotodlib/hwp/hwp_utils.py
+++ b/sotodlib/hwp/hwp_utils.py
@@ -1,0 +1,46 @@
+import time
+import numpy as np
+import matplotlib.pyplot as plt
+from sotodlib import core, tod_ops
+
+def plot_hwpss_fit_status(tod, hwpss_stats, plot_dets=None, plot_num_dets=3,
+                         save_plot=False, save_path='./', save_name='hwpss_stats.png'):
+    fig, ax = plt.subplots(1, 2, figsize=(15, 5))
+    
+    if plot_dets is None:
+        plot_step = hwpss_stats.dets.count/(plot_num_dets)
+        plot_dets_idx = np.arange(0, hwpss_stats.dets.count, plot_step).astype(int)
+        plot_dets = hwpss_stats.dets.vals[plot_dets_idx]
+    else:
+        plot_dets_idx = np.where(np.in1d(hwpss_stats.dets.vals, plot_dets))[0]
+
+    for i, det_idx in enumerate(plot_dets_idx):
+        ax[0].plot(hwpss_stats.binned_angle, hwpss_stats.binned_signal[det_idx], 
+                alpha=0.8, color='tab:blue', label='binned signal' if i ==0 else None)
+
+        modes = [int(mode_name[1:]) for mode_name in list(hwpss_stats.modes.vals[::2])]
+        ax[0].plot(hwpss_stats.binned_angle, hwpss_stats.binned_model[det_idx], 
+                alpha=0.8, color='tab:orange', label=f'binned model \n(modes = {modes})' if i ==0 else None)
+
+    ax[0].legend()
+    ax[0].set_xlabel('HWP angle [rad]')
+    ax[0].set_title(f'random {plot_num_dets} detectors')
+
+    ax[1].hist(hwpss_stats.redchi2s, bins=np.logspace(start=-1, stop=2, num=50))
+    ax[1].axvline(x=np.nanmedian(hwpss_stats.redchi2s), linestyle='dashed', color='black',
+                 label=f'median: {np.nanmedian(hwpss_stats.redchi2s):.2f}')
+    ax[1].set_xscale('log')
+    ax[1].set_yscale('log')
+    ax[1].set_title(f'reduced chi2s distribution (Ndets={hwpss_stats.dets.count})')
+    ax[1].legend()
+
+    plt.suptitle(f'HWPSS Stats for Obs Timestamp: {tod.obs_info.timestamp:.0f}, dT = {np.ptp(tod.timestamps)/60:.1f} min', 
+                     fontsize = 15)
+    save_ts = str(int(time.time()))
+    plt.subplots_adjust(top=0.85, bottom=0.2)
+    if save_plot:
+        plt.savefig(os.path.join(save_path, save_ts+'_'+save_name))
+    return fig, ax, frac_samp_glitches, interval_glitches
+    
+    
+    

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -125,14 +125,20 @@ class PSDCalc(_Preprocess):
         )
         fft_aman.wrap("freqs", freqs, [(0,"fsamps")])
         fft_aman.wrap("Pxx", Pxx, [(0,"dets"),(1,"fsamps")])
-        aman.wrap("psd", fft_aman)
+        if "psd" not in aman:
+            aman.wrap("psd", fft_aman)
+        else:
+            aman.wrap(f"psd_{self.process_cfgs['signal']}", fft_aman)
 
     def calc_and_save(self, aman, proc_aman):
         self.save(proc_aman, aman.psd)
     
     def save(self, proc_aman, fft_aman):
         if self.save_cfgs:
-            proc_aman.wrap("psd", fft_aman)
+            if "psd" not in proc_aman:
+                proc_aman.wrap("psd", fft_aman)
+            else:
+                proc_aman.wrap("psd_after", fft_aman)
 
 class Noise(_Preprocess):
     """Estimate the white noise levels in the data. Assumes the PSD has been

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -138,7 +138,7 @@ class PSDCalc(_Preprocess):
             if "psd" not in proc_aman:
                 proc_aman.wrap("psd", fft_aman)
             else:
-                proc_aman.wrap("psd_after", fft_aman)
+                proc_aman.wrap(f"psd_{self.process_cfgs['signal']}", fft_aman)
 
 class Noise(_Preprocess):
     """Estimate the white noise levels in the data. Assumes the PSD has been

--- a/sotodlib/site_pipeline/preprocess_tod.py
+++ b/sotodlib/site_pipeline/preprocess_tod.py
@@ -6,7 +6,9 @@ import argparse
 from sotodlib import core
 import sotodlib.site_pipeline.util as sp_util
 from sotodlib.preprocess import _Preprocess, PIPELINE, processes
+import logging
 
+logger = logging.getLogger(__name__)
 
 def _build_pipe_from_configs(configs):
     pipe = []

--- a/sotodlib/tod_ops/fft_ops.py
+++ b/sotodlib/tod_ops/fft_ops.py
@@ -204,7 +204,8 @@ def calc_psd(
         
     Arguments:
         aman (AxisManager): with (dets, samps) OR (channels, samps)axes.
-        signal (float ndarray): data signal to pass to scipy.signal.welch()
+        signal (float ndarray or str): data signal to pass to scipy.signal.welch(). If
+            given by string, uses aman[signal] as signal.
         timestamps (float ndarray): timestamps associated with the data signal         
         max_samples (int): maximum samples along sample axis to send to welch
         prefer (str): One of ['left', 'right', 'center'], indicating what
@@ -220,6 +221,9 @@ def calc_psd(
     """
     if signal is None:
         signal = aman.signal
+    elif isinstance(signal, str):
+        signal = aman[signal]
+    
     if timestamps is None:
         timestamps = aman.timestamps
     


### PR DESCRIPTION
Towards the first light, I have minor-updated some functions which are mainly related to check whether the preprocessing is going well or not.

Main modifications are as follows.

1. PSD calculation update
2. plot PSD before/after preprocessing
3. plot HWPSS fittiing result

# 1. PSD calculation update
Current PSD calculation can be executed only once and can only manage aman.signal, which will be annoying when we want to compare before/after preprocessing.
I have modified the way that `signal` defaults in `tod_ops.fft_ops.calc_psd`  ([link](https://github.com/simonsobs/sotodlib/blob/9f72a6ec721e752f284f9b7417dca476d5c20bcc/sotodlib/tod_ops/fft_ops.py#L222-L225C30p))
From
```python
if signal is None:
        signal = aman.signal
```
To
```python
if signal is None:
    signal = aman.signal
elif isinstance(signal, str):
    signal = aman[signal]
```
And modifed `preprocess.PSDCalc` so that the psd result should be wrapped into aman and proc_aman as `psd_{self.process_cfgs['signal']}` ((link)[https://github.com/simonsobs/sotodlib/blob/9f72a6ec721e752f284f9b7417dca476d5c20bcc/sotodlib/preprocess/processes.py#L128-L131])


# 2. plot PSD before/after preprocessing
To compare the PSD easily, added `sotodlib.hwp.hwp_utils.plot_preprocess_PSDs` ((link)[https://github.com/simonsobs/sotodlib/blob/9f72a6ec721e752f284f9b7417dca476d5c20bcc/sotodlib/hwp/hwp_utils.py#L45])
The plot below is output of `sotodlib.hwp.hwp_utils.plot_preprocess_PSDs`.
![image](https://github.com/simonsobs/sotodlib/assets/59273369/94a10d2d-d8c0-409c-81d2-291824f9835a)

# 3. plot HWPSS fitting
To check the HWPSS fitting, added `sotodlib.hwp.hwp_utils.plot_hwpss_fit_status` ((link)[https://github.com/simonsobs/sotodlib/blob/9f72a6ec721e752f284f9b7417dca476d5c20bcc/sotodlib/hwp/hwp_utils.py#L6])
The plot below is output of `sotodlib.hwp.hwp_utils.plot_hwpss_fit_status`.

![image](https://github.com/simonsobs/sotodlib/assets/59273369/ca126b92-04a6-478f-a716-6cf78db7d26b)
