### PR TITLE
update-obsdb: sanitize tags list (no empty strings)

### DIFF
--- a/sotodlib/io/bookbinder.py
+++ b/sotodlib/io/bookbinder.py
@@ -782,7 +782,8 @@ class BookBinder:
         # book should have at least one tag
         assert len(tags) > 0
         meta['subtype'] = tags[1] if len(tags) > 1 else ""
-        meta['tags'] = tags[2:]
+        # sanitize rest of tags
+        meta['tags'] = [t.strip() for t in tags[2:] if t.strip() != '']
         
         if (self.book.type == 'oper') and self.meta_files:
             meta['meta_files'] = self.meta_files

--- a/sotodlib/site_pipeline/update_obsdb.py
+++ b/sotodlib/site_pipeline/update_obsdb.py
@@ -233,10 +233,10 @@ def main(config:str,
                 logger.error(f"Unable to compute roll for obs_id {obs_id}")
                 pass
 
-            if tags != [] and tags != [""]:
-                bookcartobsdb.update_obs(obs_id, very_clean, tags=tags)
-            else:
-                bookcartobsdb.update_obs(obs_id, very_clean)
+            # Make sure no invalid tags before update.
+            tags = [t.strip() for t in tags if t.strip() != '']
+
+            bookcartobsdb.update_obs(obs_id, very_clean, tags=tags)
            
         else:
             bookcart.remove(bookpath)


### PR DESCRIPTION
Also removed a (now) unnecessary fork in how `update_obs` is called.