### PR TITLE
Site updates to data packaging

### DIFF
--- a/sotodlib/io/bookbinder.py
+++ b/sotodlib/io/bookbinder.py
@@ -570,7 +570,8 @@ class BookBinder:
         Array of output file indices for all output frames in the book
     """
     def __init__(self, book, obsdb, filedb, data_root, readout_ids, outdir,
-                 max_samps_per_frame=50_000, max_file_size=1e9):
+                 max_samps_per_frame=50_000, max_file_size=1e9, 
+                ignore_tags=False):
         self.filedb = filedb
         self.book = book
         self.data_root = data_root
@@ -584,6 +585,7 @@ class BookBinder:
 
         self.max_samps_per_frame = max_samps_per_frame
         self.max_file_size = max_file_size
+        self.ignore_tags = ignore_tags
 
         if not os.path.exists(outdir):
             os.makedirs(outdir)
@@ -746,7 +748,10 @@ class BookBinder:
 
         # make sure all tags are the same for obs in the same book
         tags = list(set(tags))
-        assert len(tags) == 1
+        if not self.ignore_tags:
+            assert len(tags) == 1
+        else:
+            tags = [','.join(tags)]
         tags = tags[0].split(',')
         # book should have at least one tag
         assert len(tags) > 0

--- a/sotodlib/io/imprinter_utils.py
+++ b/sotodlib/io/imprinter_utils.py
@@ -1,0 +1,98 @@
+"""Functions for working with an imprinter instance. These are generally
+functions expected to be needed for humans making one-off changes to the
+imprinter setup. Functions run as part of the automated pipeline are defined in imprinter.py
+"""
+
+from sotodlib.io.imprinter import ( 
+    WONT_BIND,
+    FAILED,
+    UNBOUND,
+    BOUND,
+    UPLOADED,
+    DONE,    
+)
+
+from .load_smurf import (
+    TimeCodes,
+    SupRsyncType,
+)
+
+def set_book_wont_bind(imprint, book, message=None, session=None):
+    """Change book status to WONT_BIND, meaning the files indicated into 
+    this book will not be bound. .g3 files here will go into stray books.
+
+    This function should not be integrated into automated data packaging.
+
+    This book status is necessary because without it the automated data 
+    packaging could continue to try and register and fail on the same book. 
+
+    Parameters
+    -----------
+    imprint: Imprinter instance
+    book: str or Book 
+    message: str or None
+        if not none, update book message to explain why the setting is changing
+    session: BookDB session.
+    
+    """
+    if session is None:
+        session = imprint.get_session()
+
+    if isinstance(book, str):
+        book = imprint.get_book(book)
+
+    if book.status != FAILED:
+        imprint.logger.warning(
+            f"Book {book} has not failed before being set not to WONT_BIND"
+        )
+    book.status = WONT_BIND 
+    if message is not None:
+        book.message = message
+    session.commit()
+
+def set_timecode_final(imprint, time_code):
+    """Add required entires to the g3tsmurf database in order to force the smurf
+    and/or stray books to be created. Will be used if there are errors in
+    suprsync data transfer.
+    
+    Parameters
+    -----------
+    imprint: Imprinter instance
+    time_code: 5-digit ctime code to finalize
+    """
+
+    g3session = imprint.get_g3tsmurf_session()
+
+    streams = []
+    for tube in imprint.tubes:
+        streams.extend( imprint.tubes[tube].get("slots") )
+    
+    for stream in streams:
+        tcf = g3session.query(TimeCodes).filter(
+            TimeCodes.timecode==time_code,
+            TimeCodes.stream_id == stream,
+            TimeCodes.suprsync_type == SupRsyncType.FILES.value,
+        ).one_or_none()
+        if tcf is None:
+            tcf = TimeCodes(
+                stream_id=stream,
+                suprsync_type=SupRsyncType.FILES.value,
+                timecode=time_code,
+                agent="fake",
+            )
+        g3session.add(tcf)
+
+        tcm = g3session.query(TimeCodes).filter(
+            TimeCodes.timecode==time_code,
+            TimeCodes.stream_id == stream,
+            TimeCodes.suprsync_type == SupRsyncType.META.value,
+        ).one_or_none()
+        if tcm is None:
+            tcm = TimeCodes(
+                stream_id=stream,
+                suprsync_type=SupRsyncType.META.value,
+                timecode=time_code,
+                agent="fake",
+            )
+        g3session.add(tcm)    
+    g3session.commit()

--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -1306,8 +1306,9 @@ class G3tSmurf:
                     session.query(TimeCodes)
                     .filter(
                         TimeCodes.stream_id == subdir,
-                        TimeCodes.suprsync_type
-                        == SupRsyncType.from_string(info["archive_name"]).value,
+                        TimeCodes.suprsync_type == SupRsyncType.from_string(
+                            info["archive_name"]
+                        ).value,
                         TimeCodes.timecode == info["timecode"],
                     )
                     .one_or_none()

--- a/sotodlib/site_pipeline/make_book.py
+++ b/sotodlib/site_pipeline/make_book.py
@@ -5,15 +5,13 @@ import argparse
 from sotodlib.io.imprinter import Imprinter
 
 
-def main(config: str, output_root: str, logger=None):
+def main(config: str, logger=None):
     """Make books based on imprinter db
     
     Parameters
     ----------
     im_config : str
         path to imprinter configuration file
-    output_root : str
-        root path of the books 
     """
     imprinter = Imprinter(config, db_args={'connect_args': {'check_same_thread': False}})
     # get unbound books
@@ -25,7 +23,7 @@ def main(config: str, output_root: str, logger=None):
     for book in unbound_books:
         print(f"Binding book {book.bid}")
         try:
-            imprinter.bind_book(book, output_root=output_root)
+            imprinter.bind_book(book)
         except Exception as e:
             print(f"Error binding book {book.bid}: {e}")
             print(traceback.format_exc())
@@ -38,7 +36,7 @@ def main(config: str, output_root: str, logger=None):
             continue
         print(f"Binding book {book.bid}")
         try:
-            imprinter.bind_book(book, output_root=output_root)
+            imprinter.bind_book(book)
         except Exception as e:
             print(f"Error binding book {book.bid}: {e}")
             print(traceback.format_exc())

--- a/sotodlib/site_pipeline/monitor.py
+++ b/sotodlib/site_pipeline/monitor.py
@@ -55,6 +55,7 @@ class Monitor:
         return cls(
             host = configs["host"],
             port = configs["port"],
+            database = configs["database"],
             username = configs["username"],
             password = configs["password"],
             path = configs["path"],

--- a/sotodlib/site_pipeline/update_book_plan.py
+++ b/sotodlib/site_pipeline/update_book_plan.py
@@ -38,9 +38,12 @@ def main(
     """
     if stream_ids is not None:
         stream_ids = stream_ids.split(",")
-    imprinter = Imprinter(config, db_args={'connect_args': {'check_same_thread': False}})
-    # leaving min_ctime and max_ctime as None will go through all available data,
-    # so preferreably set them to a reasonable range based on update_delay
+    imprinter = Imprinter(
+        config, db_args={'connect_args': {'check_same_thread': False}}
+    )
+    
+    # leaving min_ctime and max_ctime as None will go through all available 
+    # data, so preferreably set them to a reasonable range based on update_delay
     if not from_scratch and min_ctime is None:
         min_ctime = dt.datetime.now() - dt.timedelta(days=update_delay)
     if isinstance(min_ctime, dt.datetime):
@@ -48,14 +51,16 @@ def main(
     if isinstance(max_ctime, dt.datetime):
         max_ctime = max_ctime.timestamp()
     # obs and oper books
-    imprinter.update_bookdb_from_g3tsmurf(min_ctime=min_ctime, max_ctime=max_ctime,
-                                          ignore_singles=False,
-                                          stream_ids=stream_ids,
-                                          force_single_stream=force_single_stream)
+    imprinter.update_bookdb_from_g3tsmurf(
+        min_ctime=min_ctime, max_ctime=max_ctime,
+        ignore_singles=False,
+        stream_ids=stream_ids,
+        force_single_stream=force_single_stream
+    )
     # hk books
-    imprinter.register_hk_books()
+    imprinter.register_hk_books(min_ctime=min_ctime, max_ctime=max_ctime)
     # smurf and stray books
-    imprinter.register_timecode_books()
+    imprinter.register_timecode_books(min_ctime=min_ctime, max_ctime=max_ctime)
 
 def get_parser(parser=None):
     if parser is None:

--- a/sotodlib/site_pipeline/update_book_plan.py
+++ b/sotodlib/site_pipeline/update_book_plan.py
@@ -41,7 +41,7 @@ def main(
     imprinter = Imprinter(config, db_args={'connect_args': {'check_same_thread': False}})
     # leaving min_ctime and max_ctime as None will go through all available data,
     # so preferreably set them to a reasonable range based on update_delay
-    if not from_scratch:
+    if not from_scratch and min_ctime is None:
         min_ctime = dt.datetime.now() - dt.timedelta(days=update_delay)
     if isinstance(min_ctime, dt.datetime):
         min_ctime = min_ctime.timestamp()

--- a/sotodlib/site_pipeline/update_g3tsmurf_db.py
+++ b/sotodlib/site_pipeline/update_g3tsmurf_db.py
@@ -67,9 +67,12 @@ def main(config: Optional[str] = None, update_delay: float = 2,
         logger.info("Will send monitor information to Influx")
         try:
             monitor = Monitor.from_configs(cfgs["monitor"]["connect_configs"])
+            to_record = cfgs["monitor"].get("record", [])
         except Exception as e:
             logger.error(f"Monitor connectioned failed {e}")
             monitor = None
+            to_record = []
+
     updates_start = dt.datetime.now().timestamp()
 
     SMURF.index_metadata(min_ctime=min_time.timestamp())
@@ -95,15 +98,17 @@ def main(config: Optional[str] = None, update_delay: float = 2,
         if monitor is not None:
             if obs.stop is not None:
                 try:
-                    record_timing(monitor, obs, cfgs)
-                    record_tuning(monitor, obs, cfgs)
+                    if "timing_on" in to_record:
+                        record_timing(monitor, obs, cfgs)
+                    if "has_tuneset" in to_record:
+                        record_tuning(monitor, obs, cfgs)
                 except Exception as e:
                     logger.error(f"Monitor Update failed for {obs.obs_id} with {e}")
 
 def _obs_tags(obs, cfgs):
     
     tags = [{
-        "tel_tube" : cfgs["monitor"]["tel_tube"], 
+        "telescope" : cfgs["monitor"]["telescope"], 
         "stream_id" : obs.stream_id
     }]
 
@@ -116,13 +121,13 @@ def record_tuning(monitor, obs, cfgs):
     Will be used to alter if the database readout_ids are not working.
     """
     tags, log_tags = _obs_tags(obs, cfgs)
-    if not monitor.check("timing_on", obs.obs_id, tags=tags[0]):
+    if not monitor.check("has_tuneset", obs.obs_id, tags=tags[0]):
         monitor.record(
             "has_tuneset", 
             [ len(obs.tunesets)==1 ], 
             [obs.timestamp], 
             tags, 
-            "data_pkg", 
+            cfgs["monitor"]["measurement"], 
             log_tags=log_tags
         )
         monitor.write()
@@ -139,7 +144,7 @@ def record_timing(monitor, obs, cfgs):
             [obs.timing], 
             [obs.timestamp], 
             tags, 
-            "data_pkg", 
+            cfgs["monitor"]["measurement"], 
             log_tags=log_tags
         )
         monitor.write()


### PR DESCRIPTION
A bunch of changes to deal with some hanging issues with stray / smurf books. Biggest issue was that smurf and stray books needed to be made per daq node and, given the structure of imprinter, it was much easier to just add the requirement that we have one imprinter instance / database per daq node (that's how things are set up at the site but pieces of the code were more flexible than that).  

* Closes the two linked issues. 
* prevents stray books from being made if there are books throwing errors that we might want in stray books later. 
* adds a `WONT_BIND` status option that we can set by hand. If books have that status than their .g3 files will get added into the stray books
* stream ids that aren't part of the telescope tubes go into stray books
* add some utility functions that we might need to use for database maintenance
* add min/max ctimes to searches for registering hk / smurf / stray books
* add output root as a field in the imprinter config file because it doesn't make since to track book status's if we don't know where all the books are sent. 

site configs updates to go with it: https://github.com/simonsobs/site-pipeline-configs/pull/11 