### PR TITLE
Bilinear mapmaking

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,7 +71,7 @@ master_doc = 'index'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/sotodlib/coords/pmat.py
+++ b/sotodlib/coords/pmat.py
@@ -85,6 +85,8 @@ class P:
     - det_weights (optional): weights (one per detector) to apply to
       time-ordered data when binning a map (and also when binning a
       weights matrix).  [dets]
+    - interpol (optional): How to interpolate the values for samples
+      between pixel centers. Forwarded to Projectionist.
 
     These things can be updated freely, with the following caveats:
 
@@ -111,7 +113,7 @@ class P:
 
     """
     def __init__(self, sight=None, fp=None, geom=None, comps='T',
-                 cuts=None, threads=None, det_weights=None, interpol="nearest"):
+                 cuts=None, threads=None, det_weights=None, interpol=None):
         self.sight = sight
         self.fp = fp
         self.geom = wrap_geom(geom)
@@ -127,7 +129,7 @@ class P:
                 rot=None, cuts=None, threads=None, det_weights=None,
                 timestamps=None, focal_plane=None, boresight=None,
                 boresight_equ=None, wcs_kernel=None, weather='typical',
-                site='so', interpol="nearest"):
+                site='so', interpol=None):
         """Set up a Projection Matrix for a TOD.  This will ultimately call
         the main P constructor, but some missing arguments will be
         extracted from tod and computed along the way.

--- a/sotodlib/coords/pmat.py
+++ b/sotodlib/coords/pmat.py
@@ -111,7 +111,7 @@ class P:
 
     """
     def __init__(self, sight=None, fp=None, geom=None, comps='T',
-                 cuts=None, threads=None, det_weights=None):
+                 cuts=None, threads=None, det_weights=None, interpol="nearest"):
         self.sight = sight
         self.fp = fp
         self.geom = wrap_geom(geom)
@@ -120,12 +120,14 @@ class P:
         self.threads = threads
         self.active_tiles = None
         self.det_weights = det_weights
+        self.interpol = interpol
 
     @classmethod
     def for_tod(cls, tod, sight=None, fp=None, geom=None, comps='T',
                 rot=None, cuts=None, threads=None, det_weights=None,
                 timestamps=None, focal_plane=None, boresight=None,
-                boresight_equ=None, wcs_kernel=None, weather='typical', site='so'):
+                boresight_equ=None, wcs_kernel=None, weather='typical',
+                site='so', interpol="nearest"):
         """Set up a Projection Matrix for a TOD.  This will ultimately call
         the main P constructor, but some missing arguments will be
         extracted from tod and computed along the way.
@@ -175,7 +177,8 @@ class P:
             geom = helpers.get_footprint(tod, wcs_kernel, sight=sight)
 
         return cls(sight=sight, fp=fp, geom=geom, comps=comps,
-                   cuts=cuts, threads=threads, det_weights=det_weights)
+                   cuts=cuts, threads=threads, det_weights=det_weights,
+                   interpol=interpol)
 
     @classmethod
     def for_geom(cls, tod, geom, comps='TQU', timestamps=None,
@@ -401,9 +404,10 @@ class P:
         if self.tiled:
             return so3g.proj.Projectionist.for_tiled(
                 self.geom.shape, self.geom.wcs, self.geom.tile_shape,
-                active_tiles=self.active_tiles)
+                active_tiles=self.active_tiles, interpol=self.interpol)
         else:
-            return so3g.proj.Projectionist.for_geom(self.geom.shape, self.geom.wcs)
+            return so3g.proj.Projectionist.for_geom(self.geom.shape,
+                self.geom.wcs, interpol=self.interpol)
 
     def _get_proj_threads(self, cuts=None):
         """Return the Projectionist and sample-thread assignment for the

--- a/sotodlib/mapmaking.py
+++ b/sotodlib/mapmaking.py
@@ -53,12 +53,13 @@ class MLMapmaker:
         self.dof          = MultiZipper()
         self.ready        = False
 
-    def add_obs(self, id, obs, noise_model=None):
+    def add_obs(self, id, obs, deslope=True, noise_model=None):
         # Prepare our tod
         ctime  = obs.timestamps
         srate  = (len(ctime)-1)/(ctime[-1]-ctime[0])
         tod    = obs.signal.astype(self.dtype, copy=False)
-        utils.deslope(tod, w=1, inplace=True)
+        if deslope:
+            utils.deslope(tod, w=deslope_order, inplace=True)
         # Allow the user to override the noise model on a per-obs level
         if noise_model is None: noise_model = self.noise_model
         # Build the noise model from the obs unless a fully

--- a/sotodlib/mapmaking.py
+++ b/sotodlib/mapmaking.py
@@ -170,10 +170,11 @@ class SignalMap(Signal):
     """Signal describing a non-distributed sky map."""
     def __init__(self, shape, wcs, comm, comps="TQU", name="sky", ofmt="{name}", output=True,
             ext="fits", dtype=np.float32, sys=None, recenter=None, tile_shape=(500,500), tiled=False,
-            interpol="nearest"):
+            interpol=None):
         """Signal describing a sky map in the coordinate system given by "sys", which defaults
         to equatorial coordinates. If tiled==True, then this will be a distributed map with
-        the given tile_shape, otherwise it will be a plain enmap."""
+        the given tile_shape, otherwise it will be a plain enmap. interpol controls the
+        pointing matrix interpolation mode. See so3g's Projectionist docstring for details."""
         Signal.__init__(self, name, ofmt, output, ext)
         self.comm  = comm
         self.comps = comps
@@ -464,7 +465,7 @@ class PmatCut:
         junk = np.empty(self.njunk, tod.dtype)
         so3g.process_cuts(self.cuts.ranges, "clear", self.model, self.params, tod, junk)
 
-def inject_map(obs, map, recenter=None, interpol="nearest"):
+def inject_map(obs, map, recenter=None, interpol=None):
     # Infer the stokes components
     map = map.preflat
     if map.shape[0] not in [1,2,3]:

--- a/sotodlib/mapmaking.py
+++ b/sotodlib/mapmaking.py
@@ -504,7 +504,7 @@ class Nmat:
     def __init__(self):
         """Initialize the noise model. In subclasses this will typically set up parameters, but not
         build the details that depend on the actual time-ordered data"""
-        self.ivar  = 1.0
+        self.ivar  = np.ones(1, dtype=np.float32)
         self.ready = True
     def build(self, tod, **kwargs):
         """Measure the noise properties of the given time-ordered data tod[ndet,nsamp], and

--- a/sotodlib/mapmaking.py
+++ b/sotodlib/mapmaking.py
@@ -169,7 +169,8 @@ class Signal:
 class SignalMap(Signal):
     """Signal describing a non-distributed sky map."""
     def __init__(self, shape, wcs, comm, comps="TQU", name="sky", ofmt="{name}", output=True,
-            ext="fits", dtype=np.float32, sys=None, recenter=None, tile_shape=(500,500), tiled=False):
+            ext="fits", dtype=np.float32, sys=None, recenter=None, tile_shape=(500,500), tiled=False,
+            interpol="nearest"):
         """Signal describing a sky map in the coordinate system given by "sys", which defaults
         to equatorial coordinates. If tiled==True, then this will be a distributed map with
         the given tile_shape, otherwise it will be a plain enmap."""
@@ -180,6 +181,7 @@ class SignalMap(Signal):
         self.recenter = recenter
         self.dtype = dtype
         self.tiled = tiled
+        self.interpol = interpol
         self.data  = {}
         ncomp      = len(comps)
         shape      = tuple(shape[-2:])
@@ -209,7 +211,8 @@ class SignalMap(Signal):
                     ctime=ctime[len(ctime)//2], geom=(self.rhs.shape, self.rhs.wcs), site=unarr(obs.site)))
             else: rot = None
             pmap = coords.pmat.P.for_tod(obs, comps=self.comps, geom=self.rhs.geometry,
-                rot=rot, threads="domdir", weather=unarr(obs.weather), site=unarr(obs.site))
+                rot=rot, threads="domdir", weather=unarr(obs.weather), site=unarr(obs.site),
+                interpol=self.interpol)
         # Build the RHS for this observation
         pcut.clear(Nd)
         obs_rhs = pmap.zeros()
@@ -461,7 +464,7 @@ class PmatCut:
         junk = np.empty(self.njunk, tod.dtype)
         so3g.process_cuts(self.cuts.ranges, "clear", self.model, self.params, tod, junk)
 
-def inject_map(obs, map, recenter=None):
+def inject_map(obs, map, recenter=None, interpol="nearest"):
     # Infer the stokes components
     map = map.preflat
     if map.shape[0] not in [1,2,3]:
@@ -473,7 +476,7 @@ def inject_map(obs, map, recenter=None):
         rot    = recentering_to_quat_lonlat(*evaluate_recentering(recenter, ctime=ctime[len(ctime)//2], geom=(map.shape, map.wcs), site=unarr(obs.site)))
     else: rot = None
     # Set up our pointing matrix for the map
-    pmat  = coords.pmat.P.for_tod(obs, comps=comps, geom=(map.shape, map.wcs), rot=rot, threads="domdir")
+    pmat  = coords.pmat.P.for_tod(obs, comps=comps, geom=(map.shape, map.wcs), rot=rot, threads="domdir", interpol=self.interpol)
     # And perform the actual injection
     pmat.from_map(map.extract(shape, wcs), dest=obs.signal)
 

--- a/sotodlib/toast/instrument.py
+++ b/sotodlib/toast/instrument.py
@@ -16,6 +16,7 @@ from toast.utils import Logger, name_UID
 from ..core.hardware import Hardware, build_readout_id, parse_readout_id
 from ..sim_hardware import sim_nominal
 from .sim_focalplane import sim_telescope_detectors
+from so3g.proj.coords import SITES
 
 
 FOCALPLANE_RADII = {
@@ -85,9 +86,9 @@ class SOSite(GroundSite):
     def __init__(
         self,
         name="ATACAMA",
-        lat=-22.958064 * u.degree,
-        lon=-67.786222 * u.degree,
-        alt=5200 * u.meter,
+        lat=SITES["so"].lat * u.degree,
+        lon=SITES["so"].lon * u.degree,
+        alt=SITES["so"].elev * u.meter,
         **kwargs,
     ):
         super().__init__(

--- a/sotodlib/toast/ops/mlmapmaker.py
+++ b/sotodlib/toast/ops/mlmapmaker.py
@@ -364,7 +364,7 @@ class MLMapmaker(Operator):
             # gamma = np.pi / 2 - gamma # good Q, lots of U
             # gamma = gamma - np.pi / 2 # inverted Q, little bit of U
             # gamma = -gamma #            inverted Q, lots of U
-            gamma = 1.5 * np.pi - gamma
+            # gamma = 1.5 * np.pi - gamma
             # for d in range(len(det_quat)):
             #     print(f"{d:03d}: {det_quat[d]}")
             #     print(f"  theta = {det_theta[d]}")

--- a/sotodlib/toast/ops/mlmapmaker.py
+++ b/sotodlib/toast/ops/mlmapmaker.py
@@ -356,28 +356,7 @@ class MLMapmaker(Operator):
             # Convert the focalplane offsets into the expected form
             det_to_row = {y["name"]: x for x, y in enumerate(fp.detector_data)}
             det_quat = np.array([fp.detector_data["quat"][det_to_row[x]] for x in dets])
-            """
-            det_theta, det_phi, det_pa = toast.qarray.to_iso_angles(det_quat)
-
-            radius = np.sin(det_theta)
-            xi  = radius * np.sin(det_phi)
-            eta = radius * np.cos(det_phi)
-            gamma = np.pi/2 - det_pa
-            """
             xi, eta, gamma = quat_to_xieta(det_quat)
-            # gamma = gamma #             good Q, little bit of U
-            # gamma = np.pi / 2 - gamma # good Q, lots of U
-            # gamma = gamma - np.pi / 2 # inverted Q, little bit of U
-            # gamma = -gamma #            inverted Q, lots of U
-            # gamma = 1.5 * np.pi - gamma
-            # for d in range(len(det_quat)):
-            #     print(f"{d:03d}: {det_quat[d]}")
-            #     print(f"  theta = {det_theta[d]}")
-            #     print(f"  phi   = {det_phi[d]}")
-            #     print(f"  pa    = {det_pa[d]}")
-            #     print(f"  xi    = {xi[d]}")
-            #     print(f"  eta   = {eta[d]}")
-            #     print(f"  gamma = {gamma[d]}")
 
             axfp = AxisManager()
             axfp.wrap("xi", xi, axis_map=[(0, axdets)])
@@ -391,7 +370,7 @@ class MLMapmaker(Operator):
             # Azimuth is measured in the opposite direction from longitude
             az = 2 * np.pi - phi
             el = np.pi / 2 - theta
-            roll = pa  # FIXME: double check this...
+            roll = pa
 
             axbore = AxisManager()
             axbore.wrap("az", az, axis_map=[(0, axsamps)])

--- a/sotodlib/toast/ops/mlmapmaker.py
+++ b/sotodlib/toast/ops/mlmapmaker.py
@@ -21,6 +21,7 @@ from toast.utils import Logger, Environment, rate_from_times
 from toast.timing import function_timer, Timer
 from toast.observation import default_values as defaults
 from toast.fft import FFTPlanReal1DStore
+from toast.instrument_coords import xieta_to_quat, quat_to_xieta
 
 import so3g
 
@@ -350,12 +351,20 @@ class MLMapmaker(Operator):
             # Convert the focalplane offsets into the expected form
             det_to_row = {y["name"]: x for x, y in enumerate(fp.detector_data)}
             det_quat = np.array([fp.detector_data["quat"][det_to_row[x]] for x in dets])
+            """
             det_theta, det_phi, det_pa = toast.qarray.to_iso_angles(det_quat)
 
             radius = np.sin(det_theta)
             xi  = radius * np.sin(det_phi)
             eta = radius * np.cos(det_phi)
             gamma = np.pi/2 - det_pa
+            """
+            xi, eta, gamma = quat_to_xieta(det_quat)
+            # gamma = gamma #             good Q, little bit of U
+            # gamma = np.pi / 2 - gamma # good Q, lots of U
+            # gamma = gamma - np.pi / 2 # inverted Q, little bit of U
+            # gamma = -gamma #            inverted Q, lots of U
+            gamma = 1.5 * np.pi - gamma
             # for d in range(len(det_quat)):
             #     print(f"{d:03d}: {det_quat[d]}")
             #     print(f"  theta = {det_theta[d]}")

--- a/sotodlib/toast/ops/mlmapmaker.py
+++ b/sotodlib/toast/ops/mlmapmaker.py
@@ -244,7 +244,7 @@ class MLMapmaker(Operator):
     @traitlets.validate("nmat_type")
     def _check_nmat_type(self, proposal):
         check = proposal["value"]
-        allowed = ["NmatUncorr", "NmatDetvecs"]
+        allowed = ["NmatUncorr", "NmatDetvecs", "Nmat"]
         if check not in allowed:
             msg = f"nmat_type must be one of {allowed}, not {check}"
             raise traitlets.TraitError(msg)

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -293,8 +293,14 @@ def simulation_test_data(
         elnod_start=el_nod,
         elnods=el_nods,
         scan_accel_az=3 * u.degree / u.second ** 2,
+        use_ephem=False,
+        use_qpoint=True,
     )
     sim_ground.apply(data)
+
+    # corotator = so_ops.CoRotator(name="corotate_lat")
+    # corotator.apply(data)
+
     return data
 
 

--- a/tests/test_mapmaker_pointing.py
+++ b/tests/test_mapmaker_pointing.py
@@ -1,0 +1,196 @@
+# Copyright (c) 2023 Simons Observatory.
+# Full license can be found in the top level "LICENSE" file.
+
+"""Check that pointing expanded with TOAST is compatible with the MLMapmaker
+
+"""
+
+import os
+import tempfile
+import unittest
+
+import astropy.units as u
+import numpy as np
+from pixell import utils, enmap, curvedsky
+
+try:
+    # Import sotodlib toast module first, which sets global toast defaults
+    import sotodlib.toast as sotoast
+    import sotodlib.toast.ops as so_ops
+    import toast
+    from toast.observation import default_values as defaults
+    toast_available = True
+except ImportError as e:
+    toast_available = False
+
+if toast_available:
+    import healpy as hp
+
+from ._helpers import calibration_schedule, close_data_and_comm, simulation_test_data
+
+
+class MapmakerPointingTest(unittest.TestCase):
+    def test_mapmaker_pointing(self):
+        if not toast_available:
+            print("toast cannot be imported- skipping unit tests", flush=True)
+            return
+
+        log = toast.utils.Logger.get()
+
+        nnz = 3
+        nside = 1024
+        wpix = hp.nside2pixarea(nside, degrees=True)**.5 * 60
+        npix = 12 * nside**2
+        # testdir = tempfile.TemporaryDirectory()
+        class TestDir:
+            name = "testdata"
+        testdir = TestDir()
+
+        comm, procs, rank = toast.get_world()
+        data = simulation_test_data(
+            comm,
+            telescope_name=None,
+            wafer_slot="w00",
+            bands="LAT_f230",
+            sample_rate=10.0 * u.Hz,
+            thin_fp=16,
+            cal_schedule=False,
+        )
+
+        pointing = toast.ops.PointingDetectorSimple(
+            name="det_pointing_radec",
+            quats="quats_radec",
+            boresight=defaults.boresight_radec,
+            shared_flag_mask=0,
+        )
+        pixels = toast.ops.PixelsHealpix(
+            nside=nside,
+            create_dist="pixel_dist",
+            detector_pointing=pointing,
+        )
+        weights = toast.ops.StokesWeights(
+            name="weights_radec",
+            weights="weights_radec",
+            mode="IQU",
+            detector_pointing=pointing,
+        )
+
+        input_map_file = os.path.join(
+            testdir.name,
+            "pointing_test_map.fits",
+        )
+        if rank == 0:
+            input_map = np.zeros([nnz, npix], dtype=np.float32)
+            input_map[1] = 1
+            hp.write_map(
+                input_map_file, input_map, nest=pixels.nest, column_units="K"
+            )
+        log.info_rank(f"Wrote test map to {input_map_file}", comm=comm)
+
+        if data.comm.comm_world is not None:
+            data.comm.comm_world.Barrier()
+
+        # Scan map into timestreams
+        scan_hpix = toast.ops.ScanHealpixMap(
+            file=input_map_file,
+            det_data=defaults.det_data,
+            pixel_pointing=pixels,
+            stokes_weights=weights,
+        )
+        scan_hpix.apply(data)
+        
+        # Bin the map using TOAST
+        toast.ops.DefaultNoiseModel(noise_model="noise_model").apply(data)
+        binner = toast.ops.BinMap(
+            pixel_dist="pixel_dist",
+            pixel_pointing=pixels,
+            stokes_weights=weights,
+            noise_model="noise_model",
+            shared_flag_mask=0,
+        )
+        toast.ops.MapMaker(
+            name="mapmaker",
+            det_data=defaults.det_data,
+            binning=binner,
+            write_hits=True,
+            write_binmap=True,
+            write_rcond=False,
+            write_invcov=False,
+            write_cov=False,
+            write_map=False,
+            output_dir=testdir.name,
+        ).apply(data)
+        file_hits_toast = os.path.join(testdir.name, "mapmaker_hits.fits")
+        file_map_toast = os.path.join(testdir.name, "mapmaker_binmap.fits")
+
+        # Create an area file
+        areafile = os.path.join(testdir.name, "area_file.fits")
+        box = utils.parse_box("-51:-35,35:49") * utils.degree
+        res = wpix * utils.arcmin
+        shape, wcs = enmap.geometry(box, res=res, proj="car")
+        wcs.wcs.crpix[1] -= 0.5
+        enmap.write_map(areafile, enmap.zeros(shape, wcs, np.uint8))
+
+        mapmaker = so_ops.MLMapmaker(
+            area=areafile,
+            name="mlmapmaker",
+            out_dir=testdir.name,
+            comps="TQU",
+            nmat_type="Nmat",
+            maxiter=3,
+            truncate_tod=True,
+            write_hits=True,
+            write_rhs=False,
+            write_div=False,
+            write_bin=True,
+            deslope=False,
+        )
+        mapmaker.apply(data)
+
+        if rank == 0:
+            file_hits = os.path.join(testdir.name, "mlmapmaker_sky_hits.fits")
+            file_map = os.path.join(testdir.name, "mlmapmaker_sky_map.fits")
+            hits = enmap.read_map(file_hits).astype(int)
+            sky = enmap.read_map(file_map)
+            good = hits != 0
+            limit = np.percentile(hits[good], 0.85)
+            ind = hits > limit
+
+            toast_hits = hp.read_map(file_hits_toast)
+            toast_sky = hp.read_map(file_map_toast, None)
+            toast_good = toast_hits != 0
+            toast_limit = np.percentile(toast_hits[toast_good], 0.85)
+            toast_ind = toast_hits > toast_limit
+
+            rms = []
+            means = []
+            toast_rms = []
+            toast_means = []
+            log.info(f"            {'MLMapmaker':16}            {'TOAST':16}")
+            log.info(f"Hits        {np.sum(hits):8}       {np.sum(toast_hits):8}")
+            log.info(f"Hit pixels  {np.sum(good):8}       {np.sum(toast_good):8}")
+            log.info(f"After cut   {np.sum(ind):8}       {np.sum(toast_ind):8}")
+            for i in range(3):
+                rms.append(np.std(sky[i][ind].ravel()))
+                means.append(np.mean(sky[i][ind].ravel()))
+                toast_rms.append(np.std(toast_sky[i][toast_ind].ravel()))
+                toast_means.append(np.mean(toast_sky[i][toast_ind].ravel()))
+                log.info(
+                    f"{i:3} {means[i]:12.6f} +- {rms[i]:12.6f}, "
+                    f"{toast_means[i]:12.6f} +- {toast_rms[i]:12.6f}"
+                )
+
+            tol = 1e-3
+            if np.abs(means[0]) > tol:
+                raise RuntimeError("Found non-zero I")
+
+            if np.abs(means[1] - 1) > tol:
+                raise RuntimeError("Found non-unit Q")
+
+            if np.abs(means[2]) > tol:
+                raise RuntimeError("Found non-zero U")
+
+        close_data_and_comm(data)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_mapmaker_pointing.py
+++ b/tests/test_mapmaker_pointing.py
@@ -42,9 +42,6 @@ class MapmakerPointingTest(unittest.TestCase):
         wpix = hp.nside2pixarea(nside, degrees=True)**.5 * 60
         npix = 12 * nside**2
         testdir = tempfile.TemporaryDirectory()
-        class TestDir:
-            name = "testdata"
-        testdir = TestDir()
 
         comm, procs, rank = toast.get_world()
         data = simulation_test_data(


### PR DESCRIPTION
This pull request adds support for bilinear mapmaking to sotodlib. This functionality depends on the bilinear branch of so3g, but I've added some temporary scaffoling in this pull request to still make standard nearest neighbor mapmaking work while using the old version of so3g. This scaffolding is quite ugly, so I suggest we remove it as soon as possible. The scaffolding involves working around the shape of the threads/rangs/ivals (I wish this thing had a more consistent name in the code!) object having 4D in new so3g and 3D in the old one; as well as the Projectionist accepting a new interpol argument in the new version but not in the old version.