### PR TITLE
Put so3g into docs build requirements.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -98,10 +98,10 @@ autodoc_default_options = {
 # some external dependencies are not met at build time and break the
 # building process.
 autodoc_mock_imports = []
-for missing in ('numpy', 'matplotlib', 'healpy', 'astropy','sqlalchemy',
+for missing in ('matplotlib', 'healpy', 'sqlalchemy',
                 'quaternionarray', 'yaml', 'toml', 'sqlite3','tqdm',
                 'skyfield', 'h5py', 'pyfftw', 'scipy',
-                'toast', 'spt3g', 'so3g', 'pixell', 'scikit', 'skimage',
+                'toast', 'pixell', 'scikit', 'skimage',
                 'traitlets', 'ephem', 'influxdb', 'pycpd', 'detmap'):
     try:
         foo = import_module(missing)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,6 +5,7 @@ sphinx-argparse==0.3.1
 
 # Required because it is used at root level in some modules.
 numpy
+so3g
 
 # Required in order to support using Quantities for default function
 # argument values like:


### PR DESCRIPTION
This should fix the docs build.

The error is from so3g being mocked, so astropy.units can't handle it.