### PR TITLE
Fix warning about astropy.units

### DIFF
--- a/sotodlib/toast/ops/sim_source.py
+++ b/sotodlib/toast/ops/sim_source.py
@@ -511,7 +511,7 @@ class SimSource(Operator):
     )
 
     source_azimuth_acceleration = Quantity(
-        u.Quantity(2, u.Unit("deg / s / s")),
+        u.Quantity(2, u.Unit("deg / s2")),
         help = 'Maximum acceleration of the drone along the azimuthal axis'
     )
 
@@ -531,7 +531,7 @@ class SimSource(Operator):
     )
 
     source_elevation_acceleration = Quantity(
-        u.Quantity(2, u.Unit("deg / s / s")),
+        u.Quantity(2, u.Unit("deg / s2")),
         help = 'Maximum acceleration of the drone along the elevation axis'
     )
 


### PR DESCRIPTION
Fix warning about unit declaration; seen on python 3.10, astropy 5.3.4.
```
>>> units('deg / s / s')
WARNING: UnitsWarning: 'deg / s / s' contains multiple slashes, which is discouraged by the FITS standard [astropy.units.format.generic]
units("deg / s2")
```