### PR TITLE
Fixes float idxs for scan crossings

### DIFF
--- a/sotodlib/io/bookbinder.py
+++ b/sotodlib/io/bookbinder.py
@@ -1037,10 +1037,13 @@ def locate_scan_events(az, dy=0.001, min_gap=200, filter_window=100):
             else:
                 c_upper_enter.append(c_upper[i])
 
+    # If any empty lists are passed to concatenate, this will be cast
+    # into an array of floats instead of ints
     starts = np.sort(np.concatenate((c_lower_exit, c_upper_exit)))
     stops = np.sort(np.concatenate((c_lower_enter, c_upper_enter)))
     events = np.sort(np.concatenate((starts, stops)))
 
+    # cast back to ints just in case
     starts = starts.astype(int)
     stops = stops.astype(int)
     events = events.astype(int)

--- a/sotodlib/io/bookbinder.py
+++ b/sotodlib/io/bookbinder.py
@@ -1040,6 +1040,10 @@ def locate_scan_events(az, dy=0.001, min_gap=200, filter_window=100):
     starts = np.sort(np.concatenate((c_lower_exit, c_upper_exit)))
     stops = np.sort(np.concatenate((c_lower_enter, c_upper_enter)))
     events = np.sort(np.concatenate((starts, stops)))
+
+    starts = starts.astype(int)
+    stops = stops.astype(int)
+    events = events.astype(int)
     
     # Look for zero-crossings
     zc = []


### PR DESCRIPTION
Many books are failing with this error: 
```
2023-10-16 19:09:08,420: Preprocessing smurf obsid oper_ufm_mv19_1697142674 (INFO)
2023-10-16 19:09:08,467: Preprocessing HK Data (INFO)
Traceback (most recent call last):
  File "/so/home/jlashner/work/book_debugging/main.py", line 15, in <module>
    b.bind()
  File "/so/home/jlashner/repos/sotodlib/sotodlib/io/bookbinder.py", line 778, in bind
    self.preprocess()
  File "/so/home/jlashner/repos/sotodlib/sotodlib/io/bookbinder.py", line 634, in preprocess
    frame_splits = find_frame_splits(self.ancil)
  File "/so/home/jlashner/repos/sotodlib/sotodlib/io/bookbinder.py", line 1089, in find_frame_splits
    return block.times[idxs]
IndexError: arrays used as indices must be of integer (or boolean) type
```

After looking into it I found that these lines are resulting in float arrays instead of ints: https://github.com/simonsobs/sotodlib/blob/9f9b8afc2a2772891ed55a1790f567e9aef23b9d/sotodlib/io/bookbinder.py#L1040-L1042

In particular, this seems to be strange behavior in numpy:
```
Python 3.10.12 (main, Jul  5 2023, 18:54:27) [GCC 11.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import numpy as np
>>> x = [1, 2, 3]
>>> print(np.array(x).dtype)
int64
>>> print(np.concatenate((x, [])).dtype)
float64
```

Forcing these to be cast back into ints seems to fix the issue, and I've confirmed that books build successfully. 