### PR TITLE
Site Updates for Data Packaging

### DIFF
--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -1351,7 +1351,7 @@ class G3tSmurf:
             )
             if db_agent is None:
                 logger.info(
-                    f"Agent {agent} not found in HK database before"
+                    f"Agent {agent.agent} not found in HK database before"
                     f" update time {update_time}"
                 )
                 continue

--- a/sotodlib/site_pipeline/update_book_plan.py
+++ b/sotodlib/site_pipeline/update_book_plan.py
@@ -190,7 +190,7 @@ def get_parser(parser=None):
         '--update-delay-timecodes', type=float, 
         help= "Days to subtract from now to set as minimum ctime "
               "for timecode books",
-        default=1
+        default=7
     )
 
     return parser

--- a/sotodlib/site_pipeline/update_book_plan.py
+++ b/sotodlib/site_pipeline/update_book_plan.py
@@ -13,6 +13,9 @@ def main(
     stream_ids: Optional[str] = None,
     force_single_stream: bool = False,
     update_delay: float = 1,
+    update_delay_timecodes: Optional[float] = 7,
+    min_ctime_timecodes: Optional[float] = None,
+    max_ctime_timecodes: Optional[float] = None,
     from_scratch: bool = False,
     logger = None
     ):
@@ -33,7 +36,16 @@ def main(
     force_single_stream : bool, optional
         If True, tream multi-wafer data as if it were single wafer data, by default False
     update_delay : float, optional
-        The range of time to search through g3tsmurf db for new data in units of days, by default 1
+        The range of time to search through g3tsmurf db for new data in units of
+        days, by default 1
+    update_delay_timecodes : float, optional
+        The range of time to search through g3tsmurf db for new data in units of
+        days for timecode books, by default 7
+    min_ctime_timecodes : Optional[float], optional
+        The minimum ctime to include in the book plan for timecode (hk, smurf, stray) books, by default None
+    max_ctime_timecodes : Optional[float], optional
+        The maximum ctime to include in the book planor timecode (hk, smurf, stray) books, by default None
+
     from_scratch : bool, optional
         If True, start to search from beginning of time, by default False
     """
@@ -59,10 +71,32 @@ def main(
         stream_ids=stream_ids,
         force_single_stream=force_single_stream
     )
+
+    ## over-ride timecode book making if specific values given
+    if update_delay_timecodes is None and min_ctime_timecodes is None:
+        min_ctime_timecodes = min_ctime
+    elif min_ctime_timecodes is None:
+        min_ctime_timecodes = (
+            dt.datetime.now() - dt.timedelta(days=update_delay_timecodes)
+        )
+    if max_ctime_timecodes is None:
+        max_ctime_timecodes = max_ctime
+
+    if isinstance(min_ctime_timecodes, dt.datetime):
+        min_ctime_timecodes = min_ctime_timecodes.timestamp()
+    if isinstance(max_ctime, dt.datetime):
+        max_ctime_timecodes = max_ctime_timecodes.timestamp()
+
     # hk books
-    imprinter.register_hk_books(min_ctime=min_ctime, max_ctime=max_ctime)
+    imprinter.register_hk_books(
+        min_ctime=min_ctime_timecodes, 
+        max_ctime=max_ctime_timecodes,
+    )
     # smurf and stray books
-    imprinter.register_timecode_books(min_ctime=min_ctime, max_ctime=max_ctime)
+    imprinter.register_timecode_books(
+        min_ctime=min_ctime_timecodes, 
+        max_ctime=max_ctime_timecodes,
+    )
 
     monitor = None
     if "monitor" in imprinter.config:
@@ -144,6 +178,21 @@ def get_parser(parser=None):
         '--from-scratch', help="Builds or updates database from scratch",
         action="store_true"
     )
+    parser.add_argument(
+        '--min-ctime-timecodes', type=float, 
+        help="Minimum creation time for timecode books"
+    )
+    parser.add_argument(
+        '--max-ctime-timecodes', type=float, 
+        help="Maximum creation time for timecode books"
+    )
+    parser.add_argument(
+        '--update-delay-timecodes', type=float, 
+        help= "Days to subtract from now to set as minimum ctime "
+              "for timecode books",
+        default=1
+    )
+
     return parser
 
 

--- a/sotodlib/site_pipeline/update_librarian.py
+++ b/sotodlib/site_pipeline/update_librarian.py
@@ -23,10 +23,8 @@ def main( config: str):
     to_upload = imprinter.get_bound_books(session=session)
 
     for book in to_upload:
-        try:
-            imprinter.upload_book_to_librarian(book, session=session)
-        except:
-            pass
+        imprinter.upload_book_to_librarian(book, session=session)
+
 
 
 def get_parser(parser=None):


### PR DESCRIPTION
* The librarian upload should definitely be throwing errors when if fails instead of just passing
* I realized the timecode finalization should be based on servers instead of on stream_ids because that's actually how the files are made. This is also now possible based on the "one per daq-node" setup that is now enforced with imprinter
* Added a function that will now tell us why the timecode books aren't being made.