### PR TITLE
Metadata fixes

### DIFF
--- a/docs/context.rst
+++ b/docs/context.rst
@@ -1001,10 +1001,15 @@ intended to carry precision results needed for mapping, such as
 calibration information or precise pointing and polarization angle
 data.
 
-Certain properties may change with time, for example if wiring or
-optics tube arrangements are adjusted from one season of observations
-to the next.  The ``DetDb`` is intended to support values that change
-with time.  **The timestamp support is still under development.**
+
+.. note::
+
+   DetDb is not planned for use in SO, because of the complexity of
+   the ``readout_id`` to ``det_id`` mapping problem.  The ``det_info``
+   system (described in the :ref:`metadata-section` section) is used
+   for making detector information available in the loaded TOD object.
+   DetDb is still used for simulations and for wrapping of data from
+   other readout systems.
 
 
 Using a DetDb (Tutorial)
@@ -1202,9 +1207,10 @@ properties::
   'geometry.wafer_pol']
 
 
-Creating a DetDb [empty]
-========================
+Creating a DetDb
+================
 
+For an example, see source code of :func:`get_example<detdb.get_example>`.
 
 Database organization
 =====================
@@ -1274,6 +1280,8 @@ Auto-generated documentation should appear here.
 .. autoclass:: DetDb
    :special-members: __init__
    :members:
+
+.. autofunction:: sotodlib.core.metadata.detdb.get_example
 
 
 ---------------------------

--- a/docs/context.rst
+++ b/docs/context.rst
@@ -846,10 +846,19 @@ Metadata Request Processing
 ===========================
 
 Metadata loading is triggered automatically when
-:func:`Context.get_obs()<sotodlib.core.Context.get_obs>` is called.
-The Context code creates a dictionary of parameters, which might
-contain only the ``obs_id``.  For each item in the context.yaml
-``metadata`` entry, a series of steps are performed:
+:func:`Context.get_obs()<sotodlib.core.Context.get_obs>` (or
+``get_meta``) is called.  The parameters to ``get_obs`` define an
+observation of interest, through an ``obs_id``, as well as
+(potentially) a limited set of detectors of interest.  Processing the
+metadata request may require the code to refer to the ObsDb for more
+information about the specified ``obs_id``, and to the DetDb or
+``det_info`` dataset for more information about the detectors.
+
+Steps in metadata request processing
+------------------------------------
+
+For each item in the context.yaml ``metadata`` entry, a series of
+steps are performed:
 
 1. Read ManifestDb.
 
@@ -867,8 +876,8 @@ contain only the ``obs_id``.  For each item in the context.yaml
    is interrogated for what ``obs`` and ``dets`` fields it requires as
    Index Data.  If those fields are not already in the request, then
    the request is augmented to include them; this typically requires
-   interaction with the ObsDb and/or DetDb.  The augmented request is
-   the result of the Promotion Step.
+   interaction with the ObsDb and/or DetDb and det_info.  The
+   augmented request is the result of the Promotion Step.
 
 3. Get Endpoints.
 
@@ -905,12 +914,40 @@ contain only the ``obs_id``.  For each item in the context.yaml
    field from the result, for example).
 
 
+Rules for augmenting and using det_info
+---------------------------------------
 
-Changing det_info
------------------
+The metadata loader associates metadata results to individual
+detectors using fields from the observation's ``det_info``.  For any
+single observation, the ``det_info`` is first initialized from:
 
-Metadata entries can be used to augment the  ``det_info`` table
-that is used to screen and match metadata results.  For example::
+- The ObsFileDb; this provides the unique ``readout_id`` for each
+  channel, as well as the ``detset`` to which each belongs.
+- If a DetDb has been specified, everything in there is copied into
+  ``det_info``.
+
+From that starting point, additional fields can be loaded into the
+``det_info``; these fields can then be used to load metadata indexed
+in a variety of ways.  For the mu-mux readout used in SO, the
+following additional steps will usually be performed to augment the
+``det_info``:
+
+- A "channel map" (a.k.a. "det map", "det match", ...) result will be
+  loaded, to associate a ``det_id`` with each of the loaded
+  ``readout_id`` values (or most of them, hopefully).  While the
+  ``readout_id`` describes a specific channel of the readout hardware,
+  the ``det_id`` corresponds to a particular optical device (e.g. a
+  detector with known position, orientation, and passband).
+- Some "wafer info" will be loaded, containing various properties of
+  the detectors, as designed (for example, their approximate
+  locations; passbands; wiring information; etc.).  This is a single
+  table of data for each physical wafer, indexed naturally by
+  ``det_id``, but the rows here can not be associated with each
+  ``readout_id`` until we have loaded the "channel map".
+
+Special metadata entries in context.yaml are used to augment the
+``det_info``.  table; these are marked with ``det_info: true`` and do
+not have a ``name: ...`` field.  For example::
 
   metadata:
   - ...
@@ -918,39 +955,37 @@ that is used to screen and match metadata results.  For example::
     det_info: true
   - ...
 
-The boolean ``'det_info': true`` marks the above as a special metadata
-entry to update ``det_info``.  It is expected that the database
-(``more_det_info.sqlite``) is a standard ManifestDb, which will be
-queried in the usual way except that when we get to the "Wrap
-Metadata" step, instead the following is performed:
+It is expected that the database (``more_det_info.sqlite``) is a
+standard ManifestDb, which will be queried in the usual way except
+that when we get to the "Wrap Metadata" step, instead the following is
+performed:
 
-  - An index field will be identified in the current active
-    ``det_info`` -- it can be either ``dets:readout_id`` or
-    ``dets:det_id`` -- to match against the new metadata.
-  - The columns from the new metadata are merged into the active
-    ``det_info``, ensuring that the index field values correspond.
-  - Only the rows for which the index field has the same value in the
-    two objects are kept.
+- All the loaded fields are inspected, and any fields that are already
+  found in the current ``det_info`` are used as Index fields.
+- The columns from the new metadata are merged into the active
+  ``det_info``, ensuring that the index field values correspond.
+- Only the rows for which the index field has the same value in the
+  two objects are kept.
 
-As subsequent metadata are processed, they can match against any
-fields that have been added to ``det_info`` by preceding entries in
-the metadata list.  However, currently it is only possible to augment
-``det_info`` using ``readout_id`` or ``det_id``.
+Here are a few more tips about det_info:
 
-By default, ``readout_id`` / ``det_id`` are expected to be unique
-indices.  It is often useful to permit multiple matches, especially
-for the special value "NOT_FOUND" in ``det_id``.  To permit this, add
-'multi: true' to the metadata block.  For example::
+- *All* fields in the det_info metdata should be prefixed with
+  ``dets:``, to signify that they are associated with the dets axis
+  (this is similar to fields used as index fields in standard
+  metadata.
+- The field called ``dets:readout_id`` is assumed, throughout the
+  Context/Metdata code, to correspond to the values in the ``.dets``
+  axis of the TOD AxisManager.
+- By convention, ``dets:det_id`` is used for the physical detector (or
+  pseudo-detector device) identifier.  The special value "NO_MATCH" is
+  used for cases where the ``det_id`` could not be determined.
 
-  metadata:
-  ...
-  - db: 'wafer_det_map.sqlite'   # the 'readout_id' -> 'det_id' mapping
-    det_info: true
-  - db: 'wafer_info.sqlite'      # the 'det_id' -> misc properties table
-    det_info: true
-    multi: true                  # Set multi=true if det_id=NOT_FOUND might
-                                 # need to be broadcast to multiple readout_id
-  ...
+When new det_info are merged in, any fields found in both the existing
+and new det_info will be used to form the association.  Many-to-many
+matching is fully supported, meaning that a unique index
+(e.g. ``readout_id``) does not need to be used in the new det_info.
+However, it is expected that in most cases either ``readout_id`` or
+``det_id`` will be used to label det_info contributions.
 
 
 ------------------------------------

--- a/sotodlib/core/context.py
+++ b/sotodlib/core/context.py
@@ -444,8 +444,7 @@ class Context(odict):
 
         # Incorporate detset info from obsfiledb.
         detsets_info = self.obsfiledb.get_det_table(obs_id)
-        det_info = metadata.merge_det_info(det_info, detsets_info,
-                                           ['readout_id'])
+        det_info = metadata.merge_det_info(det_info, detsets_info)
 
         # Make the request for SuperLoader
         request = {'obs:obs_id': obs_id}

--- a/sotodlib/core/metadata/cli.py
+++ b/sotodlib/core/metadata/cli.py
@@ -166,7 +166,7 @@ def main(args=None):
             if item is None:
                 print(f'  "{args.obs_id}" not found!')
             else:
-                for k, v in db.get(args.obs_id).items():
+                for k, v in db.get(args.obs_id, tags=True).items():
                     print(f'  {k:<20}: {v}')
 
     elif args._subcmd == 'obsfiledb':

--- a/sotodlib/core/metadata/detdb.py
+++ b/sotodlib/core/metadata/detdb.py
@@ -518,10 +518,11 @@ class DetDb(object):
 
 
 def get_example():
-    """
-    Returns an example DetDb, mapped to RAM, for the SO LAT-like
-    array.  The two property tables are called "base" and "geometry".
-    The geometry table is not currently populated.
+    """Returns an example DetDb, mapped to RAM.  The two property tables
+    are called "base" and "geometry".  This example is for
+    demonstrating the code and interface and has no relation to any
+    instrument's actual detector layout!
+
     """
     db = DetDb()
 

--- a/sotodlib/core/metadata/loader.py
+++ b/sotodlib/core/metadata/loader.py
@@ -213,7 +213,7 @@ class SuperLoader:
             # invent one so that we at least get the structure of the
             # metadata (even though we'll throw out all the actual
             # results).  You can get here if someone passes dets=[].
-            candidate_index_lines = man.inspect(request, False)
+            candidate_index_lines = man.inspect(request, False, prefix=dbpath)
             index_lines.append(candidate_index_lines[0])
             to_skip = [False]
 

--- a/sotodlib/core/metadata/loader.py
+++ b/sotodlib/core/metadata/loader.py
@@ -1,5 +1,6 @@
 from sotodlib import core
 
+import collections
 import logging
 import os
 import numpy as np
@@ -95,6 +96,12 @@ class SuperLoader:
                 specified in the ManifestDb, and is normally
                 unnecessary but can be used for debugging /
                 work-arounds.
+
+            ``det_info`` (bool, optional)
+                If True, treat the metadata as a contribution to
+                det_info. The metadata will be merged into the active
+                det_info object.
+
 
           Any filenames in the ManifestDb that are given as relative
           paths will be resolved relative to the directory where the
@@ -431,10 +438,8 @@ class SuperLoader:
                     reraise(spec, e)
 
             if spec.get('det_info') and error is None:
-                det_info = merge_det_info(
-                    det_info, item, multi=spec.get('multi', False))
+                det_info = merge_det_info(det_info, item)
                 item = None
-
                 det_info, aug_request = check_tags(det_info, aug_request)
 
             if check:
@@ -483,8 +488,7 @@ def _filter_items(prefix, d, remove=True):
     return [k[len(prefix)*remove:] for k in d if k.startswith(prefix)]
 
 
-def merge_det_info(det_info, new_info, multi=False,
-                   index_columns=['readout_id', 'det_id']):
+def merge_det_info(det_info, new_info, multi=True):
     """Args:
 
       det_info (ResultSet or None): The det_info table to start from,
@@ -492,9 +496,7 @@ def merge_det_info(det_info, new_info, multi=False,
       new_info (ResultSet): New data to merge/check against
         det_info; only columns with dets: prefix are processed.
       multi (bool): whether to permit some rows to match multiple
-        rows.
-      index_columns: columns that will be recognized as indexing
-        columns.
+        rows; this is True by default.
 
     Returns:
       A (possibly) new det_info table, containing updates and
@@ -515,41 +517,49 @@ def merge_det_info(det_info, new_info, multi=False,
             f'{new_info}')
     new_info.keys = new_keys
 
-    for match_key in index_columns:
-        if match_key in new_info.keys and \
-           (det_info is None or match_key in det_info.keys):
-            break
-    else:
-        raise ValueError(
-            f'No co-index key ({index_columns}) was found in both '
-            f'{det_info} and {new_info}')
-
     if det_info is None:
         return new_info
 
-    if multi:
-        # Permit duplicate keys.
-        i0 = core.util.get_multi_index(
-            new_info[match_key], det_info[match_key])
-        i1 = np.arange(len(det_info[match_key]))
-        i0, i1 = i0[i0>=0], i1[i0>=0]
-    else:
-        both, i0, i1 = core.util.get_coindices(
-            new_info[match_key], det_info[match_key],
-            check_unique=True)
+    join_on = list(set(new_info.keys).intersection(det_info.keys))
+    if len(join_on) == 0:
+        raise ValueError(
+            f'Cannot merge det_info: no common keys in '
+            f'{det_info} and {new_info}.')
+
+    new_index = list(zip(*[new_info[k] for k in join_on]))
+    det_index = list(zip(*[det_info[k] for k in join_on]))
+
+    # Perform the row-row matching, accepting that rows of new_info
+    # may match multiple entries of det_info.  (This is so new_info
+    # can have a det_id = 'NO_MATCH' entry.)
+    i0 = core.util.get_multi_index(
+        new_index, det_index)
+    i1 = np.arange(len(det_index))
+    i0, i1 = i0[i0>=0], i1[i0>=0]
+
+    if not multi and len(i0) != len(set(i0)):
+        offenders = collections.Counter(i0)
+        offenders = [new_index[i] for i, v in offenders.items() if v > 1][:10]
+        raise ValueError(
+            'Some new items matched up to more than one entry in the '
+            'existing det_info.  Should this entry have multi=True? '
+            f'Offenders: {join_on} = {offenders}')
 
     # Common fields need to be in accordance, then drop them.
     common_keys = set(new_info.keys) & set(det_info.keys)
     for k in common_keys:
         if len(i0) and np.any(new_info[k][i0] != det_info[k][i1]):
-            raise ValueError(f'Conflict in field "{k}"')
+            raise ValueError(
+                'When reconciling new det_info, a disagreement in the value '
+                f'of field {k} was observed.  If this is due to ambiguity '
+                f'in the det_id, maybe add {k} to the match_keys?')
 
     logger.debug(f' ... updating det_info (row count '
                  f'{len(det_info)} -> {len(i1)})')
     det_info = det_info.subset(rows=i1)
-    new_info = new_info.subset([k for k in new_info.keys
-                        if k != match_key and k not in common_keys],
-                       rows=i0)
+    new_info = new_info.subset(
+        [k for k in new_info.keys if k not in common_keys],
+        rows=i0)
     det_info.merge(new_info)
     return det_info
 

--- a/sotodlib/core/metadata/manifest.py
+++ b/sotodlib/core/metadata/manifest.py
@@ -489,7 +489,7 @@ class ManifestDb:
             raise ValueError('Matched multiple rows with index data: %s' % rows)
         return rows[0]
 
-    def inspect(self, params={}, strict=True):
+    def inspect(self, params={}, strict=True, prefix=None):
         """Given (partial) Index Data and Endpoint Data, find and return the
         complete matching records.
 
@@ -498,6 +498,7 @@ class ManifestDb:
           strict (bool): if True, a ValueError will be raised if
             params contains any keys that aren't recognized as Index
             or Endpoint data.
+          prefix (str or None): As in .match().
 
         Returns:
           A list of results matching the query.  Each result in the
@@ -522,6 +523,9 @@ class ManifestDb:
                   'from map join files on map.file_id=files.id %s' % where_str, p)
         rows = c.fetchall()
         rows = [self.scheme._format_row(dict(zip(rp, r))) for r in rows]
+        if prefix is not None:
+            for r in rows:
+                r['filename'] = os.path.join(prefix, r['filename'])
         if filename:
             # manual filter...
             rows = [r for r in rows if r['filename'] == filename]

--- a/sotodlib/core/metadata/manifest.py
+++ b/sotodlib/core/metadata/manifest.py
@@ -680,14 +680,16 @@ def get_parser(parser=None):
         endpoint fields.  (This mode is chosen by default.)
         """)
 
-    # "table"
+    # "entries"
     p = cmdsubp.add_parser(
-        'table', usage="""Syntax:
+        'entries', help=
+        "Show all entries in the database.",
+        usage="""Syntax:
 
     %(prog)s
 
         This will print every row of the metadata map table,
-        including the filename.
+        including the filename, and with two header rows.
         """)
 
 
@@ -827,7 +829,7 @@ def main(args=None):
 
         print()
 
-    elif args.mode == 'table':
+    elif args.mode == 'entries':
         # Print the table of entries.
         schema = db.scheme.as_resultset()
         keys = []
@@ -942,3 +944,6 @@ def main(args=None):
             db.conn.commit()
             c.execute('vacuum')
             db.to_file(args.output_db)
+
+    else:
+        print(f'Sorry, {args.mode} not implemented.')

--- a/sotodlib/core/metadata/resultset.py
+++ b/sotodlib/core/metadata/resultset.py
@@ -27,8 +27,15 @@ class ResultSet(object):
       >>> rset[10]
       {'base.array_code': 'LF1', 'base.freq_code': 'f027'}
 
-    (You can also access the raw row data in .rows, which is a simple
-    list of tuples.)
+    Note that the array or dict returned by indexing the ResultSet
+    present copies of the data, not changing those objects will not
+    update the original ResultSet.
+
+    You can also access the raw row data in .rows, which is a simple
+    list of tuples.  If you want to edit the data in a ResultSet,
+    modify those data rows directly, or else use ``.asarray()`` to get
+    a numpy array, modify the result, and create and a new ResultSet
+    from that using the ``.from_friend`` constructor.
 
     You can get a structured numpy array using:
 
@@ -67,11 +74,21 @@ class ResultSet(object):
 
     @classmethod
     def from_friend(cls, source):
+        """Return a new ResultSet populated with data from source.
+
+        If source is a ResultSet, a copy is made.  If source is a
+        numpy structured array, the ResultSet is constructed based on
+        the dtype names and rows of source.
+
+        Otherwise, a TypeError is raised.
+
+        """
         if isinstance(source, np.ndarray):
-            keys = source.dtype.names # structured array?
+            keys = source.dtype.names  # structured array?
             return cls(keys, list(source))
         if isinstance(source, ResultSet):
             return cls(source.keys, source.rows)
+        raise TypeError(f"No implementation to construct {cls} from {source.__class__}.")
 
     def copy(self):
         return self.__class__(self.keys, self.rows)


### PR DESCRIPTION
This PR brings one major functional change needed for proper functioning of the context system, and a few little bugfixes.

Major functional change is in how det_info is merged during metadata parsing with Context.  det_info now merges more like how other metadata does -- any fields are matched against fields with the same name in the existing det_info, and that is used to associate new data to each existing readout channel.  This should be backwards compatible (stuff that used to work will still work), but now lots of other stuff will work too (this is especially needed to associate stuff with det_id=NO_MATCH rows).

Other little fixes:
- CLI: `so-metadata metadata metadata.sqlite entries` -- mode to dump all rows in the table existed but didn't show up in help output.
- DetDb docs are updated to downplay use of DetDb in favor of det_info.  Not complete, but better.
- ObsDb: useless duplicate "tag" entries are now forbidden; existing ObsDbs with duplicate rows will not cause multiple entries to show up in queries on those tags.  Addresses #623 .
- Docs for ResultSet.from_friend.
- ManifestDb.inspect handles prefix=... arg in the same was as .match does; this is needed for getting an empty metadata shell when no dets are being loaded.

This PR does nothing to address the "ignore_missing" stuff -- that is coming next ...