### PR TITLE
Add detector calibration info to update_caldb script

### DIFF
--- a/docs/site_pipeline.rst
+++ b/docs/site_pipeline.rst
@@ -107,7 +107,13 @@ Module Docs
 .. automodule:: sotodlib.site_pipeline.update_smurf_caldbs
    :no-members:
   
-The calibration info described below is used to populate the calibration db:
+The calibration info described below is used to populate the calibration db.
+For more information on how calibration info is computed in sodetlib, checkout
+the following docs and source code:
+
+- `Bias step docs <https://sodetlib.readthedocs.io/en/latest/operations/bias_steps.html>`_
+- `IV docs <https://sodetlib.readthedocs.io/en/latest/operations/iv.html>`_
+- `sodetlib source code <https://github.com/simonsobs/sodetlib>`_
 
 .. autoclass:: sotodlib.site_pipeline.update_smurf_caldbs.CalInfo
    :no-members:

--- a/docs/site_pipeline.rst
+++ b/docs/site_pipeline.rst
@@ -97,6 +97,28 @@ Module documentation
    :members:
    :undoc-members:
 
+update-smurf-caldbs
+-----------------------
+This update script is used to add detset and calibration metadata to manifest
+dbs
+
+Module Docs
+`````````````````````````
+.. automodule:: sotodlib.site_pipeline.update_smurf_caldbs
+   :no-members:
+  
+The calibration info described below is used to populate the calibration db:
+
+.. autoclass:: sotodlib.site_pipeline.update_smurf_caldbs.CalInfo
+   :no-members:
+
+Command line arguments
+`````````````````````````
+.. argparse::
+   :module: sotodlib.site_pipeline.update_smurf_caldbs
+   :func: get_parser
+   :prog: update_smurf_caldbs.py
+
 Detector and Readout ID Mapping
 -------------------------------
 

--- a/sotodlib/core/metadata/obsfiledb.py
+++ b/sotodlib/core/metadata/obsfiledb.py
@@ -229,6 +229,13 @@ class ObsFileDb:
         """
         c = self.conn.execute('select distinct obs_id from files')
         return [r[0] for r in c]
+    
+    def get_obs_with_detset(self, detset):
+        """Returns a list of all obs_ids that include a specified detset"""
+        c =self.conn.execute(
+            f"select distinct obs_id from files where detset='{detset}'"
+        )
+        return [r[0] for r in c]
 
     def get_detsets(self, obs_id):
         """Returns a list of all detsets represented in the observation

--- a/sotodlib/core/metadata/obsfiledb.py
+++ b/sotodlib/core/metadata/obsfiledb.py
@@ -232,7 +232,7 @@ class ObsFileDb:
     
     def get_obs_with_detset(self, detset):
         """Returns a list of all obs_ids that include a specified detset"""
-        c =self.conn.execute(
+        c = self.conn.execute(
             f"select distinct obs_id from files where detset='{detset}'"
         )
         return [r[0] for r in c]

--- a/sotodlib/io/load_book.py
+++ b/sotodlib/io/load_book.py
@@ -194,6 +194,30 @@ def load_book_file(filename, dets=None, samples=None, no_signal=False):
                             no_signal=no_signal)
 
 
+def load_smurf_npy_data(ctx, obs_id, substr):
+    """
+    Loads an sodetlib npy file from Z_smurf archive of book.
+
+    Args
+    _____
+    obs_id: str
+        obs-id of book to load file from
+    substr: str
+        substring to use to find numpy file in Z_smurf
+    """
+    files = ctx.obsfiledb.get_files(obs_id)
+    book_dir = os.path.dirname(list(files.values())[0][0][0])
+    smurf_dir = os.path.join(book_dir, 'Z_smurf')
+    for f in os.listdir(smurf_dir):
+        if substr in f:
+            fpath = os.path.join(smurf_dir, f)
+            break
+    else:
+        raise FileNotFoundError("Could not find npy file")
+    res = np.load(fpath, allow_pickle=True).item()
+    return res
+
+
 def _load_book_detset(files, prefix='', load_ancil=True,
                       dets=None, samples=None, no_signal=False,
                       signal_buffer=None):

--- a/sotodlib/io/load_book.py
+++ b/sotodlib/io/load_book.py
@@ -769,4 +769,53 @@ def _frames_iterator(files, prefix, samples, smurf_proc=None):
             # Alternately, use frame['sample_range']
 
 
+def get_cal_obsids(ctx, obs_id, cal_type):
+    """
+    Returns set of obs-ids corresponding to the most recent calibration
+    operations for a given obsid.
+
+    Args
+    ------
+    ctx: core.Context
+        Context object
+    obs_id: str
+        obs_id for which you want to get relevant calibration info
+    cal_type: str
+        Calibration subtype to use in the obsdb query. For example: 'iv' or
+        'bias_steps'.
+
+    Returns
+    ----------
+        obs_ids: dict
+            Dict of obs_ids for each detset in specified operation
+    """
+    obs = ctx.obsdb.query(f"obs_id == '{obs_id}'")[0]
+    detsets = ctx.obsfiledb.get_detsets(obs_id)
+    min_ct = obs['start_time'] - 3600*24*7
+    cal_all = ctx.obsdb.query(
+        f"""
+        start_time <= {obs['start_time']} and subtype=='{cal_type}'
+        and start_time > {min_ct}
+        """, sort=['start_time']
+    )[::-1]
+
+    obs_ids = {
+        ds: None for ds in detsets
+    }
+    ids_to_find = len(obs_ids)
+    ids_found = 0
+
+    for o in cal_all:
+        dsets = ctx.obsfiledb.get_files(o['obs_id']).keys()
+        for ds in dsets:
+            if ds in obs_ids:
+                if obs_ids[ds] is None:
+                    obs_ids[ds] = o['obs_id']
+                    ids_found += 1
+        if ids_to_find == ids_found:
+            break
+
+    return obs_ids
+
+
 core.OBSLOADER_REGISTRY['obs-book'] = load_obs_book

--- a/sotodlib/site_pipeline/update_smurf_caldbs.py
+++ b/sotodlib/site_pipeline/update_smurf_caldbs.py
@@ -238,8 +238,6 @@ def get_cal_resset(ctx: core.Context, obs_id):
             if rtm_bit_to_volt is None:
                 rtm_bit_to_volt = ivas[dset]['meta']['rtm_bit_to_volt']
 
-
-
     bias_step_obsids = get_cal_obsids(ctx, obs_id, 'bias_steps')
     bsas = {dset: None for dset in bias_step_obsids}
     for dset, oid in bias_step_obsids.items():
@@ -249,8 +247,6 @@ def get_cal_resset(ctx: core.Context, obs_id):
                 rtm_bit_to_volt = bsas[dset]['meta']['rtm_bit_to_volt']
 
     rtm_bit_to_volt = DEFAULT_RTM_BIT_TO_VOLT
-
-
 
     # Add IV info
     for i, cal in enumerate(cals):

--- a/sotodlib/site_pipeline/update_smurf_caldbs.py
+++ b/sotodlib/site_pipeline/update_smurf_caldbs.py
@@ -77,7 +77,7 @@ def smurf_detset_info(config: Union[str, dict],
     ctx = core.Context(config['context'])
 
 
-    if not os.path.exists(config['archive']['index']):
+    if not os.path.exists(config['archive']['detset']['index']):
         scheme = core.metadata.ManifestScheme()
         scheme.add_exact_match('dets:detset')
         scheme.add_data_field('dataset')
@@ -424,7 +424,10 @@ def update_det_caldb(ctx, idx_path, detset_idx, h5_path, logger=None,
         }, filename=h5_path, replace=overwrite)
 
 
-def run_update_det_caldb(config, logger=None, format_exc=False, show_pb=False, overwrite=False):
+def run_update_det_caldb(config_path, logger=None, format_exc=False, show_pb=False, overwrite=False):
+    with open(config_path, 'r') as f:
+        config = yaml.safe_load(f)
+
     ctx = core.Context(config['context'])
     update_det_caldb(
         ctx, 

--- a/sotodlib/site_pipeline/update_smurf_caldbs.py
+++ b/sotodlib/site_pipeline/update_smurf_caldbs.py
@@ -8,19 +8,29 @@ Configuration file required:
 config = {
     'context': 'context.yaml',
     'archive': {
-        'index': 'manifest.sqlite',
-        'h5file': 'manifest.h5'
+        'detset': {
+            'index': 'manifest.sqlite',
+            'h5file': 'manifest.h5'
+        },
+        'det_cal': {
+            'index': 'det_cal.sqlite',
+            'h5file': 'det_cal.h5
+        },
     },
     'g3tsmurf': g3tsmurf_hwp_config.yaml',
     'imprinter': imprinter.yaml,
 }
 """
 
+import traceback
 import os
 import argparse
 import yaml
+from dataclasses import dataclass, astuple
+import numpy as np
+from tqdm.auto import tqdm
 
-from typing import Optional
+from typing import Optional, List
 
 from sotodlib import core
 from sotodlib.io.metadata import write_dataset
@@ -28,12 +38,16 @@ from sotodlib.io.load_smurf import G3tSmurf, TuneSets
 from sotodlib.io.imprinter import Imprinter
 import sotodlib.site_pipeline.util as sp_util
 
+# stolen  from pysmurf, max bias volt / num_bits
+DEFAULT_RTM_BIT_TO_VOLT = 10 / 2**19
+
 default_logger = sp_util.init_logger("smurf_caldbs")
 
 def main(config:str | dict, 
         overwrite:Optional[bool]=False,
         logger=None):
     smurf_detset_info(config, overwrite, logger)
+    run_update_det_caldb(config, log=logger)
 
 def smurf_detset_info(config:str | dict, 
         overwrite:Optional[bool]=False,
@@ -60,12 +74,12 @@ def smurf_detset_info(config:str | dict,
         scheme.add_exact_match('dets:detset')
         scheme.add_data_field('dataset')
         db = core.metadata.ManifestDb( 
-            config['archive']['index'], 
+            config['archive']['detset']['index'], 
             scheme=scheme
         )
     else:
         db = core.metadata.ManifestDb( 
-            config['archive']['index'],
+            config['archive']['detset']['index'],
         )
 
     keys = [
@@ -109,7 +123,7 @@ def smurf_detset_info(config:str | dict,
             })
         write_dataset(
             det_rs, 
-            config['archive']['h5file'], 
+            config['archive']['detset']['h5file'], 
             ts.name, 
             overwrite,
         )
@@ -117,7 +131,248 @@ def smurf_detset_info(config:str | dict,
         if ts.name not in added_detsets:
             db_data = {'dets:detset': ts.name,
                     'dataset': ts.name}
-            db.add_entry(db_data, config['archive']['h5file'])
+            db.add_entry(db_data, config['archive']['detset']['h5file'])
+
+
+def get_cal_obsids(ctx, obs_id, cal_type):
+    """
+    Returns set of obs-ids corresponding to the most recent calibration
+    operations for a given obsid:
+
+    Returns
+    ----------
+        obs_ids: dict
+            Dict of obs_ids for each detset in specified operation
+    """
+    obs = ctx.obsdb.query(f"obs_id == '{obs_id}'")[0]
+    detsets = ctx.obsfiledb.get_detsets(obs_id)
+    min_ct = obs['start_time'] - 3600*24*7
+    cal_all = ctx.obsdb.query(
+        f"""
+        start_time <= {obs['start_time']} and subtype=='{cal_type}'
+        and start_time > {min_ct}
+        """, sort=['start_time']
+    )[::-1]
+
+    obs_ids = {
+        ds: None for ds in detsets
+    }
+
+    for o in cal_all:
+        dsets = ctx.obsfiledb.get_files(o['obs_id']).keys()
+        for ds in dsets:
+            if ds in obs_ids:
+                if obs_ids[ds] is None:
+                    obs_ids[ds] = o['obs_id']
+
+    return obs_ids
+
+# Dtype for calibration set
+cal_dtype = [
+    ('dets:readout_id', '<U40'),
+    ('dets:cal.r_tes', float),
+    ('dets:cal.r_frac', float),
+    ('dets:cal.p_bias', float),
+    ('dets:cal.s_i', float),
+    ('dets:cal.bg', int),
+    ('dets:cal.bg_polarity', int),
+    ('dets:cal.r_n', float),
+    ('dets:cal.p_sat', float),
+]
+
+@dataclass
+class CalInfo:
+    # Fields must be ordered like cal_dtype!
+    readout_id: str = ''
+
+    # From bias steps
+    r_tes: float = np.nan   # Ohm
+    r_frac: float = np.nan
+    p_bias: float = np.nan  # J
+    s_i: float = np.nan     # 1/V
+
+    # From IV
+    bg: int = -1
+    polarity: int = 1
+    r_n: float = np.nan  
+    p_sat: float = np.nan   # J
+
+
+def _load_smurf_npy(obs_id, substr):
+    """
+    Loads npy file from Z_smurf archive of book.
+
+    Args
+    _____
+    obs_id: str
+        obs-id of book to load file from
+    substr: str
+        substring to use to find numpy file in Z_smurf
+    """
+    files = ctx.obsfiledb.get_files(obs_id)
+    book_dir = os.path.dirname(list(files.values())[0][0][0])
+    smurf_dir = os.path.join(book_dir, 'Z_smurf')
+    for f in os.listdir(smurf_dir):
+        if substr in f:
+            fpath = os.path.join(smurf_dir, f)
+            break
+    else:
+        raise FileNotFoundError("Could not find npy file")
+    res = np.load(fpath, allow_pickle=True).item()
+    return res
+
+
+def get_cal_resset(ctx: core.Context, obs_id):
+    """Returns calibration ResultSet for a given ObsId"""
+    am = ctx.get_obs(obs_id, samples=(0, 1), ignore_missing=True)
+
+    cals = [CalInfo(rid) for rid in am.det_info.readout_id]
+
+    iv_obsids = get_cal_obsids(ctx, obs_id, 'iv')
+
+    rtm_bit_to_volt = None
+    ivas = {dset: None for dset in iv_obsids}
+    for dset, oid in iv_obsids.items():
+        if oid is not None:
+            ivas[dset] = _load_smurf_npy(oid, 'iv')
+            if rtm_bit_to_volt is None:
+                rtm_bit_to_volt = ivas[dset]['meta']['rtm_bit_to_volt']
+
+
+
+    bias_step_obsids = get_cal_obsids(ctx, obs_id, 'bias_steps')
+    bsas = {dset: None for dset in bias_step_obsids}
+    for dset, oid in bias_step_obsids.items():
+        if oid is not None:
+            bsas[dset] = _load_smurf_npy(oid, 'bias_step_analysis')
+            if rtm_bit_to_volt is None:
+                rtm_bit_to_volt = bsas[dset]['meta']['rtm_bit_to_volt']
+
+    rtm_bit_to_volt = DEFAULT_RTM_BIT_TO_VOLT
+
+
+
+    # Add IV info
+    for i, cal in enumerate(cals):
+        band = am.det_info.smurf.band[i]
+        chan = am.det_info.smurf.channel[i]
+        detset = am.det_info.detset[i]
+        iva = ivas[detset]
+
+        if iva is None: # No IV analysis for this detset
+            continue
+
+        ridx = np.where(
+            (iva['bands'] == band) & (iva['channels'] == chan)
+        )[0]
+        if not ridx: # Channel doesn't exist in IV analysis
+            continue
+
+        ridx = ridx[0]
+        cal.bg = iva['bgmap'][ridx]
+        cal.polarity = iva['polarity'][ridx]
+        cal.r_n = iva['R_n'][ridx]
+        cal.p_sat = iva['p_sat'][ridx]
+    
+    obs_biases = dict(zip(am.bias_lines.vals, am.biases[:, 0] * 2*rtm_bit_to_volt))
+    for i, cal in enumerate(cals):
+        band = am.det_info.smurf.band[i]
+        chan = am.det_info.smurf.channel[i]
+        detset = am.det_info.detset[i]
+        stream_id = am.det_info.stream_id[i]
+        bg = cal.bg
+        bsa = bsas[detset]
+
+        if bsa is None or bg == -1:
+            continue
+
+        bl_label = f'{stream_id}_b{bg:0>2}'
+        # If observation bias differs from bias-steps by more than 0.1 V,
+        # don't include bias step calibration info
+        if np.abs(obs_biases[bl_label] - bsa['Vbias'][bg]) > 0.1:
+            continue
+
+        ridx = np.where(
+            (bsa['bands'] == band) & (bsa['channels'] == chan)
+        )[0]
+        if not ridx: # Channel doesn't exist in bias step analysis
+            continue
+
+        ridx = ridx[0]
+        cal.r_tes = bsa['R0'][ridx]
+        cal.r_frac = bsa['Rfrac'][ridx]
+        cal.p_bias = bsa['Pj'][ridx]
+        cal.s_i = bsa['Si'][ridx]
+
+    rset = core.metadata.ResultSet.from_friend(np.array(
+        [astuple(c) for c in cals], dtype=cal_dtype
+    ))
+    return rset
+
+
+def get_obs_with_detsets(ctx, detset_idx):
+    """Gets all observations with detset data"""
+    db = core.metadata.ManifestDb(detset_idx)
+    detsets = db.get_entries(['dataset'])['dataset']
+
+    obs_ids = set()
+    for dset in detsets:
+        cur = ctx.obsfiledb.conn.execute(
+            f"select distinct obs_id from files where detset='{dset}'"
+        )
+        obs_ids = obs_ids.union({r[0] for r in cur})
+    return obs_ids
+
+
+def update_det_caldb(ctx, idx_path, detset_idx, h5_path, log=None, 
+                     show_pb=False, format_exc=False):
+    if log is None:
+        log = default_logger
+
+    if not os.path.exists(idx_path):
+        scheme = core.metadata.ManifestScheme()
+        scheme.add_exact_match('obs:obs_id')
+        scheme.add_data_field('dataset')
+        db = core.metadata.ManifestDb(scheme=scheme)
+        db.to_file(idx_path)
+    db = core.metadata.ManifestDb(idx_path)
+    
+    # detset_db = metadata.Manifest(detset_idx)
+    existing_obsids = db.get_entries(['dataset'])['dataset']
+    all_obsids = get_obs_with_detsets(ctx, detset_idx)
+    remaining_obsids = \
+        sorted(list(set(all_obsids) - set(existing_obsids)),
+            key=(lambda s: s.split('_')[1]))
+    
+    log.info(f"{len(remaining_obsids)} bias step datasets to add.....")
+    for obs_id in tqdm(remaining_obsids, disable=(not show_pb)):
+        try:
+            rset = get_cal_resset(ctx, obs_id)
+        except Exception as e:
+            log.error(f"Failed on {obs_id}: {e}")
+            if format_exc:
+                log.error(traceback.format_exc())
+            continue
+        
+        log.info(f"Writing metadata for {obs_id}")
+        write_dataset(rset, h5_path, obs_id, overwrite=True)
+        db.add_entry({
+            'obs:obs_id': obs_id,
+            'dataset': obs_id,
+        }, filename=h5_path,)
+
+
+def run_update_det_caldb(config, log=None):
+    ctx = core.Context(config['context'])
+    update_det_caldb(
+        ctx, 
+        config['archive']['det_cal']['index'],
+        config['archive']['detset']['index'],
+        config['archive']['det_cal']['h5file'],
+        show_pb=False,
+        log=log
+    )
+
 
 def get_parser(parser=None):
     if parser is None:

--- a/sotodlib/site_pipeline/update_smurf_caldbs.py
+++ b/sotodlib/site_pipeline/update_smurf_caldbs.py
@@ -175,6 +175,8 @@ def get_cal_obsids(ctx, obs_id, cal_type):
     obs_ids = {
         ds: None for ds in detsets
     }
+    ids_to_find = len(obs_ids)
+    ids_found = 0
 
     for o in cal_all:
         dsets = ctx.obsfiledb.get_files(o['obs_id']).keys()
@@ -182,6 +184,9 @@ def get_cal_obsids(ctx, obs_id, cal_type):
             if ds in obs_ids:
                 if obs_ids[ds] is None:
                     obs_ids[ds] = o['obs_id']
+                    ids_found += 1
+        if ids_to_find == ids_found:
+            break
 
     return obs_ids
 


### PR DESCRIPTION
This update adds a new function to the `update_smurf_caldbs` script that will write detector calibration info pulled from sodetlib IVs and bias steps to a Manifestdb + hdf5 archive. I have run this and tested in my home directory on a subset of the full observation list. I think it should take ~ an hour or so to run completely, so we may want to run directly as the pipeline user before adding to prefect, so we don't have a massive hour-long operation.