### PR TITLE
allow passing loggers into some databasing classes for working with prefect

### DIFF
--- a/sotodlib/io/bookbinder.py
+++ b/sotodlib/io/bookbinder.py
@@ -18,7 +18,7 @@ if not log.hasHandlers():
     init_logger('bookbinder')
 
 
-def setup_logger(logfile=None):
+def setup_logger(logfile=None, log=None):
     """
     This setups up a logger for bookbinder. If a logfile is passed, it will
     write to that file as well as stdout. It is useful to create a one-off
@@ -26,7 +26,8 @@ def setup_logger(logfile=None):
     a separate log-file for each bookbinder instance.
     """
     fmt = '%(asctime)s: %(message)s (%(levelname)s)'
-    log = logging.Logger('bookbinder', level=logging.DEBUG)
+    if log is None:
+        log = logging.Logger('bookbinder', level=logging.DEBUG)
 
     ch = logging.StreamHandler(sys.stdout)
     formatter = logging.Formatter(fmt)
@@ -558,6 +559,7 @@ class BookBinder:
         Dict of readout_ids to use for each stream_id. If provided, these
         will be used to set the `names` in the signal frames. If not provided,
         names will be taken from the input frames.
+    logger: logging.Logger, optional
 
     
     Attributes
@@ -575,7 +577,7 @@ class BookBinder:
     """
     def __init__(self, book, obsdb, filedb, data_root, readout_ids, outdir,
                  max_samps_per_frame=50_000, max_file_size=1e9, 
-                ignore_tags=False):
+                 ignore_tags=False, logger=None):
         self.filedb = filedb
         self.book = book
         self.data_root = data_root
@@ -595,7 +597,7 @@ class BookBinder:
             os.makedirs(outdir)
 
         logfile = os.path.join(outdir, 'Z_bookbinder_log.txt')
-        self.log = setup_logger(logfile)
+        self.log = setup_logger(logfile, log=logger)
 
         self.ancil = AncilProcessor(self.hkfiles, book.bid, log=self.log)
         self.streams = {}

--- a/sotodlib/io/g3thk_db.py
+++ b/sotodlib/io/g3thk_db.py
@@ -2,7 +2,7 @@ import sqlalchemy as db
 from sqlalchemy.exc import IntegrityError
 
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker, relationship
+from sqlalchemy.orm import sessionmaker, relationship, joinedload
 
 import os
 import yaml
@@ -524,7 +524,7 @@ class G3tHk:
         if agents.count() == 0:
             self.logger.warning(f"no agents found between {start} and {stop}")
 
-        agents = agents.filter(HKAgents.instance_id == instance_id).all()
+        agents = agents.filter(HKAgents.instance_id == instance_id).options(joinedload(HKAgents.fields)).all()
         return agents
 
     def get_last_update(self):

--- a/sotodlib/io/g3thk_utils.py
+++ b/sotodlib/io/g3thk_utils.py
@@ -6,10 +6,10 @@ import logging
 
 from sotodlib.io.g3thk_db import G3tHk, HKFiles, HKAgents, HKFields
 
-logger = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 
-def pysmurf_monitor_control_list(agent, start=None, stop=None, HK=None, logger=logger):
+def pysmurf_monitor_control_list(agent, start=None, stop=None, HK=None, logger=None):
     """Return list of stream_ids controlled by a pysmurf-monitor agent
 
     Arguments
@@ -26,6 +26,7 @@ def pysmurf_monitor_control_list(agent, start=None, stop=None, HK=None, logger=l
     -------
     stream_ids: list of stream_ids monitored by agent
     """
+    logger = _logger if logger is None else logger
     if isinstance(agent, str):
         if start is None or stop is None:
             raise ValueError(
@@ -51,7 +52,7 @@ def pysmurf_monitor_control_list(agent, start=None, stop=None, HK=None, logger=l
     return np.unique(stream_ids)
 
 
-def check_was_streaming(stream_id, start, stop, cfgs=None, HK=None, servers=None):
+def check_was_streaming(stream_id, start, stop, cfgs=None, HK=None, servers=None, logger=None):
     """Query the HK database to see if a specific stream_id was
     streaming during a time range.
 
@@ -81,9 +82,9 @@ def check_was_streaming(stream_id, start, stop, cfgs=None, HK=None, servers=None
     ------
     ValueError if stream_id is found in multiple pysmurf-monitors
     """
-
+    logger = _logger if logger is None else logger
     if HK is None:
-        HK = G3tHk.from_configs(cfgs)
+        HK = G3tHk.from_configs(cfgs, logger=logger)
     if servers is None:
         servers = cfgs["finalization"]["servers"]
     assert HK.get_last_update() >= stop

--- a/sotodlib/io/g3thk_utils.py
+++ b/sotodlib/io/g3thk_utils.py
@@ -26,7 +26,6 @@ def pysmurf_monitor_control_list(agent, start=None, stop=None, HK=None, logger=l
     -------
     stream_ids: list of stream_ids monitored by agent
     """
-    logger.info(f"Finding monitor control list for agent: {agent}")
     if isinstance(agent, str):
         if start is None or stop is None:
             raise ValueError(
@@ -38,7 +37,7 @@ def pysmurf_monitor_control_list(agent, start=None, stop=None, HK=None, logger=l
         if len(agent_list) == 0: 
             logger.warning(f"Agent {agent} not running between {start} and {stop}")
             return np.array([], dtype='<U8') 
-        logger.info(f"Agents to go through ({len(agent_list)}):: {agent_list}")
+        logger.info(f"Total agents to go through: {len(agent_list)}")
         return np.unique(
                 np.concatenate([pysmurf_monitor_control_list(agent, logger=logger) for agent in agent_list])
         )

--- a/sotodlib/io/g3thk_utils.py
+++ b/sotodlib/io/g3thk_utils.py
@@ -9,7 +9,7 @@ from sotodlib.io.g3thk_db import G3tHk, HKFiles, HKAgents, HKFields
 logger = logging.getLogger(__name__)
 
 
-def pysmurf_monitor_control_list(agent, start=None, stop=None, HK=None):
+def pysmurf_monitor_control_list(agent, start=None, stop=None, HK=None, logger=logger):
     """Return list of stream_ids controlled by a pysmurf-monitor agent
 
     Arguments
@@ -26,6 +26,7 @@ def pysmurf_monitor_control_list(agent, start=None, stop=None, HK=None):
     -------
     stream_ids: list of stream_ids monitored by agent
     """
+    logger.info(f"Finding monitor control list for agent: {agent}")
     if isinstance(agent, str):
         if start is None or stop is None:
             raise ValueError(
@@ -37,8 +38,9 @@ def pysmurf_monitor_control_list(agent, start=None, stop=None, HK=None):
         if len(agent_list) == 0: 
             logger.warning(f"Agent {agent} not running between {start} and {stop}")
             return np.array([], dtype='<U8') 
+        logger.info(f"Agents to go through ({len(agent_list)}):: {agent_list}")
         return np.unique(
-                np.concatenate([pysmurf_monitor_control_list(agent) for agent in agent_list])
+                np.concatenate([pysmurf_monitor_control_list(agent, logger=logger) for agent in agent_list])
         )
     stream_ids = []
     for field in agent.fields:

--- a/sotodlib/io/imprinter.py
+++ b/sotodlib/io/imprinter.py
@@ -273,7 +273,7 @@ class Imprinter:
             (
                 self.g3tsmurf_session,
                 self.archive,
-            ) = create_g3tsmurf_session(self.g3tsmurf_config)
+            ) = create_g3tsmurf_session(self.g3tsmurf_config, logger=self.logger)
         if not return_archive:
             return self.g3tsmurf_session
         return self.g3tsmurf_session, self.archive
@@ -282,7 +282,8 @@ class Imprinter:
         """Get a G3tHk database using the g3tsmurf config file."""
         if self.hk_archive is None:
             self.hk_archive = G3tHk.from_configs(
-                self.g3tsmurf_config
+                self.g3tsmurf_config,
+                logger=self.logger
             )
         return self.hk_archive
 
@@ -1056,6 +1057,7 @@ class Imprinter:
         stream_filt = or_(*[G3tObservations.stream_id == s for s in streams])
 
         # check data transfer finalization
+        self.logger.info("Getting finalization time from G3tHK db...")
         final_time = SMURF.get_final_time(
             streams, min_ctime, max_ctime, check_control=True
         )

--- a/sotodlib/io/imprinter.py
+++ b/sotodlib/io/imprinter.py
@@ -565,6 +565,7 @@ class Imprinter:
             bookbinder = BookBinder(
                 book, obsdb, filedb, lvl2_data_root, readout_ids, book_path,
                 ignore_tags=ignore_tags,
+                logger=self.logger
             )
             return bookbinder
 

--- a/sotodlib/io/load_book.py
+++ b/sotodlib/io/load_book.py
@@ -193,7 +193,7 @@ def load_book_file(filename, dets=None, samples=None, no_signal=False):
 
 def _load_book_detset(files, prefix='', load_ancil=True,
                       dets=None, samples=None, no_signal=False,
-                      signal_buffer=None):
+                      signal_buffer=None, logger=logger):
     """Read data from a single detset.
 
     If a list of dets is specified, it may include dets that aren't
@@ -297,7 +297,7 @@ def _load_book_detset(files, prefix='', load_ancil=True,
     if stat.num_chans is not None:
         # This is an AxisManager, with dets axis for just this stream
         # ... extract and stack data later.
-        ch_info = load_smurf.get_channel_info(stat, mask=det_idx_in_stream)
+        ch_info = load_smurf.get_channel_info(stat, mask=det_idx_in_stream, logger=logger)
         # And this stuff is per stream, so keep it separate.
         iir_params = {'enabled': stat.filter_enabled,
                       'b': stat.filter_b,

--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -1395,13 +1395,11 @@ class G3tSmurf:
             )
         if session is None:
             session = self.Session()
-        self.logger.info("Initializing G3tHk db...")
         HK = G3tHk(
             os.path.join(os.path.split(self.archive_path)[0], "hk"),
             self.hk_db_path,
             logger=self.logger
         )
-        self.logger.info("Initializing G3tHk db...")
 
         agent_list = []
         if "servers" not in self.finalize:
@@ -1446,7 +1444,6 @@ class G3tSmurf:
                     stop = last_update
             self.logger.info("Getting pysmurf monitor control list:")
             sids = pysmurf_monitor_control_list(pm, start, stop, HK, logger=self.logger)
-            self.logger.info(f"\t{sids}")
             if np.any([s in stream_ids for s in sids]):
                 agent_list.append(server["smurf-suprsync"])
                 agent_list.append(server["timestream-suprsync"])

--- a/sotodlib/site_pipeline/make_book.py
+++ b/sotodlib/site_pipeline/make_book.py
@@ -13,33 +13,33 @@ def main(config: str, logger=None):
     im_config : str
         path to imprinter configuration file
     """
-    imprinter = Imprinter(config, db_args={'connect_args': {'check_same_thread': False}})
+    imprinter = Imprinter(config, db_args={'connect_args': {'check_same_thread': False}}, logger=logger)
     # get unbound books
     unbound_books = imprinter.get_unbound_books()
     already_failed_books = imprinter.get_failed_books()
     
-    print(f"Found {len(unbound_books)} unbound books and "
-          f"{len(already_failed_books)} failed books")
+    logger.info(f"Found {len(unbound_books)} unbound books and "
+                f"{len(already_failed_books)} failed books")
     for book in unbound_books:
-        print(f"Binding book {book.bid}")
+        logger.info(f"Binding book {book.bid}")
         try:
             imprinter.bind_book(book)
         except Exception as e:
-            print(f"Error binding book {book.bid}: {e}")
-            print(traceback.format_exc())
+            logger.error(f"Error binding book {book.bid}: {e}")
+            logger.error(traceback.format_exc())
 
-    print("Retrying failed books") 
+    logger.info("Retrying failed books")
     failed_books = imprinter.get_failed_books()
     for book in failed_books:
         if book in already_failed_books:
-            print(f"Book {book.bid} has already failed twice, not re-trying")
+            logger.info(f"Book {book.bid} has already failed twice, not re-trying")
             continue
-        print(f"Binding book {book.bid}")
+        logger.info(f"Binding book {book.bid}")
         try:
             imprinter.bind_book(book)
         except Exception as e:
-            print(f"Error binding book {book.bid}: {e}")
-            print(traceback.format_exc())
+            logger.error(f"Error binding book {book.bid}: {e}")
+            logger.error(traceback.format_exc())
             # it has failed twice, ideally we want people to look at it now
             # do something here
 

--- a/sotodlib/site_pipeline/update_book_plan.py
+++ b/sotodlib/site_pipeline/update_book_plan.py
@@ -67,6 +67,7 @@ def main(
         max_ctime = max_ctime.timestamp()
 
     # obs and oper books
+    logger.info("Updating imprinter db based on g3tsmurf db...")
     imprinter.update_bookdb_from_g3tsmurf(
         min_ctime=min_ctime, max_ctime=max_ctime,
         ignore_singles=False,
@@ -90,11 +91,13 @@ def main(
         max_ctime_timecodes = max_ctime_timecodes.timestamp()
 
     # hk books
+    logger.info(f"Registering hk books between {min_ctime_timecodes} and {max_ctime_timecodes}")
     imprinter.register_hk_books(
         min_ctime=min_ctime_timecodes, 
         max_ctime=max_ctime_timecodes,
     )
     # smurf and stray books
+    logger.info(f"Registering timecode books between {min_ctime_timecodes} and {max_ctime_timecodes}")
     imprinter.register_timecode_books(
         min_ctime=min_ctime_timecodes, 
         max_ctime=max_ctime_timecodes,

--- a/sotodlib/site_pipeline/update_book_plan.py
+++ b/sotodlib/site_pipeline/update_book_plan.py
@@ -102,13 +102,13 @@ def main(
 
     monitor = None
     if "monitor" in imprinter.config:
-        imprinter.logger.info("Will send monitor information to Influx")
+        logger.info("Will send monitor information to Influx")
         try:
             monitor = Monitor.from_configs(
                 imprinter.config["monitor"]["connect_configs"]
             )
         except Exception as e:
-            imprinter.logger.error(f"Monitor connectioned failed {e}")
+            logger.error(f"Monitor connectioned failed {e}")
             monitor = None
 
     if monitor is not None:

--- a/sotodlib/site_pipeline/update_g3thk_database.py
+++ b/sotodlib/site_pipeline/update_g3thk_database.py
@@ -3,13 +3,10 @@ Script for running updates on (or creating) a g3tsmurf database. This setup
 is specifically designed to work when the data is dynamically coming in. Meaning is 
 is designed to work from something like a cronjob. 
 """
-import os
 import yaml
-import datetime as dt
-import numpy as np
 import argparse
 import logging
-from sqlalchemy import not_, or_, and_, desc
+from sqlalchemy import desc
 
 from sotodlib.io.g3thk_db import G3tHk, HKFiles, logger as default_logger
 
@@ -29,8 +26,8 @@ def main(config=None, from_scratch=False, verbosity=2, logger=None):
     elif verbosity == 3:
         logger.setLevel(logging.DEBUG)
 
-    cfgs = yaml.safe_load( open(config, "r"))
-    HK = G3tHk.from_configs(cfgs)
+    cfgs = yaml.safe_load(open(config, "r"))
+    HK = G3tHk.from_configs(cfgs, logger=logger)
 
     if from_scratch or HK.session.query(HKFiles).count()==0:
         logger.info("Building Database from Scratch, May take awhile")

--- a/sotodlib/site_pipeline/update_g3tsmurf_db.py
+++ b/sotodlib/site_pipeline/update_g3tsmurf_db.py
@@ -9,11 +9,10 @@ import datetime as dt
 import numpy as np
 import argparse
 import logging
-from sqlalchemy import not_, or_, and_
 from typing import Optional
 
 from sotodlib.site_pipeline.monitor import Monitor
-from sotodlib.io.load_smurf import G3tSmurf, Observations, logger as default_logger
+from sotodlib.io.load_smurf import G3tSmurf, Observations, _logger as default_logger
 
 
 def main(config: Optional[str] = None, update_delay: float = 2, 
@@ -31,13 +30,13 @@ def main(config: Optional[str] = None, update_delay: float = 2,
         overrides update_delay
     verbosity: int
         0-3, higher numbers = more printouts
-    logger: logging.logger
-        allows passing another longer to execution functions
     index_via_actions: bool
         if True, will look through action folders to create observations, this
         will be necessary for data older than Oct 2022 but creates concurancy 
         issues on systems (like the site) running automatic deletion of level 2 
         data.
+    logger: logging.logger
+        allows passing another longer to execution functions
     """
 
     show_pb = True if verbosity > 1 else False
@@ -53,8 +52,8 @@ def main(config: Optional[str] = None, update_delay: float = 2,
     elif verbosity == 3:
         logger.setLevel(logging.DEBUG)
 
-    cfgs = yaml.safe_load( open(config, "r"))
-    SMURF = G3tSmurf.from_configs(cfgs)
+    cfgs = yaml.safe_load(open(config, "r"))
+    SMURF = G3tSmurf.from_configs(cfgs, logger=logger)
 
     if from_scratch:
         logger.info("Building Database from Scratch, May take awhile")


### PR DESCRIPTION
The issue with logging in prefect is that, although prefect loggers are passed in as an argument to the flow, they didn't get passed all the way into each class that does the actual work such as G3tsmurf or Imprinter classes. This PR is a step towards fixing it. 