### PR TITLE
use joinedload instead of lazyload to speed up db queries in hk

### DIFF
--- a/sotodlib/io/g3thk_db.py
+++ b/sotodlib/io/g3thk_db.py
@@ -2,7 +2,7 @@ import sqlalchemy as db
 from sqlalchemy.exc import IntegrityError
 
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker, relationship
+from sqlalchemy.orm import sessionmaker, relationship, joinedload
 
 import os
 import yaml
@@ -521,7 +521,7 @@ class G3tHk:
         if agents.count() == 0:
             logger.warning(f"no agents found between {start} and {stop}")
 
-        agents = agents.filter(HKAgents.instance_id == instance_id).all()
+        agents = agents.filter(HKAgents.instance_id == instance_id).options(joinedload(HKAgents.fields)).all()
         return agents
 
     def get_last_update(self):


### PR DESCRIPTION
improve performance of hk agent loading by eager loading all children fields. 