### PR TITLE
Add logger import.

### DIFF
--- a/sotodlib/site_pipeline/preprocess_tod.py
+++ b/sotodlib/site_pipeline/preprocess_tod.py
@@ -6,7 +6,8 @@ import argparse
 from sotodlib import core
 import sotodlib.site_pipeline.util as sp_util
 from sotodlib.preprocess import _Preprocess, PIPELINE, processes
-
+import logging
+logger = logging.getLogger(__name__)
 
 def _build_pipe_from_configs(configs):
     pipe = []

--- a/sotodlib/site_pipeline/preprocess_tod.py
+++ b/sotodlib/site_pipeline/preprocess_tod.py
@@ -6,8 +6,8 @@ import argparse
 from sotodlib import core
 import sotodlib.site_pipeline.util as sp_util
 from sotodlib.preprocess import _Preprocess, PIPELINE, processes
-import logging
-logger = logging.getLogger(__name__)
+
+logger = sp_util.init_logger("preprocess")
 
 def _build_pipe_from_configs(configs):
     pipe = []
@@ -249,6 +249,7 @@ def main(
     configs, context = _get_preprocess_context(configs)
     if logger is None: 
         logger = sp_util.init_logger("preprocess")
+    globals()['logger'] = logger
 
     if obs_id is not None:
         tot_query = f"obs_id=='{obs_id}'"


### PR DESCRIPTION
When the `sotodlib.site_pipeline.preprocess_tod` method `_build_pipe_from_configs` is called and the config dictionary includes a process name which doesn't have a corresponding class defined in `sotodlib.preprocess.processes` a log warning should be raised but currently that logging is not imported properly so that log statement breaks the code. I now added that import and tested that it works.