### PR TITLE
Separate non-res channels into separate field in G3File

### DIFF
--- a/sotodlib/io/bookbinder.py
+++ b/sotodlib/io/bookbinder.py
@@ -625,7 +625,7 @@ class SmurfStreamProcessor:
         in_offset_idxs = np.arange(len(self.times)) - offsets[self.frame_idxs]
 
         # Mask to use to separate out non-resonator signal from resonator signal
-        res_chans = np.array(['NONE' not in r for r in self.readout_ids], dtype=bool)
+        tracked_chans = np.array(['NONE' not in r for r in self.readout_ids], dtype=bool)
 
         # Handle file writers
         writer = None
@@ -743,8 +743,8 @@ class SmurfStreamProcessor:
             oframe['flag_smurfgaps'] = core.G3VectorBool(~filled)
 
             ts = core.G3VectorTime(ts * core.G3Units.s)
-            oframe['signal'] = so3g.G3SuperTimestream(self.readout_ids[res_chans], ts, data[res_chans, :])
-            oframe['non_res_signal'] = so3g.G3SuperTimestream(self.readout_ids[~res_chans], ts, data[~res_chans, :])
+            oframe['signal'] = so3g.G3SuperTimestream(self.readout_ids[tracked_chans], ts, data[tracked_chans, :])
+            oframe['untracked'] = so3g.G3SuperTimestream(self.readout_ids[~tracked_chans], ts, data[~tracked_chans, :])
             oframe['primary'] = so3g.G3SuperTimestream(self.primary_names, ts, primary)
             oframe['tes_biases'] = so3g.G3SuperTimestream(self.bias_names, ts, biases)
             oframe['stream_id'] = self.stream_id

--- a/sotodlib/io/bookbinder.py
+++ b/sotodlib/io/bookbinder.py
@@ -624,6 +624,9 @@ class SmurfStreamProcessor:
         # Sample idx within each in-frame for every input sample
         in_offset_idxs = np.arange(len(self.times)) - offsets[self.frame_idxs]
 
+        # Mask to use to separate out non-resonator signal from resonator signal
+        res_chans = np.array(['NONE' not in r for r in self.readout_ids], dtype=bool)
+
         # Handle file writers
         writer = None
         cur_file_idx = None
@@ -740,7 +743,8 @@ class SmurfStreamProcessor:
             oframe['flag_smurfgaps'] = core.G3VectorBool(~filled)
 
             ts = core.G3VectorTime(ts * core.G3Units.s)
-            oframe['signal'] = so3g.G3SuperTimestream(self.readout_ids, ts, data)
+            oframe['signal'] = so3g.G3SuperTimestream(self.readout_ids[res_chans], ts, data[res_chans, :])
+            oframe['non_res_signal'] = so3g.G3SuperTimestream(self.readout_ids[~res_chans], ts, data[~res_chans, :])
             oframe['primary'] = so3g.G3SuperTimestream(self.primary_names, ts, primary)
             oframe['tes_biases'] = so3g.G3SuperTimestream(self.bias_names, ts, biases)
             oframe['stream_id'] = self.stream_id

--- a/sotodlib/io/bookbinder.py
+++ b/sotodlib/io/bookbinder.py
@@ -626,6 +626,7 @@ class SmurfStreamProcessor:
 
         # Mask to use to separate out non-resonator signal from resonator signal
         tracked_chans = np.array(['NONE' not in r for r in self.readout_ids], dtype=bool)
+        readout_id_arr = np.array(self.readout_ids)
 
         # Handle file writers
         writer = None
@@ -743,8 +744,8 @@ class SmurfStreamProcessor:
             oframe['flag_smurfgaps'] = core.G3VectorBool(~filled)
 
             ts = core.G3VectorTime(ts * core.G3Units.s)
-            oframe['signal'] = so3g.G3SuperTimestream(self.readout_ids[tracked_chans], ts, data[tracked_chans, :])
-            oframe['untracked'] = so3g.G3SuperTimestream(self.readout_ids[~tracked_chans], ts, data[~tracked_chans, :])
+            oframe['signal'] = so3g.G3SuperTimestream(readout_id_arr[tracked_chans], ts, data[tracked_chans, :])
+            oframe['untracked'] = so3g.G3SuperTimestream(readout_id_arr[~tracked_chans], ts, data[~tracked_chans, :])
             oframe['primary'] = so3g.G3SuperTimestream(self.primary_names, ts, primary)
             oframe['tes_biases'] = so3g.G3SuperTimestream(self.bias_names, ts, biases)
             oframe['stream_id'] = self.stream_id


### PR DESCRIPTION
As we discussed today, the easiest way at the moment to resolve the discrepancy between the det-db and non-resonator channels existing in the data is to separate them from the 'signal' array in the bookbinder. This PR selects channels that don't have an associated stream-id or tunefile and puts them into a separate array instead of adding them to `signal`.

The implementation here may need to change if we change the readout_ids of fixed tones so they aren't marked with NONE.