### PR TITLE
Split HK sources from Detector data sources

### DIFF
--- a/sotodlib/io/imprinter.py
+++ b/sotodlib/io/imprinter.py
@@ -604,9 +604,9 @@ class Imprinter:
             raise BookBoundError(f"Book {bid} is already bound")
         assert book.type in VALID_OBSTYPES
 
-        # find appropriate binder for the book type
-        binder = self._get_binder_for_book(book, output_root=output_root)
         try:
+            # find appropriate binder for the book type
+            binder = self._get_binder_for_book(book, output_root=output_root)
             binder.bind(pbar=pbar)
 
             # write M_book file

--- a/sotodlib/io/imprinter.py
+++ b/sotodlib/io/imprinter.py
@@ -468,7 +468,7 @@ class Imprinter:
         if book.type in ["obs", "oper"]:
             session_id = book.bid.split("_")[1]
             first5 = session_id[:5]
-            odir = op.join(output_root, book.type, first5)
+            odir = op.join(output_root, book.tel_tube, book.type, first5)
             if not op.exists(odir):
                 os.makedirs(odir)
             book_path = os.path.join(odir, book.bid)
@@ -494,7 +494,7 @@ class Imprinter:
             book_path_src = op.join(root, first5)
 
             # get target directory for hk book
-            odir = op.join(output_root, book.type)
+            odir = op.join(output_root, book.tel_tube, book.type)
             if not op.exists(odir):
                 os.makedirs(odir)
             book_path_tgt = os.path.join(odir, book.bid)
@@ -535,7 +535,7 @@ class Imprinter:
             book_path_src = op.join(root, first5)
 
             # get target directory for hk book
-            odir = op.join(output_root, book.type)
+            odir = op.join(output_root, book.tel_tube, book.type)
             if not op.exists(odir):
                 os.makedirs(odir)
             book_path_tgt = os.path.join(odir, book.bid)

--- a/sotodlib/io/imprinter.py
+++ b/sotodlib/io/imprinter.py
@@ -147,6 +147,10 @@ def loop_over_sources(method):
 class Imprinter:
     def __init__(self, im_config=None, db_args={}, logger=None):
         """Imprinter manages the book database.
+        
+        Imprinter at the site is set up to be one per level 2 daq node. Some pieces
+        of this code have worked with one imprinter for multiple daq nodes but this 
+        has not be end-to-end tested.
 
         Example configuration file::
         
@@ -169,13 +173,21 @@ class Imprinter:
             daq-node:
               g3tsmurf: g3tsmurf config file
 
-        The different tel-tubes will be bound into separate books containing 
-        only the stream_ids listed under slots. While the hk_sources take a 
-        g3tsmurf config key, that is just for symmetry, those files only need
-        to include a data_prefix and g3thk_db entry if only hk books are being 
-        created from that configuration. The g3tsmurf configurations are assumed
-        to be one per daq node, meaning this example could have the same config
-        file repeated several times.
+        The sources entry lists the different tel-tubes that will be bound into 
+        separate books containing only the stream_ids listed under slots. TODO: 
+        There is currently no option to have an empty slot. The tel-tube entries 
+        define the folder books are written to ex: output_root/tel-tube/obs/
+
+        The hk_sources entry determines if housekeeping books should be made, and 
+        where. While it take a g3tsmurf config key, that is just for symmetry with
+        sources. Those config files only need to include a data_prefix and g3thk_db 
+        entry if only hk books are being created from that configuration. The 
+        daq-node entry defines where the books are written to ex: output_root/daq-node/hk
+
+        The g3tsmurf configurations are assumed to be one per daq node, meaning 
+        this example could have the same config file repeated several times. The 
+        repetition is based on the idea that one imprinter could manage multiple 
+        daq-nodes, although that is not the current setup.
 
         Parameters
         ----------

--- a/sotodlib/io/imprinter.py
+++ b/sotodlib/io/imprinter.py
@@ -1095,7 +1095,8 @@ class Imprinter:
             {obs_id: [file_paths...]}
 
         """
-        session = self.get_g3tsmurf_session(book.tel_tube)
+        if book.type in ["obs", "oper", "stray"]:
+            session = self.get_g3tsmurf_session(book.tel_tube)
         if book.type in ["obs", "oper"]:
             obs_ids = [o.obs_id for o in book.obs]
             obs = (

--- a/sotodlib/io/imprinter.py
+++ b/sotodlib/io/imprinter.py
@@ -148,6 +148,35 @@ class Imprinter:
     def __init__(self, im_config=None, db_args={}, logger=None):
         """Imprinter manages the book database.
 
+        Example configuration file::
+        
+          db_path: imprinter.db
+          
+          sources:
+            tel-tube1:
+              g3tsmurf: g3tsmurf config file
+              slots:
+                - stream_id1
+                - stream_id2
+                - stream_id3
+            tel-tube2:
+              g3tsmurf: g3tsmurf config file
+              slots:
+                - stream_id4
+                - stream_id5
+          
+          hk_sources:
+            daq-node:
+              g3tsmurf: g3tsmurf config file
+
+        The different tel-tubes will be bound into separate books containing 
+        only the stream_ids listed under slots. While the hk_sources take a 
+        g3tsmurf config key, that is just for symmetry, those files only need
+        to include a data_prefix and g3thk_db entry if only hk books are being 
+        created from that configuration. The g3tsmurf configurations are assumed
+        to be one per daq node, meaning this example could have the same config
+        file repeated several times.
+
         Parameters
         ----------
         im_config: str
@@ -226,10 +255,10 @@ class Imprinter:
     def get_g3thk(self, source):
         """Get a G3tHk database using the g3tsmurf config file."""
         if source not in self.hk_archives:
-            if source in self.config["sources"]:
-                s_type = "sources"
-            elif source in self.config["hk_sources"]:
+            if source in self.config["hk_sources"]:
                 s_type = "hk_sources"
+            elif source in self.config["sources"]:
+                s_type = "sources"
             else:
                 raise ValueError(f"Cannot find {source} in configs")
             self.hk_archives[source] = G3tHk.from_configs(

--- a/sotodlib/site_pipeline/make_book.py
+++ b/sotodlib/site_pipeline/make_book.py
@@ -2,10 +2,10 @@ from typing import Optional
 import traceback
 import argparse
 
-from ..io.imprinter import Imprinter
+from sotodlib.io.imprinter import Imprinter
 
 
-def main(config: str, output_root: str, source: Optional[str], logger=None):
+def main(config: str, output_root: str, logger=None):
     """Make books based on imprinter db
     
     Parameters
@@ -14,17 +14,14 @@ def main(config: str, output_root: str, source: Optional[str], logger=None):
         path to imprinter configuration file
     output_root : str
         root path of the books 
-    source: str, optional
-        data source to use, e.g., sat1, latrt, tsat. If None, use all sources
     """
     imprinter = Imprinter(config, db_args={'connect_args': {'check_same_thread': False}})
     # get unbound books
     unbound_books = imprinter.get_unbound_books()
-    failed_books = imprinter.get_failed_books()
-    if source is not None:
-        unbound_books = [book for book in unbound_books if book.tel_tube == source]
-        failed_books = [book for book in failed_books if book.tel_tube == source]
-    print(f"Found {len(unbound_books)} unbound books and {len(failed_books)} failed books")
+    already_failed_books = imprinter.get_failed_books()
+    
+    print(f"Found {len(unbound_books)} unbound books and "
+          f"{len(already_failed_books)} failed books")
     for book in unbound_books:
         print(f"Binding book {book.bid}")
         try:
@@ -33,8 +30,12 @@ def main(config: str, output_root: str, source: Optional[str], logger=None):
             print(f"Error binding book {book.bid}: {e}")
             print(traceback.format_exc())
 
-    print("Retrying previously failed books") 
+    print("Retrying failed books") 
+    failed_books = imprinter.get_failed_books()
     for book in failed_books:
+        if book in already_failed_books:
+            print(f"Book {book.bid} has already failed twice, not re-trying")
+            continue
         print(f"Binding book {book.bid}")
         try:
             imprinter.bind_book(book, output_root=output_root)
@@ -50,7 +51,6 @@ def get_parser(parser=None):
         parser = argparse.ArgumentParser()
     parser.add_argument('config', type=str, help="Path to imprinter configuration file")
     parser.add_argument('output_root', type=str, help="Root path of the books")
-    parser.add_argument('--source', type=str, help="Data source to use, e.g., sat1, latrt, tsat. If None, use all sources")
     return parser
 
 


### PR DESCRIPTION
This update, matched with [site-pipeline-config changes here](https://github.com/simonsobs/site-pipeline-configs/pull/9) make the HK bookbinding separate from the detector book binding. This is necessary for the LAT data, which has the HK and detector data going to separate places and for the site hk data, which has no detectors. I've tested this on some of the site level 2 data and looks like it all works. 