### PR TITLE
Wcs resolutions

### DIFF
--- a/sotodlib/coords/helpers.py
+++ b/sotodlib/coords/helpers.py
@@ -270,7 +270,13 @@ def get_wcs_kernel(proj, ra=None, dec=None, res=None):
 
     if proj == 'car':
         wcs.wcs.crpix = [1.0, 0.5]
-
+        
+        # Check if the resolution is sensible, for SHTs
+        res = res * 180./np.pi # Easier to do this check in degs
+        div = 90./res - np.round(90./res)
+        if len(str(div).split('.')[1]) > 3:
+            raise ValueError("Please use a standard resolution")
+    
     return wcs
 
 

--- a/sotodlib/coords/helpers.py
+++ b/sotodlib/coords/helpers.py
@@ -274,7 +274,7 @@ def get_wcs_kernel(proj, ra=None, dec=None, res=None):
         # Check if the resolution is sensible, for SHTs
         res = res * 180./np.pi # Easier to do this check in degs
         div = 90./res - np.round(90./res)
-        if len(str(div).split('.')[1]) > 3:
+        if abs(div) > 1e-8:
             raise ValueError("Please use a standard resolution")
     
     return wcs

--- a/sotodlib/coords/helpers.py
+++ b/sotodlib/coords/helpers.py
@@ -270,13 +270,13 @@ def get_wcs_kernel(proj, ra=None, dec=None, res=None):
 
     if proj == 'car':
         wcs.wcs.crpix = [1.0, 0.5]
-        
+
         # Check if the resolution is sensible, for SHTs
-        res = res * 180./np.pi # Easier to do this check in degs
+        res = res * 180./np.pi  # Easier to do this check in degs
         div = 90./res - np.round(90./res)
         if abs(div) > 1e-8:
-            raise ValueError("Please use a standard resolution")
-    
+            raise ValueError(f"The requested resolution {res} deg does not divide 90 deg evenly.")
+
     return wcs
 
 


### PR DESCRIPTION
As mentioned in #554 , I've updated the check to be even at a degree level, and check this quantitatively, rather than by parsing a string.

`if abs(div) > 1e-8:` will only let projections with real remainders through, and won't catch any that might be a result of float point inaccuracy. 

I've tested this with inputs in arcsecs, arcmins and degrees. Let me know if I've missed something. 