### PR TITLE
Bookbinder only examines Azimuth positions around detector data

### DIFF
--- a/sotodlib/io/imprinter_cli.py
+++ b/sotodlib/io/imprinter_cli.py
@@ -1,3 +1,12 @@
+""" Command-line interface for helping to clear out or clean up failed books. 
+
+--action=failed: the script will cycle through failed books and
+give the option to retry binding (useful if software changes mean we expect the
+books to now be successfully bound), to skip binding those files (push
+timestreams into the stray books), or do nothing.
+
+--action=timecodes: not implemented yet
+"""
 import os
 import argparse
 from typing import Optional


### PR DESCRIPTION
The bookbinder currently looks at calculating framing off of azimuth position for almost 20 minutes of buffer time around different observations. And somehow today we managed to move the mount of satp3 so that the framing calculator became an infinite loop. 

This PR **does not** fix that infinite loop but does stop the current error by significantly reducing the amount of buffer time around the detector data that we use to calculate when turn-arounds / starts / stops are happening. This was a faster quick-fix that will hopefully hold until we can get a real fix around this issue. I have double checked that the framing remains identical for two SATp1 scans, (1 cmb, 1 point source) and that it fixes the issue with the satp3 book that was infinite looping.  