### PR TITLE
Changes to book loader

### DIFF
--- a/sotodlib/io/load.py
+++ b/sotodlib/io/load.py
@@ -31,7 +31,6 @@ from collections import OrderedDict
 
 from .. import core
 from .load_toast_h5 import load_toast_h5_obs
-from .load_book import load_obs_book
 
 
 # Interim, Oct. 2021.  Wait a year, remove this caution.
@@ -600,7 +599,6 @@ core.OBSLOADER_REGISTRY.update(
     {
         'pipe-s0001': load_observation,
         'toast3-hdf': load_toast_h5_obs,
-        'obs-book': load_obs_book,
         'default': load_observation,
     }
 )

--- a/sotodlib/io/load_book.py
+++ b/sotodlib/io/load_book.py
@@ -376,6 +376,7 @@ def _concat_filesets(results, ancil=None, timestamps=None,
     # Primary (and other stuff to group per-stream)
     aman.wrap('primary', core.AxisManager(aman.samps))
     aman.wrap('iir_params', core.AxisManager())
+    aman['iir_params'].wrap('per_stream', True)
     for r in results.values():
         # Primary.
         _prim = core.AxisManager(aman.samps)
@@ -387,7 +388,6 @@ def _concat_filesets(results, ancil=None, timestamps=None,
         for k, v in r['iir_params'].items():
             _iir.wrap(k, v)
         aman['iir_params'].wrap(r['stream_id'], _iir)
-        aman['iir_params'].wrap('per_stream', True)
 
     # det_info
     det_info = core.metadata.ResultSet(

--- a/sotodlib/io/load_book.py
+++ b/sotodlib/io/load_book.py
@@ -121,10 +121,10 @@ def load_obs_book(db, obs_id, dets=None, prefix=None, samples=None,
         # Load the ancil files, to get ancil stuff.
         _one_fileset = next(iter(file_map.values()))
         ancil_files = _get_ancil_files(_one_fileset)
-        ancil = _load_book_detset(ancil_files, prefix=prefix, load_ancil=True,
-                                  samples=samples, dets=[])
-        ancil = ancil['ancil']
-        timestamps = ancil['timestamps']
+        _res = _load_book_detset(ancil_files, prefix=prefix, load_ancil=True,
+                                 samples=samples, dets=[])
+        ancil = _res['ancil']
+        timestamps = _res['timestamps']
 
     return _concat_filesets(results, ancil, timestamps,
                             signal_buffer=signal_buffer)
@@ -179,11 +179,11 @@ def _load_book_detset(files, prefix='', load_ancil=True,
     ancil_acc = None
     times_acc = None
     if load_ancil:
-        times_acc = Accumulator1d(('samps'), samples=samples)
-        ancil_acc = AccumulatorTimesampleMap(('samps'), samples=samples)
-    primary_acc = AccumulatorNamed(('samps'), samples=samples)
+        times_acc = Accumulator1d(samples=samples)
+        ancil_acc = AccumulatorTimesampleMap(samples=samples)
+    primary_acc = AccumulatorNamed(samples=samples)
     bias_names = []
-    bias_acc = Accumulator2d(('samps'), samples=samples)
+    bias_acc = Accumulator2d(samples=samples)
     signal_acc = None
     these_dets = None
 
@@ -191,12 +191,12 @@ def _load_book_detset(files, prefix='', load_ancil=True,
         signal_acc = None
     elif signal_buffer is not None:
         signal_acc = Accumulator2d(
-            ('samps'), samples=samples,
+            samples=samples,
             insert_at=signal_buffer,
             keys_to_keep=dets)
     else:
         signal_acc = Accumulator2d(
-            ('samps'), samples=samples,
+            samples=samples,
             keys_to_keep=dets)
 
     for frame, frame_offset in _frames_iterator(files, prefix, samples):
@@ -372,9 +372,7 @@ def _get_ancil_files(non_ancil_files):
 
 
 class Accumulator:
-    def __init__(self, axes, shape=None, samples=None, preconsumed=None):
-        self.axes = axes
-        self.ndim = len(axes)
+    def __init__(self, shape=None, samples=None, preconsumed=None):
         if samples is None:
             samples = None, None
         samples = list(samples)

--- a/sotodlib/io/load_book.py
+++ b/sotodlib/io/load_book.py
@@ -693,3 +693,6 @@ def _frames_iterator(files, prefix, samples, smurf_proc=None):
             yield frame, offset
             offset += len(frame['ancil'].times)
             # Alternately, use frame['sample_range']
+
+
+core.OBSLOADER_REGISTRY['obs-book'] = load_obs_book

--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -2598,8 +2598,8 @@ def get_channel_info(
     Args
     -----
     status : SmurfStatus instance
-    mask : bool array
-        mask of which channels to use
+    mask : bool or int array
+        mask to select which channels to use (and possibly re-order them)
     archive : G3tSmurf instance (optionl)
         G3tSmurf instance for looking for tunes/tunesets
     obsfiledb : ObsfileDb instance (optional)

--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -2130,14 +2130,31 @@ class SmurfStatus:
             filenames = [filename]
         else:
             filenames = filename
-        status = {}
+        processor = cls._get_frame_processor()
         for file in filenames:
             reader = so3g.G3IndexedReader(file)
             while True:
                 frames = reader.Process(None)
                 if len(frames) == 0:
                     break
-                frame = frames[0]
+                if processor.process(frames[0]):
+                    break
+        return processor.get_status()
+
+    @classmethod
+    def _get_frame_processor(cls):
+        """Returns a processor that can receive frames and ultimately return a
+        SmurfStatus object.
+
+        User should pass each frame into the return object's "process"
+        method, then call get_status to return a SmurfStatus.  The
+        "process" function returns True if the frame is a
+        "dump_frame".
+
+        """
+        class _WiringFrameHandler(dict):
+            def process(self, frame):
+                status = self
                 if str(frame.type) == "Wiring":
                     status["stream_id"] = frame.get("sostream_id")
                     status["session_id"] = frame.get("session_id")
@@ -2149,9 +2166,12 @@ class SmurfStatus:
                     status.update(yaml.safe_load(frame["status"]))
                     if frame["dump"]:
                         status["dump_frame"] = True
-                        break
+                        return True
                     status["dump_frame"] = False
-        return cls(status)
+                return False
+            def get_status(self):
+                return cls(self)
+        return _WiringFrameHandler()
 
     @classmethod
     def from_time(cls, time, archive, stream_id=None, show_pb=False):


### PR DESCRIPTION
Book -> AxisManager loader module is substantially rewritten.

Now:
- `load_book_file()` can be used to load any .g3 file from an obs/oper book, without obsfiledb support.  In fact you can load (and concatenate) multiple files from any single detset.  The output is basically identical to what you'd get loading them through obsfiledb/Context.  This addresses #514 .
- The Book "ancil" data (i.e. position encoders) are loaded into the AxisManager.  In the present design, they are all simply copied into a sub-axisman called "ancil".  They are also copied, and scaled, into a sub-axisman called "boresight".  As the data are processed I am imagining that "ancil" will remain untouched but "boresight" might be updated (or recomputed) based on a pointing model. 
- Wiring frames are parsed, using SmurfStatus, and key info include in .det_info.smurf and .iir_params.<stream_id>.

Here's what loaded TOD looks like:
```
>>> tod
AxisManager(timestamps[samps], ancil*[samps], boresight*[samps], signal[dets,samps],
  biases[bias_lines,samps], primary*[samps], iir_params*, det_info*[dets], flags*[dets,samps],
  dets:LabelAxis(10336), samps:OffsetAxis(100000), bias_lines:LabelAxis(72))
>>> tod.det_info
AxisManager(detset[dets], stream_id[dets], smurf*[dets], dets:LabelAxis(10336))
>>> tod.det_info.smurf
AxisManager(band[dets], channel[dets], frequency[dets], rchannel[dets], dets:LabelAxis(10336))
>>> tod.iir_params
AxisManager(per_stream, ufm_mv22*, ufm_mv19*, ufm_mv6*, ufm_mv18*, ufm_mv14*, ufm_mv9*)
>>> tod.iir_params.ufm_mv6
AxisManager(enabled, b[16], a[16], fscale)
```