### PR TITLE
Imprinter Updates

### DIFF
--- a/sotodlib/io/bookbinder.py
+++ b/sotodlib/io/bookbinder.py
@@ -128,7 +128,7 @@ class AncilProcessor:
         self.blocks = {
             name: HKBlock(name) 
             for name in ['ACU_broadcast', 'ACU_summary_output', 
-                         'HWPEncoder_freq']
+                         'HWPEncoder_freq', 'ACU_corotator']
         }
         self.anc_frame_data = None
         self.out_files = []
@@ -195,8 +195,13 @@ class AncilProcessor:
                 block.times, 
                 block.data['Corrected_Boresight']
             )
-        if 'Corrected_Corotation' in block.data:
-            corotation = np.interp(times, block.times, block.data['Corrected_Corotation'])
+        block = self.blocks['ACU_corotator']
+        if 'Corotator_current_position' in block.data:
+            corotation = np.interp(
+                times, 
+                block.times, 
+                block.data['Corotator_current_position']
+            )
 
         anc_frame_data = []
         for oframe_idx in np.unique(frame_idxs):
@@ -225,7 +230,7 @@ class AncilProcessor:
             if boresight is not None:
                 anc_data['boresight_enc'] = core.G3VectorDouble(boresight[m])
             if corotation is not None:
-                anc_data['corotation_enc'] = core.G3VectorDouble(corotation[m])
+                anc_data['corotator_enc'] = core.G3VectorDouble(corotation[m])
             oframe['ancil'] = anc_data
             writer(oframe)
             anc_frame_data.append(anc_data)

--- a/sotodlib/io/bookbinder.py
+++ b/sotodlib/io/bookbinder.py
@@ -721,6 +721,8 @@ class BookBinder:
 
         meta = {}
         meta['book_id'] = self.book.bid
+        meta['type'] = self.book.type
+
         meta['start_time'] = float(self.times[0])
         meta['stop_time'] = float(self.times[-1])
         meta['n_frames'] = len(np.unique(self.frame_idxs))
@@ -742,7 +744,7 @@ class BookBinder:
             meta['telescope'] = self.book.tel_tube[:3].lower()
         else: 
             meta['telescope'] = telescope
-        # parse e.g., sat1 -> st1, latc1 -> c1
+
         if 'tube_slot' not in tube_config:
             self.log.warning("tube_slot key missing from tube_config. guessing")
         meta['tube_slot'] = tube_config.get(
@@ -752,7 +754,6 @@ class BookBinder:
         meta['tube_flavor'] = tube_config.get('tube_flavor')
         meta['wafer_slots'] = tube_config.get('wafer_slots')
 
-        meta['type'] = self.book.type
         detsets = []
         tags = []
 

--- a/sotodlib/io/bookbinder.py
+++ b/sotodlib/io/bookbinder.py
@@ -736,13 +736,15 @@ class BookBinder:
         meta['sample_ranges'] = sample_ranges
 
         if telescope is None:
-            log.warning("telescope not explicitly defined. guessing from book")
+            self.log.warning(
+                "telescope not explicitly defined. guessing from book"
+            )
             meta['telescope'] = self.book.tel_tube[:3].lower()
         else: 
             meta['telescope'] = telescope
         # parse e.g., sat1 -> st1, latc1 -> c1
         if 'tube_slot' not in tube_config:
-            log.warning("tube_slot key missing from tube_config. guessing")
+            self.log.warning("tube_slot key missing from tube_config. guessing")
         meta['tube_slot'] = tube_config.get(
             'tube_slot',
             self.book.tel_tube.lower().replace("sat","satst")[3:]

--- a/sotodlib/io/bookbinder.py
+++ b/sotodlib/io/bookbinder.py
@@ -713,7 +713,7 @@ class BookBinder:
 
         self.meta_files = meta_files
 
-    def get_metadata(self):
+    def get_metadata(self, telescope=None, tube_config={}):
         """
         Returns metadata dict for the book
         """
@@ -735,9 +735,18 @@ class BookBinder:
             sample_ranges.append([i0, i1+1])
         meta['sample_ranges'] = sample_ranges
 
-        meta['telescope'] = self.book.tel_tube[:3].lower()
+        if telescope is None:
+            meta['telescope'] = self.book.tel_tube[:3].lower()
+        else: 
+            meta['telescope'] = telescope
         # parse e.g., sat1 -> st1, latc1 -> c1
-        meta['tube_slot'] = self.book.tel_tube.lower().replace("sat","satst")[3:]
+        meta['tube_slot'] = tube_config.get(
+            'tube_slot',
+            self.book.tel_tube.lower().replace("sat","satst")[3:]
+        )
+        meta['tube_flavor'] = tube_config.get('tube_flavor')
+        meta['wafer_slots'] = tube_config.get('wafer_slots')
+
         meta['type'] = self.book.type
         detsets = []
         tags = []

--- a/sotodlib/io/bookbinder.py
+++ b/sotodlib/io/bookbinder.py
@@ -736,10 +736,13 @@ class BookBinder:
         meta['sample_ranges'] = sample_ranges
 
         if telescope is None:
+            log.warning("telescope not explicitly defined. guessing from book")
             meta['telescope'] = self.book.tel_tube[:3].lower()
         else: 
             meta['telescope'] = telescope
         # parse e.g., sat1 -> st1, latc1 -> c1
+        if 'tube_slot' not in tube_config:
+            log.warning("tube_slot key missing from tube_config. guessing")
         meta['tube_slot'] = tube_config.get(
             'tube_slot',
             self.book.tel_tube.lower().replace("sat","satst")[3:]

--- a/sotodlib/io/imprinter.py
+++ b/sotodlib/io/imprinter.py
@@ -165,14 +165,23 @@ class Imprinter:
 
           tel_tubes:
             tel_tube1:
-              slots:
-                - stream_id1
-                - stream_id2
-                - stream_id3
+              tube_slot: c0
+              wafer_slots:
+                - wafer_slot: ws0
+                  stream_id: stream_id0
+                - wafer_slot: ws1
+                  stream_id: stream_id1
+                - wafer_slot: ws2
+                  stream_id: stream_id12
             tel_tube2:
-              slots:
-                - stream_id4
-                - stream_id5
+              tube_slot: i1
+              wafer_slots:
+                - wafer_slot: ws0
+                  stream_id: stream_id3
+                - wafer_slot: ws1
+                  stream_id: stream_id4
+                - wafer_slot: ws2
+                  stream_id: None
           
         Standard Book directory structure based off config file example:
         output_root/
@@ -188,9 +197,12 @@ class Imprinter:
                 hk/
         
         The tel_tubes entry lists the different tel-tubes that will be bound
-        into separate books containing only the stream_ids listed under slots.
-        For the SATs we expect one entry under tel_tubes but the LAT will have
-        many. TODO: There is currently no option to have an empty slot. 
+        into separate books. Each tel_tube entry is expected to have a tube_slot
+        name and is required to have a wafer_slots list. Each wafer slot must
+        have a wafer_slot and stream_id entry. If stream_id is None then it will
+        be treated as an empty slot. The wafers/stream_ids listed in each
+        tel_tube are bound together. For the SATs we expect one entry under 
+        tel_tubes but the LAT will have many.
         
         The build_det_data and build_hk entries determines if detector books
         (obs,oper,smurf,stray) and housekeeping (hk) books should be made,
@@ -218,7 +230,32 @@ class Imprinter:
         self.build_hk = self.config.get("build_hk")
         self.build_det = self.config.get("build_det")
 
-        self.tubes = self.config.get("tel_tubes", {})
+        self.logger = logger
+        if logger is None:
+            self.logger = logging.getLogger("imprinter")
+            if not self.logger.hasHandlers():
+                self.logger = init_logger("imprinter")
+
+        self.tube_configs = self.config.get("tel_tubes", {})
+        self.tubes = dict()
+        for tube, cfg in self.tube_configs.items():
+            self.tubes[tube] = dict()
+            self.tubes[tube]['slots'] = list()
+            if 'wafer_slots' not in self.tube_configs[tube]:
+                if 'slots' in self.tube_configs[tube]:
+                    self.tubes[tube]['slots'] = self.tube_configs[tube]['slots']
+                    self.logger.warning(f"Tube {tube} missing wafer_slots "
+                    "entry. Are you using an old configuration format?")
+                    continue
+                
+            for slot in self.tube_configs[tube]['wafer_slots']:
+                if slot['stream_id'].lower() == 'none':
+                    self.tubes[tube]['slots'].append(
+                        f"NONE_{slot['wafer_slot']}"
+                    )
+                else:
+                    self.tubes[tube]['slots'].append(slot['stream_id'])
+                                        
 
         # check whether db_path directory exists
         if not op.exists(op.dirname(self.db_path)):
@@ -235,11 +272,7 @@ class Imprinter:
         self.hk_archive = None
         self.librarian = None
 
-        self.logger = logger
-        if logger is None:
-            self.logger = logging.getLogger("imprinter")
-            if not self.logger.hasHandlers():
-                self.logger = init_logger("imprinter")
+        
 
     def get_session(self):
         """Get a new session or return the existing one
@@ -730,7 +763,13 @@ class Imprinter:
             # write M_index file
             mfile = os.path.join(binder.outdir, "M_index.yaml")
             with open(mfile, "w") as f:
-                yaml.dump(binder.get_metadata(), f)
+                yaml.dump(
+                    binder.get_metadata(
+                        telescope=self.daq_node,
+                        tube_config = self.tube_configs[book.tel_tube],
+                    ), 
+                    f
+                )
 
             book.path = op.abspath(binder.outdir)
 

--- a/sotodlib/io/imprinter.py
+++ b/sotodlib/io/imprinter.py
@@ -741,6 +741,8 @@ class Imprinter:
                 book, 
                 ignore_tags=ignore_tags,
             )
+            book.path = op.abspath(binder.outdir)
+
             binder.bind(pbar=pbar)
 
             # write M_book file
@@ -761,17 +763,18 @@ class Imprinter:
                 yaml.dump(book_meta, f)
 
             # write M_index file
+            if book.type in ['obs', 'oper']:
+                tc = self.tube_configs[book.tel_tube]
+            else:
+                tc = {}
             mfile = os.path.join(binder.outdir, "M_index.yaml")
             with open(mfile, "w") as f:
                 yaml.dump(
                     binder.get_metadata(
                         telescope=self.daq_node,
-                        tube_config = self.tube_configs[book.tel_tube],
-                    ), 
-                    f
+                        tube_config = tc,
+                    ), f
                 )
-
-            book.path = op.abspath(binder.outdir)
 
             if book.type in ['obs', 'oper']:
                 # check that detectors books were written out correctly

--- a/sotodlib/io/imprinter.py
+++ b/sotodlib/io/imprinter.py
@@ -172,7 +172,7 @@ class Imprinter:
                 - wafer_slot: ws1
                   stream_id: stream_id1
                 - wafer_slot: ws2
-                  stream_id: stream_id12
+                  stream_id: stream_id2
             tel_tube2:
               tube_slot: i1
               wafer_slots:

--- a/sotodlib/io/imprinter.py
+++ b/sotodlib/io/imprinter.py
@@ -1122,8 +1122,10 @@ class Imprinter:
             G3tObservations.timestamp >= min_ctime,
             G3tObservations.timestamp <= max_ctime,
             stream_filt,
-            G3tObservations.stop == None,
-            G3tObservations.stop >= dt.datetime.utcfromtimestamp(max_ctime),
+            or_(
+                G3tObservations.stop == None,
+                G3tObservations.stop >= dt.datetime.utcfromtimestamp(max_ctime),
+            ),
         )
         # if we have incomplete observations in our stream_id list we cannot
         # bookbind any observations overlapping the incomplete ones.

--- a/sotodlib/io/imprinter.py
+++ b/sotodlib/io/imprinter.py
@@ -619,13 +619,13 @@ class Imprinter:
                     self.indir = indir
                     self.outdir = outdir
 
-                def get_metadata(self):
+                def get_metadata(self, telescope=None, tube_config={}):
                     return {
                         "book_id": book.bid,
                         # dummy start and stop times
                         "start_time": float(first5) * 1e5,
                         "stop_time": (float(first5) + 1) * 1e5,
-                        "telescope": book.tel_tube.lower(),
+                        "telescope": telescope,
                         "type": book.type,
                     }
 
@@ -661,13 +661,13 @@ class Imprinter:
                     self.outdir = outdir
                     self.file_list = file_list
 
-                def get_metadata(self):
+                def get_metadata(self, telescope=None, tube_config={}):
                     return {
                         "book_id": book.bid,
                         # dummy start and stop times
                         "start_time": float(first5) * 1e5,
                         "stop_time": (float(first5) + 1) * 1e5,
-                        "telescope": book.tel_tube.lower(),
+                        "telescope": telescope,
                         "type": book.type,
                     }
 

--- a/sotodlib/io/imprinter.py
+++ b/sotodlib/io/imprinter.py
@@ -1123,6 +1123,7 @@ class Imprinter:
             G3tObservations.timestamp <= max_ctime,
             stream_filt,
             G3tObservations.stop == None,
+            G3tObservations.stop >= dt.datetime.utcfromtimestamp(max_ctime),
         )
         # if we have incomplete observations in our stream_id list we cannot
         # bookbind any observations overlapping the incomplete ones.

--- a/sotodlib/io/imprinter_cli.py
+++ b/sotodlib/io/imprinter_cli.py
@@ -1,0 +1,86 @@
+import os
+import argparse
+from typing import Optional
+
+from sotodlib.io.imprinter import Imprinter, Books
+import sotodlib.io.imprinter_utils as utils
+
+def main(
+        imprint_config:str, 
+        action:str, 
+        g3_config:Optional[str]=None,
+        output_root:Optional[str]=None
+    ):
+    print("You must be running this from an account with write permissions to"
+         " the database and the book write directory.")
+    
+    imprint = Imprinter(imprint_config)
+    ## overrides that often happen because running inside and outside dockers
+    if output_root is not None:
+        if not os.path.exists(output_root):
+            raise ValueError(f"Output root {output_root} does not exist")
+        imprint.output_root = output_root
+    if g3_config is not None:
+        if not os.path.exists(g3_config):
+            raise ValueError(f"G3tSmurf config file {g3_config} does not exist")
+        imprint.g3tsmurf_config = g3_config
+
+    if action == 'failed':
+        check_failed_books(imprint)
+    elif action == 'timecodes':
+        raise NotImplementedError
+    else:
+        raise ValueError("Chosen action must be 'failed' or 'timecodes'")
+
+def check_failed_books(imprint:Imprinter):
+    fail_list = imprint.get_failed_books()
+    for book in fail_list:
+        print(
+            f"Book ID: {book.bid}\n"
+            f"Failed with message:\n"
+            f"{book.message}"
+        )
+        resp = None
+        while resp is None:
+            resp = input(
+                "Possible Actions to Take: "
+                "\n\t1. Retry Binding"
+                "\n\t2. Permanently Skip Binding"
+                "\n\t3. Do Nothing"
+                "\nInput Response: "
+            )
+            try: 
+                resp = int(resp)
+            except:
+                print(f"Invalid Response {resp}")
+                resp=None
+            if resp is None or resp < 1 or resp > 3:
+                print(f"Invalid Response {resp}")
+                resp=None
+        print(f"You selected {resp}")
+        if resp == 1:
+            utils.set_book_rebind(imprint, book)
+        elif resp == 2:
+            utils.set_book_wont_bind(imprint, book)
+        elif resp == 3:
+            pass
+        else:
+            raise ValueError("how did I get here?")
+
+def get_parser(parser=None):
+    if parser is None:
+        parser = argparse.ArgumentParser()
+    parser.add_argument("--imprint-config", help="Imprinter config file",
+        type=str, required=True)
+    parser.add_argument("--action", help=" 'failed' or 'timecodes' ",
+        type=str, required=True)
+    parser.add_argument("--g3-config", help="G3tSmurf config file",
+        type=str)
+    parser.add_argument("--output-root", help="Overide imprinter output root?",
+        type=str)
+    return parser
+
+if __name__ == '__main__':
+    parser = get_parser(parser=None)
+    args = parser.parse_args()
+    main(**vars(args))

--- a/sotodlib/io/imprinter_utils.py
+++ b/sotodlib/io/imprinter_utils.py
@@ -6,6 +6,8 @@ from sqlalchemy import or_
 import datetime as dt
 import os
 import os.path as op
+import shutil
+
 
 from sotodlib.io.imprinter import ( 
     Books,
@@ -75,11 +77,11 @@ def set_book_rebind(imprint, book):
         binder = None
     if binder is not None:
         book_dir = op.abspath(binder.outdir)
-        print(f"Removing all files from {book_dir}")
-        os.removedirs(book_dir)
+        if op.exists(book_dir):
+            print(f"Removing all files from {book_dir}")
+            shutil.rmtree(book_dir)
     book.status = 0
     imprint.get_session().commit()
-
 
     
 def get_timecode_final(imprint, time_code, type='all'):


### PR DESCRIPTION
Should be solving all of #602  and #578

* Adds corotator positions into the LAT books. (doesn't solve the larger "why is the bookbinder hardcoding those fields?" question but good enough for now). 
* Adds ability for imprinter to deal with an empty wafer slot in an optics tube
* Accepts more info from the imprinter configuration file and adds the wafer slot info into the `M_index.yaml` file. I've left this backward compatible since this is probably be a slow roll-out on the site config pieces.

All of these have been tested on site data. Example new index file: 
```
az_speed_mean: 1.4717079588791546
az_speed_stdev: 0.16743276067991805
book_id: obs_1700036552_satp1_1111111
detsets:
- ufm_mv19_1699368806_tune
- ufm_mv18_1699303578_tune
- ufm_mv22_1699294049_tune
- ufm_mv29_1699293235_tune
- ufm_mv7_1699291060_tune
- ufm_mv9_1699291790_tune
- ufm_mv15_1699290944_tune
hwp_freq_mean: null
hwp_freq_stdev: null
n_frames: 136
n_samples: 750704
sample_ranges:
- - 0
  - 138415
- - 138415
  - 273615
- - 273615
  - 414447
- - 414447
  - 549647
- - 549647
  - 690481
- - 690481
  - 750704
session_id: '1700036552'
start_time: 1700036564.5227563
stop_time: 1700040318.0377562
stream_ids:
- ufm_mv19
- ufm_mv18
- ufm_mv22
- ufm_mv29
- ufm_mv7
- ufm_mv9
- ufm_mv15
subtype: cmb
tags:
- 55-95
telescope: satp1
tube_flavor: mf
tube_slot: st1
type: obs
wafer_slots:
- stream_id: ufm_mv19
  wafer_flavor: mf
  wafer_slot: ws0
- stream_id: ufm_mv18
  wafer_flavor: mf
  wafer_slot: ws1
- stream_id: ufm_mv22
  wafer_flavor: mf
  wafer_slot: ws2
- stream_id: ufm_mv29
  wafer_flavor: mf
  wafer_slot: ws3
- stream_id: ufm_mv7
  wafer_flavor: mf
  wafer_slot: ws4
- stream_id: ufm_mv9
  wafer_flavor: mf
  wafer_slot: ws5
- stream_id: ufm_mv15
  wafer_flavor: mf
  wafer_slot: ws6

```