### PR TITLE
Better toast defaults

### DIFF
--- a/sotodlib/toast/workflows/pointing.py
+++ b/sotodlib/toast/workflows/pointing.py
@@ -159,9 +159,11 @@ def select_pointing(job, otherargs, runargs, data):
     if hasattr(job_ops, "binner"):
         job_ops.binner.pixel_pointing = job.pixels_solve
         job_ops.binner.stokes_weights = job.weights_solve
+        job_ops.binner.full_pointing = otherargs.full_pointing
     if hasattr(job_ops, "binner_final"):
         job_ops.binner_final.pixel_pointing = job.pixels_final
         job_ops.binner_final.stokes_weights = job.weights_final
+        job_ops.binner_final.full_pointing = otherargs.full_pointing
         # If we are not using a different binner for our final binning, use the
         # same one as the solve.
         if not job_ops.binner_final.enabled:

--- a/sotodlib/toast/workflows/proc_characterize.py
+++ b/sotodlib/toast/workflows/proc_characterize.py
@@ -116,6 +116,7 @@ def hn_map(job, otherargs, runargs, data):
         job_ops.h_n.pixel_pointing = job.pixels_final
         job_ops.h_n.pixel_dist = job_ops.binner_final.pixel_dist
         job_ops.h_n.output_dir = otherargs.out_dir
+        job_ops.h_n.save_pointing = otherargs.full_pointing
         job_ops.h_n.apply(data)
 
 
@@ -153,6 +154,7 @@ def cadence_map(job, otherargs, runargs, data):
         job_ops.cadence_map.pixel_pointing = job.pixels_final
         job_ops.cadence_map.pixel_dist = job_ops.binner_final.pixel_dist
         job_ops.cadence_map.output_dir = otherargs.out_dir
+        job_ops.cadence_map.save_pointing = otherargs.full_pointing
         job_ops.cadence_map.apply(data)
 
 
@@ -190,4 +192,5 @@ def crosslinking_map(job, otherargs, runargs, data):
         job_ops.crosslinking.pixel_pointing = job.pixels_final
         job_ops.crosslinking.pixel_dist = job_ops.binner_final.pixel_dist
         job_ops.crosslinking.output_dir = otherargs.out_dir
+        job_ops.crosslinking.save_pointing = otherargs.full_pointing
         job_ops.crosslinking.apply(data)

--- a/sotodlib/toast/workflows/proc_demodulation.py
+++ b/sotodlib/toast/workflows/proc_demodulation.py
@@ -38,12 +38,14 @@ def setup_demodulate(operators):
             nbin_psd=64,
             nsum=1,
             naverage=64,
+            enabled=False,
         )
     )
     operators.append(
         toast.ops.FitNoiseModel(
             name="demod_noise_estim_fit",
             out_model="demod_noise_fit",
+            enabled=False,
         )
     )
 

--- a/sotodlib/toast/workflows/proc_filters.py
+++ b/sotodlib/toast/workflows/proc_filters.py
@@ -131,7 +131,7 @@ def setup_filter_poly1d(operators):
         None
 
     """
-    operators.append(toast.ops.PolyFilter(name="polyfilter1D"))
+    operators.append(toast.ops.PolyFilter(name="polyfilter1D", enabled=False))
 
 
 @workflow_timer

--- a/sotodlib/toast/workflows/proc_flagging.py
+++ b/sotodlib/toast/workflows/proc_flagging.py
@@ -72,7 +72,7 @@ def setup_flag_noise_outliers(operators):
         toast.ops.FitNoiseModel(
             name="noise_cut_fit",
             out_model="noise_cut_fit",
-            enabled=False,
+            enabled=True,
         )
     )
     operators.append(
@@ -80,7 +80,7 @@ def setup_flag_noise_outliers(operators):
             name="noise_cut_flag",
             sigma_NET=5.0,
             sigma_fknee=5.0,
-            enabled=False,
+            enabled=True,
         )
     )
 

--- a/sotodlib/toast/workflows/proc_flagging.py
+++ b/sotodlib/toast/workflows/proc_flagging.py
@@ -201,4 +201,5 @@ def processing_mask(job, otherargs, runargs, data):
             # We are using the same pointing matrix as the mapmaking
             job_ops.processing_mask.pixel_dist = job_ops.binner.pixel_dist
             job_ops.processing_mask.pixel_pointing = job.pixels_solve
+        job_ops.processing_mask.save_pointing = otherargs.full_pointing
         job_ops.processing_mask.apply(data)

--- a/sotodlib/toast/workflows/proc_flagging.py
+++ b/sotodlib/toast/workflows/proc_flagging.py
@@ -72,6 +72,7 @@ def setup_flag_noise_outliers(operators):
         toast.ops.FitNoiseModel(
             name="noise_cut_fit",
             out_model="noise_cut_fit",
+            enabled=False,
         )
     )
     operators.append(
@@ -79,6 +80,7 @@ def setup_flag_noise_outliers(operators):
             name="noise_cut_flag",
             sigma_NET=5.0,
             sigma_fknee=5.0,
+            enabled=False,
         )
     )
 

--- a/sotodlib/toast/workflows/proc_mapmaker.py
+++ b/sotodlib/toast/workflows/proc_mapmaker.py
@@ -27,6 +27,7 @@ def setup_mapmaker(operators, templates):
         toast.templates.Offset(
             name="baselines",
             step_time=2.0 * u.second,
+            enabled=False,
         )
     )
     templates.append(

--- a/sotodlib/toast/workflows/proc_mapmaker.py
+++ b/sotodlib/toast/workflows/proc_mapmaker.py
@@ -37,6 +37,7 @@ def setup_mapmaker(operators, templates):
             flag_mask=defaults.shared_mask_invalid,
             increment=np.pi / 180.0,  # One degree, az field is in radians
             bins=None,
+            enabled=False,
         )
     )
     operators.append(toast.ops.BinMap(name="binner", pixel_dist="pix_dist"))

--- a/sotodlib/toast/workflows/proc_mapmaker_filterbin.py
+++ b/sotodlib/toast/workflows/proc_mapmaker_filterbin.py
@@ -47,6 +47,7 @@ def mapmaker_filterbin(job, otherargs, runargs, data):
 
     if job_ops.filterbin.enabled:
         job_ops.filterbin.binning = job_ops.binner_final
+        job_ops.filterbin.binning.full_pointing = otherargs.full_pointing
         job_ops.filterbin.det_data = job_ops.sim_noise.det_data
         job_ops.filterbin.output_dir = otherargs.out_dir
         if otherargs.obsmaps:

--- a/sotodlib/toast/workflows/proc_noise_est.py
+++ b/sotodlib/toast/workflows/proc_noise_est.py
@@ -37,6 +37,7 @@ def setup_noise_estimation(operators):
         toast.ops.FitNoiseModel(
             name="noise_estim_fit",
             out_model="noise_estim_fit",
+            enabled=False,
         )
     )
 

--- a/sotodlib/toast/workflows/sim_detector_readout.py
+++ b/sotodlib/toast/workflows/sim_detector_readout.py
@@ -67,7 +67,7 @@ def setup_simulate_detector_noise(operators):
         None
 
     """
-    operators.append(toast.ops.SimNoise(name="sim_noise"))
+    operators.append(toast.ops.SimNoise(name="sim_noise", enabled=False))
 
 
 @workflow_timer


### PR DESCRIPTION
Disable all unnecessary TOAST operators by default.

Extend support for `--full_pointing` command line option.