### PR TITLE
Faster glitch flagging

### DIFF
--- a/sotodlib/flags.py
+++ b/sotodlib/flags.py
@@ -95,7 +95,10 @@ def get_glitch_flags(
     )
     # get the threshods based on n_sig x nlev = n_sig x iqu x 0.741
     fvec = np.abs(fvec)
-    iqr_range = 0.741 * stats.iqr(fvec, axis=1)
+        if fvec.shape[1] > 50000:
+        ds = int(fvec.shape[1]/20000)
+    else: ds = 1
+    iqr_range = 0.741 * stats.iqr(fvec[:,::ds], axis=1)
     # get flags
     msk = fvec > iqr_range[:, None] * n_sig
     flag = RangesMatrix([Ranges.from_bitmask(m) for m in msk])

--- a/sotodlib/flags.py
+++ b/sotodlib/flags.py
@@ -97,7 +97,8 @@ def get_glitch_flags(
     fvec = np.abs(fvec)
     if fvec.shape[1] > 50000:
         ds = int(fvec.shape[1]/20000)
-    else: ds = 1
+    else: 
+        ds = 1
     iqr_range = 0.741 * stats.iqr(fvec[:,::ds], axis=1)
     # get flags
     msk = fvec > iqr_range[:, None] * n_sig

--- a/sotodlib/flags.py
+++ b/sotodlib/flags.py
@@ -95,7 +95,7 @@ def get_glitch_flags(
     )
     # get the threshods based on n_sig x nlev = n_sig x iqu x 0.741
     fvec = np.abs(fvec)
-        if fvec.shape[1] > 50000:
+    if fvec.shape[1] > 50000:
         ds = int(fvec.shape[1]/20000)
     else: ds = 1
     iqr_range = 0.741 * stats.iqr(fvec[:,::ds], axis=1)


### PR DESCRIPTION
Based on the discussions in issue #536, I have put in a catch to supply a decimation factor for the Fourier filtered signal if there are over 50,000 samples in the AxisManager. The decimated array will now be around 20,000 samples, which will speed up the `stats.iqr` step. 