### PR TITLE
Downsampling mode into timing logic

### DIFF
--- a/sotodlib/io/g3tsmurf_db.py
+++ b/sotodlib/io/g3tsmurf_db.py
@@ -125,7 +125,7 @@ class Observations(Base):
         across stream_ids.
     timing : bool
         If true, the files of the entry observation were made with times
-        referenced to the external timing system and high precision timestamps.
+        aligned to the external timing system and high precision timestamps.
     duration : float
         The total observation time in seconds
     n_samples : integer

--- a/sotodlib/io/g3tsmurf_db.py
+++ b/sotodlib/io/g3tsmurf_db.py
@@ -125,7 +125,7 @@ class Observations(Base):
         across stream_ids.
     timing : bool
         If true, the files of the entry observation were made with times
-        referenced to the timing system.
+        referenced to the external timing system and high precision timestamps.
     duration : float
         The total observation time in seconds
     n_samples : integer
@@ -231,7 +231,8 @@ class Files(Base):
     stream_id : The stream_id for the file. Generally of the form crateXslotY.
         These are expected to map one per UXM.
     timing : bool
-        If true, every frame in the file has times that are referenced to the timing system
+        If true, every frame in the file has high precision timestamps (slightly
+        different definition than obs.timing)
     n_frames : Integer
         Number of frames in the .g3 file
     frames : list of SQLALchemy Frame Instances

--- a/sotodlib/io/imprinter.py
+++ b/sotodlib/io/imprinter.py
@@ -1240,8 +1240,14 @@ class Imprinter:
                                 continue
 
                             t_list = [o for o in obs_list if o.timing]
-                            nt_list = [o for o in obs_list if ~o.timing]
-                            assert len(t_list)+len(nt_list) == len(obs_list)
+                            nt_list = [o for o in obs_list if not o.timing]
+                            
+                            if len(t_list)+len(nt_list) != len(obs_list):
+                                raise ValueError(f"Cannot safely split timing"  
+                                    f"info for {obs_list}"
+                                )
+                                
+
                             if len(t_list) > 0:
                                 # add all of the possible overlaps
                                 add_to_output(t_list, "obs")

--- a/sotodlib/io/imprinter_utils.py
+++ b/sotodlib/io/imprinter_utils.py
@@ -7,7 +7,7 @@ import datetime as dt
 import os
 import os.path as op
 import shutil
-
+import time
 
 from sotodlib.io.imprinter import ( 
     Books,
@@ -77,6 +77,8 @@ def set_book_rebind(imprint, book):
         binder = None
     if binder is not None:
         book_dir = op.abspath(binder.outdir)
+        del binder
+        time.sleep(1)
         if op.exists(book_dir):
             print(f"Removing all files from {book_dir}")
             shutil.rmtree(book_dir)

--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -368,6 +368,7 @@ class G3tSmurf:
         total_channels = 0
         file_start, file_stop = None, None
         frame_idx = -1
+        timing = None
         
 
         while True:

--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -369,7 +369,6 @@ class G3tSmurf:
         file_start, file_stop = None, None
         frame_idx = -1
         timing = None
-        
 
         while True:
             try:

--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -368,7 +368,7 @@ class G3tSmurf:
         total_channels = 0
         file_start, file_stop = None, None
         frame_idx = -1
-        timing = None
+        
 
         while True:
             try:
@@ -1082,7 +1082,13 @@ class G3tSmurf:
             obs.duration = flist[-1].stop.timestamp() - flist[0].start.timestamp()
             obs.stop = flist[-1].stop
             # f.timing is None if the file has no Scan Frames
-            obs.timing = np.all([f.timing or (f.timing is None) for f in flist])
+            # timing requires external downsampling AND high precision 
+            # timestamps. file.timing checks high precision. obs.timing
+            # includes external downsampling
+            obs.timing = (
+                np.all([f.timing or (f.timing is None) for f in flist]) 
+                and status.downsample_external
+            )
             logger.debug(f"Setting {obs.obs_id} stop time to {obs.stop}")
         session.commit()
 
@@ -2073,6 +2079,9 @@ class SmurfStatus:
         self.downsample_factor = self.status.get(f"{ds_root}.Factor")
         self.aman = self.aman.wrap("downsample_factor", self.downsample_factor)
         self.downsample_enabled = not self.status.get(f"{ds_root}.Disable")
+
+        ds_mode = self.status.get(f"{ds_root}.DownsamplerMode", "Internal")
+        self.downsample_external = ds_mode.lower() == 'external'
 
         # Tries to make resonator frequency map
         self.freq_map = np.full((self.NUM_BANDS, self.CHANS_PER_BAND), np.nan)


### PR DESCRIPTION
The last PR fixed things so that books with `obs.timing = False` got shoved in to single wafer books. 

This PR rounds out the logic to get timing = False for the two ways we could have non-cosampled UFMs. The first, which was already implemented, is low-precision timestamps in the files. The second is when the downsample mode is set to internal. Both need to be true for UFMs to be co-sampled.

I've checked that the SATp1 files get `status.downsample_external = True` and the current LAT and SATp3 files have `status.downsample_external = False`