### PR TITLE
Fix docs

### DIFF
--- a/docs/toast.rst
+++ b/docs/toast.rst
@@ -109,13 +109,13 @@ workflow functions will get their arguments exclusively from config files and
 commandline arguments.
 
 There is a large-scale simulation and reduction workflow in
-``sotodlib/workflows/so_sim.py``. This script has nearly every possible
+``sotodlib/toast/scripts/so_sim.py``. This script has nearly every possible
 operator and focuses on a typical sequence of simulating different effects and
 multiple different analyses. Different reduction paths and mapmakers can be
 selectively enabled or disabled from the commandline or config files.
 
 For processing data that already exists on disk, you can look at
-``sotodlib/workflows/so_map.py`` as an example workflow. This loads data in any
+``sotodlib/toast/scripts/so_map.py`` as an example workflow. This loads data in any
 of the supported formats and has multiple mapmaking / reduction code paths that
 can be enabled.
 

--- a/sotodlib/toast/scripts/so_convert.py
+++ b/sotodlib/toast/scripts/so_convert.py
@@ -19,11 +19,11 @@ And then writes these out to:
 
 You can see the automatically generated command line options with:
 
-    toast_so_convert.py --help
+    toast_so_convert --help
 
 Or you can dump a config file with all the default values with:
 
-    toast_so_convert.py --default_toml config.toml
+    toast_so_convert --default_toml config.toml
 
 This script contains just comments about what is going on.  For details about all the
 options for a specific Operator, see the documentation or use the help() function from

--- a/sotodlib/toast/scripts/so_map.py
+++ b/sotodlib/toast/scripts/so_map.py
@@ -16,11 +16,11 @@ running null tests, building observation matrices, etc.
 
 You can see the automatically generated command line options with:
 
-    toast_so_map.py --help
+    toast_so_map --help
 
 Or you can dump a config file with all the default values with:
 
-    toast_so_map.py --default_toml config.toml
+    toast_so_map --default_toml config.toml
 
 This script contains just comments about what is going on.  For details about all the
 options for a specific Operator, see the documentation or use the help() function from

--- a/sotodlib/toast/scripts/so_sim.py
+++ b/sotodlib/toast/scripts/so_sim.py
@@ -8,11 +8,11 @@ This script runs an SO time domain simulation.
 
 You can see the automatically generated command line options with:
 
-    toast_so_sim.py --help
+    toast_so_sim --help
 
 Or you can dump a config file with all the default values with:
 
-    toast_so_sim.py --default_toml config.toml
+    toast_so_sim --default_toml config.toml
 
 This script contains just comments about what is going on.  For details about all the
 options for a specific Operator, see the documentation or use the help() function from


### PR DESCRIPTION
- Fix example scripts path in document.
- Change `toast_so_sim.py` `toast_so_map.py` `toast_so_convert.py` to `toast_so_sim` `toast_so_map` `toast_so_convert` in example scripts. Previous ones are not in PATH.