### PR TITLE
G3thwp: debug packet drop filling to make it compatible with reference slot filling.

### DIFF
--- a/sotodlib/hwp/g3thwp.py
+++ b/sotodlib/hwp/g3thwp.py
@@ -678,7 +678,7 @@ class G3tHWP():
         Notes
         -----
 
-        Output file formatt
+        Output file format
 
         - timestamp:
             SMuRF synched timestamp

--- a/sotodlib/hwp/g3thwp.py
+++ b/sotodlib/hwp/g3thwp.py
@@ -1045,10 +1045,12 @@ class G3tHWP():
             _diff = int(np.diff(self._encd_cnt)[ii])
             # Fill dropped counters with counters one before or one after rotation.
             # This filling method works even when the reference slot counter is dropped.
-            if ii ii - self._num_edges + self._ref_edges + 1 >= 0:
-                gap_clk = self._encd_clk[ii - self._num_edges + self._ref_edges + 1 : ii+_diff - self._num_edges + self._ref_edges] - self._encd_clk[ii-self._num_edges + self._ref_edges] + self._encd_clk[ii]
+            if ii - self._num_edges + self._ref_edges + 1 >= 0:
+                gap_clk = self._encd_clk[ii - self._num_edges + self._ref_edges + 1 : ii+_diff - self._num_edges + self._ref_edges] \
+                     - self._encd_clk[ii-self._num_edges + self._ref_edges] + self._encd_clk[ii]
             else:
-                gap_clk = self._encd_clk[ii - _diff + self._num_edges: ii -1 + self._num_edges] - self._encd_clk[ii - _diff + self._num_edges -1] + self._encd_clk[ii]
+                gap_clk = self._encd_clk[ii - _diff + self._num_edges: ii -1 + self._num_edges] \
+                    - self._encd_clk[ii - _diff + self._num_edges -1] + self._encd_clk[ii]
             gap_cnt = np.arange(self._encd_cnt[ii]+1,self._encd_cnt[ii+1])
             self._encd_cnt = np.insert(self._encd_cnt, ii+1, gap_cnt)
             self._encd_clk = np.insert(self._encd_clk, ii+1, gap_clk)
@@ -1089,7 +1091,7 @@ class G3tHWP():
                 np.abs(
                     quad_split.mean() -
                     quad_split) > 0.5).flatten()
-            if len(outlier) > 5: 
+            if len(outlier) > 5:
                 logger.warning(
                     "flipping quad is corrected by mean value, please consider to use force_quad")
             for i in outlier:

--- a/sotodlib/hwp/g3thwp.py
+++ b/sotodlib/hwp/g3thwp.py
@@ -540,7 +540,7 @@ class G3tHWP():
 
         Notes
         -----------
-        Output file format 
+        Output file format
 
         * Provider: 'hwp'
             * Fast block
@@ -678,7 +678,7 @@ class G3tHWP():
         Notes
         -----
 
-        Output file formatt s
+        Output file formatt
 
         - timestamp:
             SMuRF synched timestamp


### PR DESCRIPTION
The original packet drop filling method fails when the reference slots are dropped.
`/so/level2-daq/satp1/hk/16917/1691705690.g3` is an exmple.

Changed the filling method to use the counters one before or one after rotation.

Advantage
- This method works even when the reference slots are dropped.

Disadvantage
- This method assumes that packet drop is not too frequent.
- This method assumes the drift of rotation frequency is not fast compared to the rotation period.

Before fix
![before (1)](https://github.com/simonsobs/sotodlib/assets/38639108/3c56739c-ee88-4726-a669-ba031ebfe312)
After fix
![after (1)](https://github.com/simonsobs/sotodlib/assets/38639108/e9d2a471-691a-4cfa-90e4-f4e789955886)
