### PR TITLE
Update trending_flags to work with preprocess.

### DIFF
--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -327,6 +327,26 @@ class FlagTurnarounds(_Preprocess):
     """
     name = 'flag_turnarounds'
     
+    def calc_and_save(self, aman, proc_aman):
+        if self.calc_cfgs['method'] == 'scanspeed':
+            ta, left, right = tod_ops.flags.get_turnaround_flags(aman, **self.calc_cfgs)
+            turn_aman = core.AxisManager(aman.dets, aman.samps)
+            turn_aman.wrap('turnarounds', ta, [(0, 'dets'), (1, 'samps')])
+            turn_aman.wrap('left_scan', left, [(0, 'dets'), (1, 'samps')])
+            turn_aman.wrap('right_scan', right, [(0, 'dets'), (1, 'samps')])
+            self.save(proc_aman, turn_aman)
+        if self.calc_cfgs['method'] == 'az':
+            ta = tod_ops.flags.get_turnaround_flags(aman, **self.calc_cfgs)
+            turn_aman = core.AxisManager(aman.dets, aman.samps)
+            turn_aman.wrap('turnarounds', ta, [(0, 'dets'), (1, 'samps')])
+            self.save(proc_aman, turn_aman)
+
+    def save(self, proc_aman, turn_aman):
+        if self.save_cfgs is None:
+            return
+        if self.save_cfgs:
+            proc_aman.wrap("turnaround_flags", turn_aman)
+
     def process(self, aman, proc_aman):
         tod_ops.flags.get_turnaround_flags(aman, **self.process_cfgs)
         

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -321,13 +321,21 @@ class GlitchFill(_Preprocess):
 
 class FlagTurnarounds(_Preprocess):
     """From the Azimuth encoder data, flag turnarounds, left-going, and right-going.
-        All process configs go to `get_turnaround_flags`.
+        All process configs go to ``get_turnaround_flags``. If the ``method`` key
+        is not included in the preprocess config file calc configs then it will
+        default to 'scanspeed'.
     
     .. autofunction:: sotodlib.tod_ops.flags.get_turnaround_flags
     """
     name = 'flag_turnarounds'
     
     def calc_and_save(self, aman, proc_aman):
+        if self.calc_cfgs is None:
+            self.calc_cfgs = {}
+            self.calc_cfgs['method'] = 'scanspeed'
+        elif not('method' in self.calc_cfgs):
+            self.calc_cfgs['method'] = 'scanspeed'
+
         if self.calc_cfgs['method'] == 'scanspeed':
             ta, left, right = tod_ops.flags.get_turnaround_flags(aman, **self.calc_cfgs)
             turn_aman = core.AxisManager(aman.dets, aman.samps)

--- a/sotodlib/tod_ops/flags.py
+++ b/sotodlib/tod_ops/flags.py
@@ -247,7 +247,14 @@ def get_turnaround_flags(aman, az=None, method='scanspeed', name='turnarounds',
         else:
             print(ta_flag)
             aman.flags.wrap(name, ta_flag)   
-    return ta_flag
+    if method == 'az':
+        ta_exp = RangesMatrix([ta_flag for i in range(aman.dets.count)])
+        return ta_exp
+    if method == 'scanspeed':
+        ta_exp = RangesMatrix([ta_flag for i in range(aman.dets.count)])
+        left_exp = RangesMatrix([left_flag for i in range(aman.dets.count)])
+        right_exp = RangesMatrix([right_flag for i in range(aman.dets.count)])
+        return ta_exp, left_exp, right_exp
     
 def get_glitch_flags(aman,
                      t_glitch=0.002,


### PR DESCRIPTION
The version of turnaround_flags added in the sub_polyf PR only included a process operation for preprocess. This PR adds in a calc_and_save operation and updates the flags returned to be RangesMatrices size n_dets x n_samps.