### PR TITLE
ObsDb error handling for site books

### DIFF
--- a/sotodlib/io/bookbinder.py
+++ b/sotodlib/io/bookbinder.py
@@ -722,8 +722,16 @@ class BookBinder:
         meta['type'] = self.book.type
         detsets = []
         tags = []
+
+        # build detset list in same order as slots
+        meta['stream_ids'] = self.book.slots.split(',')
+        for sid in meta['stream_ids']:
+            detsets.append(
+                [obs.tunesets[0].name for _,obs in self.obsdb.items() 
+                    if obs.stream_id == sid ][0]
+            )
+        # just append all tags, order doesn't matter
         for _, g3tobs in self.obsdb.items():
-            detsets.append(g3tobs.tunesets[0].name)
             tags.append(g3tobs.tag)
         meta['detsets'] = detsets
 
@@ -761,7 +769,7 @@ class BookBinder:
         assert len(tags) > 0
         meta['subtype'] = tags[1] if len(tags) > 1 else ""
         meta['tags'] = tags[2:]
-        meta['stream_ids'] = self.book.slots.split(',')
+        
         if (self.book.type == 'oper') and self.meta_files:
             meta['meta_files'] = self.meta_files
         return meta

--- a/sotodlib/site_pipeline/update_obsdb.py
+++ b/sotodlib/site_pipeline/update_obsdb.py
@@ -91,7 +91,9 @@ def main(config:str,
         for col, typ in config_dict["obsdb_cols"].items():
             col_list.append(col+" "+typ)
         bookcartobsdb.add_obs_columns(col_list)
-
+    if "skip_bad_books" not in config_dict:
+        config_dict["skip_bad_books"] = False
+        
     #How far back we should look
     tnow = time.time()
     if recency is not None:

--- a/sotodlib/site_pipeline/update_obsdb.py
+++ b/sotodlib/site_pipeline/update_obsdb.py
@@ -98,7 +98,7 @@ def main(config:str,
         tback = tnow - recency*86400
     else:
         tback = 0 #Back to the UNIX Big Bang 
-    print(tback)
+    
     existing = bookcartobsdb.query()["obs_id"]
 
     #Find folders that are book-like and recent

--- a/sotodlib/site_pipeline/update_obsdb.py
+++ b/sotodlib/site_pipeline/update_obsdb.py
@@ -98,7 +98,7 @@ def main(config:str,
         tback = tnow - recency*86400
     else:
         tback = 0 #Back to the UNIX Big Bang 
-
+    print(tback)
     existing = bookcartobsdb.query()["obs_id"]
 
     #Find folders that are book-like and recent
@@ -116,8 +116,16 @@ def main(config:str,
 
     for bookpath in bookcart:
         if check_meta_type(bookpath) in accept_type:
-            #obsfiledb creation
-            checkbook(bookpath, config, add=True, overwrite=True)
+
+            try:
+                #obsfiledb creation
+                checkbook(bookpath, config, add=True, overwrite=True)
+            except Exception as e:
+                if config_dict["skip_bad_books"]:
+                    print(f"failed to add {bookpath}")
+                    continue
+                else:
+                    raise e
 
             index = yaml.safe_load(open(os.path.join(bookpath, "M_index.yaml"), "rb"))
             obs_id = index.pop("book_id")


### PR DESCRIPTION
This PR adds a few things 

* fixes the miss-ordering between `stream_ids` and `detsets`. which were causing the creation of a lot of weird and wrong detsets.
* adds an option in check book to ignore the requirement of this ordering being the same
* adds an option in check book to remove fixed tones from detector lists
* adds options to just skip adding failed books to an obsfiledb / obsdb. 

Using all of these, I have now obsfiledb and obsdb making running on the site uploaded books.