### PR TITLE
obsfiledb fix, minor metadata improvements

### DIFF
--- a/sotodlib/core/metadata/cli.py
+++ b/sotodlib/core/metadata/cli.py
@@ -48,6 +48,8 @@ def get_parser():
     sp.add_argument('--key', '-k', action='append', default=[], help=
                     'If listing observations, also include the speficied db fields '
                     'in addition to obs_id.')
+    sp.add_argument('--tag', '-t', action='append', default=[], help=
+                    'Add a tag as an eligible column for query.')
     sp.add_argument('obs_id', nargs='?')
 
     # obsfiledb
@@ -63,7 +65,7 @@ def get_parser():
     return parser
 
 
-def _set_type(args):
+def _set_type(args, parser):
     if args.type is None:
         ext = os.path.splitext(args.db_file)[1]
         if ext in ['.yaml', '.yml']:
@@ -74,6 +76,14 @@ def _set_type(args):
             parser.error(
                 f'Not sure how to decode file with extension "{ext}"; pass --type=...')
     return args.type
+
+
+def _all_tokens(args, subdelim=','):
+    # ['a', 'b,c', 'd'] -> ['a', 'b', 'c', 'd']
+    out = []
+    for a in args:
+        out.extend([_x.strip() for _x in a.split(subdelim)])
+    return out
 
 
 def main(args=None):
@@ -110,7 +120,7 @@ def main(args=None):
         print()
 
     elif args._subcmd == 'obsdb':
-        _set_type(args)
+        _set_type(args, parser)
 
         if args.type == 'context':
             ctx = context.Context(args.db_file)
@@ -121,12 +131,12 @@ def main(args=None):
         # Summary mode?
         if args.obs_id is None:
             if args.list:
-                rows = db.query(args.query)
+                tags = _all_tokens(args.tag)
+
+                rows = db.query(args.query, tags=tags)
 
                 if args.list:
-                    fields = ['obs_id']
-                    for k in args.key:
-                        fields.extend([_k.strip() for _k in k.split(',')])
+                    fields = ['obs_id'] + _all_tokens(args.key)
                     for line in rows:
                         print(' '.join([str(line[k]) for k in fields]))
             else:

--- a/sotodlib/core/metadata/loader.py
+++ b/sotodlib/core/metadata/loader.py
@@ -338,15 +338,20 @@ class SuperLoader:
         # request will be added back into this by check tags.
         aug_request = _filter_items('obs:', request, False)
         if self.obsdb is not None and 'obs:obs_id' in request:
-            obs_info = self.obsdb.get(request['obs:obs_id'], add_prefix='obs:')
-            if obs_info is not None:
-                obs_info.update(aug_request)
-                aug_request.update(obs_info)
             if dest is None:
                 dest = core.AxisManager()
             obs_man = core.AxisManager()
-            for k, v in _filter_items('obs:', obs_info).items():
-                obs_man.wrap(k, v)
+            obs_info = self.obsdb.get(request['obs:obs_id'], add_prefix='obs:')
+            if obs_info is None:
+                logger.warning(
+                    f"Observation {request['obs:obs_id']} not found in obsdb; "
+                    "trying to proceed anyway. You might have metadata failures.")
+                obs_man.wrap('obs_id', request['obs:obs_id'])
+            else:
+                obs_info.update(aug_request)
+                aug_request.update(obs_info)
+                for k, v in _filter_items('obs:', obs_info).items():
+                    obs_man.wrap(k, v)
             dest.wrap('obs_info', obs_man)
             
         def reraise(spec, e):


### PR DESCRIPTION
Major thing here is a change to obsfiledb to loosen the requirement on detector names.  Previously a detector name could belong to only one detset ... but now it can belong to more than one.  (Within a single _observation_, such overlapping detsets must not be used!)

An existing obsfiledb can be upgraded to the new format, like this:
```
  so-metadata obsfiledb  /path/to/obsfiledb.sqlite  fix-db --overwrite
```

Couple of other fixes:
- addreses half of #600 -- so-metadata obsdb can handle queries that use tags.
- makes context.get_obs a bit more permissive, if an observation is not registered in obsdb yet.  fail later!