### PR TITLE
Bilinear mapmaking support

### DIFF
--- a/sotodlib/coords/pmat.py
+++ b/sotodlib/coords/pmat.py
@@ -85,6 +85,8 @@ class P:
     - det_weights (optional): weights (one per detector) to apply to
       time-ordered data when binning a map (and also when binning a
       weights matrix).  [dets]
+    - interpol (optional): How to interpolate the values for samples
+      between pixel centers. Forwarded to Projectionist.
 
     These things can be updated freely, with the following caveats:
 
@@ -111,7 +113,7 @@ class P:
 
     """
     def __init__(self, sight=None, fp=None, geom=None, comps='T',
-                 cuts=None, threads=None, det_weights=None, interpol="nearest"):
+                 cuts=None, threads=None, det_weights=None, interpol=None):
         self.sight = sight
         self.fp = fp
         self.geom = wrap_geom(geom)
@@ -127,7 +129,7 @@ class P:
                 rot=None, cuts=None, threads=None, det_weights=None,
                 timestamps=None, focal_plane=None, boresight=None,
                 boresight_equ=None, wcs_kernel=None, weather='typical',
-                site='so', interpol="nearest"):
+                site='so', interpol=None):
         """Set up a Projection Matrix for a TOD.  This will ultimately call
         the main P constructor, but some missing arguments will be
         extracted from tod and computed along the way.

--- a/sotodlib/coords/pmat.py
+++ b/sotodlib/coords/pmat.py
@@ -86,11 +86,13 @@ class P:
       time-ordered data when binning a map (and also when binning a
       weights matrix).  [dets]
     - interpol (optional): How to interpolate the values for samples
-      between pixel centers. Forwarded to Projectionist.
-      Valid options are:
+      between pixel centers. Forwarded to Projectionist. Valid
+      options are:
+
       - None, 'nn' or 'nearest': Standard nearest neighbor mapmaking.
-      - 'lin' or 'bilinear': Linearly interpolate between the four closest
-        pixels.
+      - 'lin' or 'bilinear': Linearly interpolate between the four
+        closest pixels.
+
       Default: None
 
     These things can be updated freely, with the following caveats:

--- a/sotodlib/coords/pmat.py
+++ b/sotodlib/coords/pmat.py
@@ -87,6 +87,11 @@ class P:
       weights matrix).  [dets]
     - interpol (optional): How to interpolate the values for samples
       between pixel centers. Forwarded to Projectionist.
+      Valid options are:
+      - None, 'nn' or 'nearest': Standard nearest neighbor mapmaking.
+      - 'lin' or 'bilinear': Linearly interpolate between the four closest
+        pixels.
+      Default: None
 
     These things can be updated freely, with the following caveats:
 
@@ -245,7 +250,7 @@ class P:
 
         proj, threads = self._get_proj_threads(cuts=cuts)
         proj.to_map(signal, self._get_asm(), output=self._prepare_map(dest),
-                det_weights=det_weights, comps=comps, threads=unwrap_ranges(threads, proj))
+                det_weights=det_weights, comps=comps, threads=unwrap_ranges(threads))
         return dest
 
     def to_weights(self, tod=None, dest=None, comps=None, signal=None,
@@ -283,7 +288,7 @@ class P:
 
         proj, threads = self._get_proj_threads(cuts=cuts)
         proj.to_weights(self._get_asm(), output=self._prepare_map(dest),
-                det_weights=det_weights, comps=comps, threads=unwrap_ranges(threads, proj))
+                det_weights=det_weights, comps=comps, threads=unwrap_ranges(threads))
         return dest
 
     def to_inverse_weights(self, weights_map=None, tod=None, dest=None,
@@ -403,25 +408,15 @@ class P:
     def _get_proj(self):
         if self.geom is None:
             raise ValueError("Can't project without a geometry!")
-        # Super-ugly temporary hack for transition from old to new so3g.
-        # Remove as soon as possible
-        if "_ivar_version" not in dir(so3g.proj.Projectionist):
-            assert self.interpol is None or self.interpol == "nn", "Old so3g does not support interpolated mapmaking"
-            if self.tiled:
-                return so3g.proj.Projectionist.for_tiled(
-                    self.geom.shape, self.geom.wcs, self.geom.tile_shape,
-                    active_tiles=self.active_tiles)
-            else:
-                return so3g.proj.Projectionist.for_geom(self.geom.shape,
-                    self.geom.wcs)
+        # Backwards compatibility for old so3g
+        interpol_kw = _get_interpol_args(self.interpol)
+        if self.tiled:
+            return so3g.proj.Projectionist.for_tiled(
+                self.geom.shape, self.geom.wcs, self.geom.tile_shape,
+                active_tiles=self.active_tiles, **interpol_kw)
         else:
-            if self.tiled:
-                return so3g.proj.Projectionist.for_tiled(
-                    self.geom.shape, self.geom.wcs, self.geom.tile_shape,
-                    active_tiles=self.active_tiles, interpol=self.interpol)
-            else:
-                return so3g.proj.Projectionist.for_geom(self.geom.shape,
-                    self.geom.wcs, interpol=self.interpol)
+            return so3g.proj.Projectionist.for_geom(self.geom.shape,
+                self.geom.wcs, **interpol_kw)
 
     def _get_proj_threads(self, cuts=None):
         """Return the Projectionist and sample-thread assignment for the
@@ -448,7 +443,7 @@ class P:
             if isinstance(self.threads, str) and self.threads == 'tiles':
                 logger.info('_get_proj_threads: assigning using "tiles"')
                 tile_info = proj.get_active_tiles(self._get_asm(), assign=True)
-                _tile_threads = wrap_ranges(tile_info['group_ranges'],proj)
+                _tile_threads = wrap_ranges(tile_info['group_ranges'])
             else:
                 tile_info = proj.get_active_tiles(self._get_asm())
             self.active_tiles = tile_info['active_tiles']
@@ -462,7 +457,7 @@ class P:
             if self.threads in ['simple', 'domdir']:
                 logger.info(f'_get_proj_threads: assigning using "{self.threads}"')
                 self.threads = wrap_ranges(proj.assign_threads(
-                    self._get_asm(), method=self.threads), proj)
+                    self._get_asm(), method=self.threads))
             elif self.threads == 'tiles':
                 # Computed above unless logic failed us...
                 self.threads = _thile_threads
@@ -513,12 +508,28 @@ def wrap_geom(geom):
 
 # Helpers for backwards compatibility with old so3g. Consider removing these
 # once transition is done.
-def wrap_ranges(ranges, proj):
-    if "_ivals_format" not in dir(proj) or proj._ivals_format == 1: return so3g.proj.ranges.RangesMatrix([ranges])
-    else: return ranges
+def wrap_ranges(ranges):
+    if _so3g_ivals_format() == 1:
+        return so3g.proj.ranges.RangesMatrix([ranges])
+    else:
+        return ranges
 
-def unwrap_ranges(ranges, proj):
-    if "_ivals_format" not in dir(proj) or proj._ivals_format == 1:
+def unwrap_ranges(ranges):
+    if _so3g_ivals_format() == 1:
         assert len(ranges) == 1, "Old so3g only supports simple (1-bunch) thread ranges, but got thread ranges with shape %s" % (str(ranges.shape))
         return ranges[0]
-    else: return ranges
+    else:
+        return ranges
+
+def _so3g_ivals_format():
+    projclass = so3g.proj.Projectionist
+    if not hasattr(projclass, '_ivals_format'):
+        return 1
+    else:
+        return projclass._ivals_format
+
+def _get_interpol_args(interpol):
+    if _so3g_ivals_format() >= 2:
+        return {'interpol': interpol}
+    assert interpol in [None, "nn", "nearest"], "Old so3g does not support interpolated mapmaking"
+    return {}

--- a/sotodlib/coords/pmat.py
+++ b/sotodlib/coords/pmat.py
@@ -111,7 +111,7 @@ class P:
 
     """
     def __init__(self, sight=None, fp=None, geom=None, comps='T',
-                 cuts=None, threads=None, det_weights=None):
+                 cuts=None, threads=None, det_weights=None, interpol="nearest"):
         self.sight = sight
         self.fp = fp
         self.geom = wrap_geom(geom)
@@ -120,12 +120,14 @@ class P:
         self.threads = threads
         self.active_tiles = None
         self.det_weights = det_weights
+        self.interpol = interpol
 
     @classmethod
     def for_tod(cls, tod, sight=None, fp=None, geom=None, comps='T',
                 rot=None, cuts=None, threads=None, det_weights=None,
                 timestamps=None, focal_plane=None, boresight=None,
-                boresight_equ=None, wcs_kernel=None, weather='typical', site='so'):
+                boresight_equ=None, wcs_kernel=None, weather='typical',
+                site='so', interpol="nearest"):
         """Set up a Projection Matrix for a TOD.  This will ultimately call
         the main P constructor, but some missing arguments will be
         extracted from tod and computed along the way.
@@ -175,7 +177,8 @@ class P:
             geom = helpers.get_footprint(tod, wcs_kernel, sight=sight)
 
         return cls(sight=sight, fp=fp, geom=geom, comps=comps,
-                   cuts=cuts, threads=threads, det_weights=det_weights)
+                   cuts=cuts, threads=threads, det_weights=det_weights,
+                   interpol=interpol)
 
     @classmethod
     def for_geom(cls, tod, geom, comps='TQU', timestamps=None,
@@ -401,9 +404,10 @@ class P:
         if self.tiled:
             return so3g.proj.Projectionist.for_tiled(
                 self.geom.shape, self.geom.wcs, self.geom.tile_shape,
-                active_tiles=self.active_tiles)
+                active_tiles=self.active_tiles, interpol=self.interpol)
         else:
-            return so3g.proj.Projectionist.for_geom(self.geom.shape, self.geom.wcs)
+            return so3g.proj.Projectionist.for_geom(self.geom.shape,
+                self.geom.wcs, interpol=self.interpol)
 
     def _get_proj_threads(self, cuts=None):
         """Return the Projectionist and sample-thread assignment for the

--- a/sotodlib/mapmaking.py
+++ b/sotodlib/mapmaking.py
@@ -170,10 +170,11 @@ class SignalMap(Signal):
     """Signal describing a non-distributed sky map."""
     def __init__(self, shape, wcs, comm, comps="TQU", name="sky", ofmt="{name}", output=True,
             ext="fits", dtype=np.float32, sys=None, recenter=None, tile_shape=(500,500), tiled=False,
-            interpol="nearest"):
+            interpol=None):
         """Signal describing a sky map in the coordinate system given by "sys", which defaults
         to equatorial coordinates. If tiled==True, then this will be a distributed map with
-        the given tile_shape, otherwise it will be a plain enmap."""
+        the given tile_shape, otherwise it will be a plain enmap. interpol controls the
+        pointing matrix interpolation mode. See so3g's Projectionist docstring for details."""
         Signal.__init__(self, name, ofmt, output, ext)
         self.comm  = comm
         self.comps = comps
@@ -464,7 +465,7 @@ class PmatCut:
         junk = np.empty(self.njunk, tod.dtype)
         so3g.process_cuts(self.cuts.ranges, "clear", self.model, self.params, tod, junk)
 
-def inject_map(obs, map, recenter=None, interpol="nearest"):
+def inject_map(obs, map, recenter=None, interpol=None):
     # Infer the stokes components
     map = map.preflat
     if map.shape[0] not in [1,2,3]:

--- a/sotodlib/mapmaking.py
+++ b/sotodlib/mapmaking.py
@@ -169,7 +169,8 @@ class Signal:
 class SignalMap(Signal):
     """Signal describing a non-distributed sky map."""
     def __init__(self, shape, wcs, comm, comps="TQU", name="sky", ofmt="{name}", output=True,
-            ext="fits", dtype=np.float32, sys=None, recenter=None, tile_shape=(500,500), tiled=False):
+            ext="fits", dtype=np.float32, sys=None, recenter=None, tile_shape=(500,500), tiled=False,
+            interpol="nearest"):
         """Signal describing a sky map in the coordinate system given by "sys", which defaults
         to equatorial coordinates. If tiled==True, then this will be a distributed map with
         the given tile_shape, otherwise it will be a plain enmap."""
@@ -180,6 +181,7 @@ class SignalMap(Signal):
         self.recenter = recenter
         self.dtype = dtype
         self.tiled = tiled
+        self.interpol = interpol
         self.data  = {}
         ncomp      = len(comps)
         shape      = tuple(shape[-2:])
@@ -209,7 +211,8 @@ class SignalMap(Signal):
                     ctime=ctime[len(ctime)//2], geom=(self.rhs.shape, self.rhs.wcs), site=unarr(obs.site)))
             else: rot = None
             pmap = coords.pmat.P.for_tod(obs, comps=self.comps, geom=self.rhs.geometry,
-                rot=rot, threads="domdir", weather=unarr(obs.weather), site=unarr(obs.site))
+                rot=rot, threads="domdir", weather=unarr(obs.weather), site=unarr(obs.site),
+                interpol=self.interpol)
         # Build the RHS for this observation
         pcut.clear(Nd)
         obs_rhs = pmap.zeros()
@@ -461,7 +464,7 @@ class PmatCut:
         junk = np.empty(self.njunk, tod.dtype)
         so3g.process_cuts(self.cuts.ranges, "clear", self.model, self.params, tod, junk)
 
-def inject_map(obs, map, recenter=None):
+def inject_map(obs, map, recenter=None, interpol="nearest"):
     # Infer the stokes components
     map = map.preflat
     if map.shape[0] not in [1,2,3]:
@@ -473,7 +476,7 @@ def inject_map(obs, map, recenter=None):
         rot    = recentering_to_quat_lonlat(*evaluate_recentering(recenter, ctime=ctime[len(ctime)//2], geom=(map.shape, map.wcs), site=unarr(obs.site)))
     else: rot = None
     # Set up our pointing matrix for the map
-    pmat  = coords.pmat.P.for_tod(obs, comps=comps, geom=(map.shape, map.wcs), rot=rot, threads="domdir")
+    pmat  = coords.pmat.P.for_tod(obs, comps=comps, geom=(map.shape, map.wcs), rot=rot, threads="domdir", interpol=self.interpol)
     # And perform the actual injection
     pmat.from_map(map.extract(shape, wcs), dest=obs.signal)
 


### PR DESCRIPTION
This pull request adds support for bilinear mapmaking to sotodlib. This functionality depends on the bilinear branch of so3g, but I've added some temporary scaffoling in this pull request to still make standard nearest neighbor mapmaking work while using the old version of so3g. This scaffolding is quite ugly, so I suggest we remove it as soon as possible. The scaffolding involves working around the shape of the threads/rangs/ivals (I wish this thing had a more consistent name in the code!) object having 4D in new so3g and 3D in the old one; as well as the Projectionist accepting a new interpol argument in the new version but not in the old version.