### PR TITLE
Change get_wcs_kernel to be more stringent

### DIFF
--- a/sotodlib/coords/helpers.py
+++ b/sotodlib/coords/helpers.py
@@ -221,16 +221,15 @@ def get_wcs_kernel(proj, ra=None, dec=None, res=None):
 
     Args:
       proj (str): Either the name of a FITS projection to use (e.g. 'car',
-                  'cea', 'tan'), in which case "res" must also be specified,
-                  or a string containing both the projection and the
-                  resolution, in this format:
+        'cea', 'tan'), in which case "res" must also be specified, or a
+        string containing both the projection and the resolution, in this
+        format:
 
                       proj-res
 
-                  where proj is a projection type (e.g. 'car', 'tan'
-                  'gnom') and res is the resolution, in appropriate
-                  units (deg, arcmin or arcsec).Examples of acceptable
-                  args:
+        where proj is a projection type (e.g. 'car', 'tan, 'gnom') and res
+        is the resolution, in appropriate units (deg, arcmin or arcsec).
+        Examples of acceptable args:
 
                       'car-0.5deg'
                       'tan-3arcmin'

--- a/sotodlib/coords/helpers.py
+++ b/sotodlib/coords/helpers.py
@@ -210,7 +210,7 @@ def get_horiz(tod, wrap=False, dets=None, timestamps=None, focal_plane=None,
         tod.wrap(wrap, output, [(0, 'dets'), (1, 'samps')])
     return output
 
-def test_wcs_kernel(proj, ra=None, dec=None, res=None):
+def get_wcs_kernel(proj, ra=None, dec=None, res=None):
     """Construct a WCS.  This fixes the projection type (e.g. CAR, TAN),
     centered with respect to a reference point (at ra,dec = (0,0)), and 
     resolution of a pixelization, without specifying a particular grid 

--- a/sotodlib/coords/helpers.py
+++ b/sotodlib/coords/helpers.py
@@ -222,7 +222,9 @@ def get_wcs_kernel(proj, ra=None, dec=None, res=None):
     Args:
       proj (str): Name and resolution of projection to be used. It
                   must adhere to the following format:
+
                       proj-res
+                  
                   where proj is a projection type (e.g. 'car', 'tan'
                   'gnom') and res is the resolution, in appropriate
                   units (deg, arcmin or arcsec).

--- a/sotodlib/coords/helpers.py
+++ b/sotodlib/coords/helpers.py
@@ -280,7 +280,7 @@ def get_footprint(tod, wcs_kernel, dets=None, timestamps=None, boresight=None,
     big enough to contain all data from tod.  Returns (shape, wcs).
 
     """
-    if type(wcs_kernel) == str:
+    if isinstance(wcs_kernel, str):
         wcs_kernel = get_wcs_kernel(wcs_kernel)
 
     dets = _valid_arg(dets, tod.dets.vals, src=tod)

--- a/sotodlib/coords/helpers.py
+++ b/sotodlib/coords/helpers.py
@@ -224,14 +224,16 @@ def get_wcs_kernel(proj, ra=None, dec=None, res=None):
                   must adhere to the following format:
 
                       proj-res
-                  
+
                   where proj is a projection type (e.g. 'car', 'tan'
                   'gnom') and res is the resolution, in appropriate
-                  units (deg, arcmin or arcsec).
-                  Examples of acceptable args:
+                  units (deg, arcmin or arcsec).Examples of acceptable
+                  args:
+
                       'car-0.5deg'
                       'tan-3arcmin'
                       'gnom-25arcsec'
+
       ra: Right Ascension (longitude) of the reference position, in
         radians.
       dec: Declination (latitude) of the reference position, in

--- a/sotodlib/coords/helpers.py
+++ b/sotodlib/coords/helpers.py
@@ -280,6 +280,9 @@ def get_footprint(tod, wcs_kernel, dets=None, timestamps=None, boresight=None,
     big enough to contain all data from tod.  Returns (shape, wcs).
 
     """
+    if type(wcs_kernel) == str:
+        wcs_kernel = get_wcs_kernel(wcs_kernel)
+
     dets = _valid_arg(dets, tod.dets.vals, src=tod)
     fp0 = _valid_arg(focal_plane, 'focal_plane', src=tod)
     if sight is None and 'sight' in tod:

--- a/sotodlib/coords/helpers.py
+++ b/sotodlib/coords/helpers.py
@@ -248,7 +248,7 @@ def get_wcs_kernel(proj, ra=None, dec=None, res=None):
         # Convert to radians
         res = res * np.pi/180.
         if unit == 'arcmin':
-            res / =60.
+            res /= 60.
         if unit == 'arcsec':
             res /= 3600.
 

--- a/sotodlib/coords/helpers.py
+++ b/sotodlib/coords/helpers.py
@@ -210,10 +210,11 @@ def get_horiz(tod, wrap=False, dets=None, timestamps=None, focal_plane=None,
         tod.wrap(wrap, output, [(0, 'dets'), (1, 'samps')])
     return output
 
+
 def get_wcs_kernel(proj, ra=None, dec=None, res=None):
     """Construct a WCS.  This fixes the projection type (e.g. CAR, TAN),
-    centered with respect to a reference point (at ra,dec = (0,0)), and 
-    resolution of a pixelization, without specifying a particular grid 
+    centered with respect to a reference point (at ra,dec = (0,0)), and
+    resolution of a pixelization, without specifying a particular grid
     of pixels.
 
     This interface is subject to change.
@@ -224,11 +225,11 @@ def get_wcs_kernel(proj, ra=None, dec=None, res=None):
                       proj-res
                   where proj is a projection type (e.g. 'car', 'tan'
                   'gnom') and res is the resolution, in appropriate
-                  units (deg, arcmin or arcsec). 
+                  units (deg, arcmin or arcsec).
                   Examples of acceptable args:
                       'car-0.5deg'
                       'tan-3arcmin'
-                      'gnom-25arcsec'                
+                      'gnom-25arcsec'
       ra: Right Ascension (longitude) of the reference position, in
         radians.
       dec: Declination (latitude) of the reference position, in
@@ -238,31 +239,32 @@ def get_wcs_kernel(proj, ra=None, dec=None, res=None):
     Returns a WCS object that captures the requested pixelization.
 
     """
-    if len(proj)>3:
+    if len(proj) > 3:
         m = re.match('(?P<proj>car|tan)-(?P<res>[0-9]*.?[0-9]*)(?P<unit>arcsec|arcmin|deg)', proj)
         proj = m['proj']
         res = float(m['res'])
         unit = m['unit']
-        
+
         # Convert to radians
         res = res * np.pi/180.
         if unit == 'arcmin':
-            res/=60.
+            res / =60.
         if unit == 'arcsec':
-            res/=3600.
-        
+            res /= 3600.
+
         if unit == 'deg' and res > 10:
             raise ValueError("Beam is too big")
-        
-        _, wcs = enmap.geometry(np.array((0,0)), shape=(1,1), proj=proj,
+
+        _, wcs = enmap.geometry(np.array((0, 0)), shape=(1, 1), proj=proj,
                                 res=(res, -res))
-        
+
     else:
         assert np.isscalar(res)  # This ain't enlib.
-        _, wcs = enmap.geometry(np.array((dec,ra)), shape=(1,1), proj=proj,
+        _, wcs = enmap.geometry(np.array((dec, ra)), shape=(1, 1), proj=proj,
                                 res=(res, -res))
 
     return wcs
+
 
 def get_footprint(tod, wcs_kernel, dets=None, timestamps=None, boresight=None,
                   focal_plane=None, sight=None, rot=None):


### PR DESCRIPTION
I've tried to make changes to `get_wcs_kernel` as pointed out in [issue 525.](https://github.com/simonsobs/sotodlib/issues/525)  I'm not sure this is what was envisioned, but I've tested it on an various projections and resolutions and it yields expected results. The function will throw an error in cases where the beam is too large, or doesn't come from a pre-approved set of sizes. 

If this is acceptable, I can propagate the change into `get_footprint`, which is the only function that I can find that will need to be changed.  