### PR TITLE
Bookbinding / Automation Fixes

### DIFF
--- a/sotodlib/hwp/g3thwp.py
+++ b/sotodlib/hwp/g3thwp.py
@@ -650,6 +650,7 @@ class G3tHWP():
     def _write_empty_solution_h5(self, tod, output=None, h5_address=None):
 
         logger.info('Writing empty solutions')
+        # metadata loader requires a dets axis
         aman = sotodlib.core.AxisManager(tod.dets, tod.samps)
         self._set_empty_axes(aman)
         aman.timestamps[:] = tod.timestamps
@@ -741,7 +742,7 @@ class G3tHWP():
             self._write_empty_solution_h5(tod, output, h5_address)
             return
 
-        if len(solved['fast_time']) == 0:
+        if len(solved) == 0 or len(solved['fast_time']) == 0:
             logger.info('No rotation data in the specified timestamps.')
             self._write_empty_solution_h5(tod, output, h5_address)
             return
@@ -753,7 +754,7 @@ class G3tHWP():
             logger.error(f"Exception '{e}' thrown while the template subtraction")
             pass
 
-        # write solution
+        # write solution, metadata loader requires a dets axis
         aman = sotodlib.core.AxisManager(tod.dets, tod.samps)
         self._set_empty_axes(aman)
         if solved['fast_time'][0] > tod.timestamps[0] or solved['fast_time'][-1] < tod.timestamps[-1]:

--- a/sotodlib/io/bookbinder.py
+++ b/sotodlib/io/bookbinder.py
@@ -1,4 +1,6 @@
 import so3g
+from so3g.proj import Ranges
+
 from spt3g import core
 import itertools
 import numpy as np
@@ -1027,129 +1029,80 @@ def get_hk_files(hkdir, start, stop, tbuff=10*60):
 
     return files[m].tolist()
 
-def locate_scan_events(az, dy=0.001, min_gap=200, filter_window=100):
+def locate_scan_events(
+        times, az, 
+        vel_thresh=0.01, # mount noise for satps is 0.015 deg/s level
+        min_gap=200, 
+        filter_window=100
+    ):
     """
-    Locate places where a noisy vector t changes sign: +ve, -ve, and 0. To
-    handle noise, "zero" is defined to be a threshold region from -dy to +dy.
-    Thus t is said to have a zero-crossing if it fully crosses the threshold
-    region, with the actual crossing approximated as halfway between entering
-    and exiting the region. Entrances and exits without a crossing are also
-    identified (as "stops" and "starts" respectively).
+    Locate places where the azimuth velocity changes sign, including starts and
+    stops. These locations are where we should start determining the scan 
+    framing.
 
     Parameters
     ----------
-    dy : float, optional
-        Amplitude of threshold region
+    times : ndarray float
+        times 
+    az: ndarray float
+        azimuth positions
+    vel_thresh : float, optional
+        threshold for what is considered stopped
     min_gap : int, optional
         Length of gap (in samples) longer than which events are considered separate
 
     Returns
     -------
     events : list
-        Full list containing all zero-crossings, starts, and stops
-    starts : list
-        List of places where t exits the threshold region (subset of events)
-    stops : list
-        List of places where t enters the threshold region (subset of events)
+        Full list containing all zero-crossings, starts, and stops that should become frame edges
     """
 
+    if len(az) < 1:
+        return []
+
     offset = 0
+    vel = np.diff(az)/np.diff(times)
+
     if filter_window is not None:
-        boxcar = np.ones(filter_window) / filter_window
-        az = convolve(az, boxcar, mode='same')[filter_window:-filter_window]
+        win = np.hanning(filter_window) / np.sum(np.hanning(filter_window))
+        vel = convolve(vel, win, mode='same')[filter_window:-filter_window]
         offset = filter_window
+
+    ## find places with "zero" velocity
+    zero_vel = np.abs(vel) < vel_thresh
+    if np.all(zero_vel):
+        return []
     
-    t = np.diff(az)
-
-    tmin = np.min(t)
-    tmax = np.max(t)
-
-    if len(t) == 0:
-        return [], [], []
-
-    if np.sign(tmax) == np.sign(tmin):
-        return [], [], []
-
-    # If the data does not entirely cross the threshold region,
-    # do not consider it a sign change
-    if tmin > -dy and tmax < dy:
-        return [], [], []
-
-    # Find where the data crosses the lower and upper boundaries of the threshold region
-    c_lower = (np.where(np.sign(t[:-1]+dy) != np.sign(t[1:]+dy))[0] + 1)
-    c_upper = (np.where(np.sign(t[:-1]-dy) != np.sign(t[1:]-dy))[0] + 1)
-
-    # Classify each crossing as entering or exiting the threshold region
-    c_lower_enter = []; c_lower_exit = []
-    c_upper_enter = []; c_upper_exit = []
-
-    # Noise handling:
-    # If there are multiple crossings of the same boundary (upper or lower) in
-    # quick succession (i.e., less than min_gap), it is mostly likely due to
-    # noise. In this case, take the average of each group of crossings.
-    if len(c_lower) > 0:
-        spl = np.array_split(c_lower, np.where(np.ediff1d(c_lower) > min_gap)[0] + 1)
-        c_lower = np.array([int(np.ceil(np.mean(s))) for s in spl])
-        # Determine if this crossing is entering or exiting threshold region
-        for i, s in enumerate(spl):
-            if t[s[0]-1] < t[s[-1]+1]:
-                c_lower_enter.append(c_lower[i])
-            else:
-                c_lower_exit.append(c_lower[i])
-    if len(c_upper) > 0:
-        spu = np.array_split(c_upper, np.where(np.ediff1d(c_upper) > min_gap)[0] + 1)
-        c_upper = np.array([int(np.ceil(np.mean(s))) for s in spu])
-        # Determine if this crossing is entering or exiting threshold region
-        for i, s in enumerate(spu):
-            if t[s[0]-1] < t[s[-1]+1]:
-                c_upper_exit.append(c_upper[i])
-            else:
-                c_upper_enter.append(c_upper[i])
-
-    # If any empty lists are passed to concatenate, this will be cast
-    # into an array of floats instead of ints
-    starts = np.sort(np.concatenate((c_lower_exit, c_upper_exit)))
-    stops = np.sort(np.concatenate((c_lower_enter, c_upper_enter)))
-    events = np.sort(np.concatenate((starts, stops)))
-
-    # cast back to ints just in case
-    starts = starts.astype(int)
-    stops = stops.astype(int)
-    events = events.astype(int)
+    zeros = Ranges.from_mask(zero_vel)
+    zeros.close_gaps(min_gap)
     
-    # Look for zero-crossings
-    zc = []
-    while len(c_lower) > 0 and len(c_upper) > 0:
-        # Crossing from -ve to +ve
-        if c_lower[0] < c_upper[0]:
-            b = c_lower[c_lower < c_upper[0]]
-            zc.append(int( np.ceil(np.mean([b[-1], c_upper[0]])) ))
-            c_lower = c_lower[len(b):]
-        # Crossing from +ve to -ve
-        elif c_upper[0] < c_lower[0]:
-            b = c_upper[c_upper < c_lower[0]]
-            zc.append(int( np.ceil(np.mean([b[-1], c_lower[0]])) ))
-            c_upper = c_upper[len(b):]
-
-    # Replace all upper and lower crossings that contain a zero-crossing in
-    # between with the zero-crossing itself, but ONLY if those three events
-    # happen in quick succession (i.e., shorter than min_gap). Otherwise, they
-    # are separate events -- there is likely a stop state in between; in this
-    # case, do NOT perform the replacement.
-    for z in zc:
-        before_z = events[events < z]
-        after_z  = events[events > z]
-        if (after_z[0] - before_z[-1]) < min_gap:
-            events = np.concatenate((before_z[:-1], [z], after_z[1:]))
-
-    # Ignore first / last event if it is too close to the start or end
-    if (len(t) - events[-1] < min_gap) and events[-1] not in zc:
-        events = events[:-1]
-
-    if events[0] < min_gap:
-        events = events[1:]
-
-    return events + offset, starts + offset, stops + offset
+    ## find places where velocity changes sign in case the velocity
+    ## is so fast it never gets close enough to zero
+    x = np.where( np.sign(vel) > 0 )[0]
+    y = np.where( np.diff(x) > 1 )[0]
+    cross = Ranges.zeros_like(zeros)
+    for z in y:
+        cross.add_interval( x[z]+1, x[z]+2)
+    x = np.where( np.sign(vel) < 0 )[0]
+    y = np.where( np.diff(x) > 1 )[0]
+    for z in y:
+        cross.add_interval( x[z]+1, x[z]+2)
+    
+    zeros = zeros + cross
+    events = []
+    
+    for c in zeros.ranges():   
+        # if zero period is longer than min_gap, it's a start or stop add each side to the list
+        if c[1] - c[0] > min_gap:
+            if c[0] != 0:
+                events.append( c[0] )
+            if c[1] != len(vel):
+                events.append( c[1] )
+        # otherwise, it's a zero crossing, add mean
+        else:
+            events.append( int(round( sum(c)/2 )) )
+    
+    return np.array(events, dtype='int')+offset
 
 def find_frame_splits(ancil, t0=None, t1=None):
     """
@@ -1178,7 +1131,7 @@ def find_frame_splits(ancil, t0=None, t1=None):
         axis=0
     )
     az = block.data['Corrected_Azimuth'][msk]
-    idxs = locate_scan_events(az, filter_window=100)[0]
+    idxs = locate_scan_events(block.times[msk], az, filter_window=100)
     return block.times[msk][idxs]
 
 

--- a/sotodlib/io/bookbinder.py
+++ b/sotodlib/io/bookbinder.py
@@ -100,7 +100,8 @@ class HKBlock:
                     raise ValueError(f"HK data from block {self.name} has" 
                                     " duplicate timestamps")
                 self.times = self.times[idxs]
-            assert np.all(np.diff(self.times)>0)
+            assert (np.all(np.diff(self.times)>0), f"Times from {self.name} are"
+                            " not increasing")
             for k, v in self.data.items():
                 self.data[k] = np.hstack(v)[idxs]
         else:

--- a/sotodlib/io/imprinter.py
+++ b/sotodlib/io/imprinter.py
@@ -572,7 +572,8 @@ class Imprinter:
     def _get_binder_for_book(self, 
         book, 
         pbar=False, 
-        ignore_tags=False
+        ignore_tags=False,
+        ancil_drop_duplicates=False,
     ):
         """get the appropriate bookbinder for the book based on its type"""
         with open(self.g3tsmurf_config, "r") as f:
@@ -598,6 +599,7 @@ class Imprinter:
             bookbinder = BookBinder(
                 book, obsdb, filedb, lvl2_data_root, readout_ids, book_path,
                 ignore_tags=ignore_tags,
+                ancil_drop_duplicates=ancil_drop_duplicates,
             )
             return bookbinder
 
@@ -696,6 +698,7 @@ class Imprinter:
         test_mode=False,
         pbar=False,
         ignore_tags=False,
+        ancil_drop_duplicates=False,
         check_configs={}
     ):
         """Bind book using bookbinder
@@ -714,6 +717,9 @@ class Imprinter:
         ignore_tags : bool
             If true, book will be bound even if the tags between different level 2
             operations don't match. Only ever expected to be turned on by hand.
+        ancil_drop_duplicates: if true, will drop duplicate data from ancilary  
+            files. added to deal with an ocs aggregator error. Only ever 
+            expected to be turned on by hand.
         check_configs: dict
             additional non-default configurations to send to check book
         """
@@ -740,6 +746,7 @@ class Imprinter:
             binder = self._get_binder_for_book(
                 book, 
                 ignore_tags=ignore_tags,
+                ancil_drop_duplicates=ancil_drop_duplicates,
             )
             book.path = op.abspath(binder.outdir)
 

--- a/sotodlib/io/imprinter_cli.py
+++ b/sotodlib/io/imprinter_cli.py
@@ -54,8 +54,9 @@ def check_failed_books(imprint:Imprinter):
             resp = input(
                 "Possible Actions to Take: "
                 "\n\t1. Retry Binding"
-                "\n\t2. Permanently Skip Binding"
-                "\n\t3. Do Nothing"
+                "\n\t2. Rebind with flag(s)"
+                "\n\t3. Permanently Skip Binding"
+                "\n\t4. Do Nothing"
                 "\nInput Response: "
             )
             try: 
@@ -63,15 +64,24 @@ def check_failed_books(imprint:Imprinter):
             except:
                 print(f"Invalid Response {resp}")
                 resp=None
-            if resp is None or resp < 1 or resp > 3:
+            if resp is None or resp < 1 or resp > 4:
                 print(f"Invalid Response {resp}")
                 resp=None
         print(f"You selected {resp}")
         if resp == 1:
             utils.set_book_rebind(imprint, book)
-        elif resp == 2:
-            utils.set_book_wont_bind(imprint, book)
+        if resp == 2:
+            utils.set_book_rebind(imprint, book)
+            resp = input("Ignore Tags? (y/n)")
+            ignore_tags = resp.lower() == 'y'
+            resp = input("Drop Ancillary Duplicates? (y/n)")
+            ancil_drop_duplicates = resp.lower() == 'y'
+            imprint.bind_book(
+                book, ignore_tags=ignore_tags, ancil_drop_duplicates=ancil_drop_duplicates
+            )
         elif resp == 3:
+            utils.set_book_wont_bind(imprint, book)
+        elif resp == 4:
             pass
         else:
             raise ValueError("how did I get here?")

--- a/sotodlib/io/imprinter_cli.py
+++ b/sotodlib/io/imprinter_cli.py
@@ -70,7 +70,7 @@ def check_failed_books(imprint:Imprinter):
         print(f"You selected {resp}")
         if resp == 1:
             utils.set_book_rebind(imprint, book)
-        if resp == 2:
+        elif resp == 2:
             utils.set_book_rebind(imprint, book)
             resp = input("Ignore Tags? (y/n)")
             ignore_tags = resp.lower() == 'y'

--- a/sotodlib/site_pipeline/make_hwp_solutions.py
+++ b/sotodlib/site_pipeline/make_hwp_solutions.py
@@ -11,6 +11,8 @@ import logging
 import yaml
 import datetime as dt
 import scipy 
+from typing import Optional
+
 import sotodlib
 from sotodlib import core
 from sotodlib.hwp.g3thwp import G3tHWP
@@ -60,15 +62,15 @@ def get_parser(parser=None):
     return parser
 
 def main(
-    context=None, 
-    HWPconfig=None, 
-    output_dir=None, 
-    verbose=None,
-    overwrite=False,
-    query=None,
-    min_ctime=None,
-    max_ctime=None,
-    obs_id=None,    
+    context: str, 
+    HWPconfig: str, 
+    output_dir:Optional[str] = None, 
+    verbose:Optional[int] = 2,
+    overwrite:Optional[bool] = False,
+    query:Optional[str] = None,
+    min_ctime:Optional[float] = None,
+    max_ctime:Optional[float] = None,
+    obs_id:Optional[str] = None,    
     logger=None,
  ):
     if logger is None:
@@ -171,5 +173,6 @@ def main(
     
     
 if __name__ == '__main__':
-    parser = get_parser()
-    util.main_launcher(main, get_parser)
+    parser = get_parser(parser=None)
+    args = parser.parse_args()
+    main(**vars(args))

--- a/sotodlib/site_pipeline/make_hwp_solutions.py
+++ b/sotodlib/site_pipeline/make_hwp_solutions.py
@@ -41,7 +41,8 @@ def get_parser(parser=None):
     )
     parser.add_argument(
         '--query', 
-        help="Query to pass to the observation list",  
+        help="Query to pass to the observation list. Use \\'string\\' to "
+             "pass in strings within the query.",  
         type=str
     )
     parser.add_argument(
@@ -70,7 +71,7 @@ def main(
     obs_id=None,    
  ):
     
-    print(context, HWPconfig)
+    logger.info(f"Using context {context} and HWPconfig {HWPconfig}")
     configs = yaml.safe_load(open(HWPconfig, "r"))
     args = parser.parse_args()
     if args.output_dir is None:
@@ -124,6 +125,8 @@ def main(
         tot_query = tot_query[4:-4]
         if tot_query=="":
             tot_query="1"
+
+    logger.debug(f"Sending query to obsdb: {tot_query}")
     obs_list = ctx.obsdb.query(tot_query)
         
     if len(obs_list)==0:
@@ -143,12 +146,16 @@ def main(
     #write solutions
     for obs in run_list:
         h5_address = obs["obs_id"]
-        print(h5_address)
+        logger.info(f"Calculating Angles for {h5_address}")
         tod = ctx.get_obs(obs, no_signal=True)
         
         # make angle solutions
         g3thwp = G3tHWP(HWPconfig)
-        g3thwp.write_solution_h5(tod, output=output_filename, h5_address=h5_address)
+        g3thwp.write_solution_h5(
+            tod, 
+            output=output_filename, 
+            h5_address=h5_address
+        )
         
         del g3thwp
         

--- a/sotodlib/site_pipeline/make_hwp_solutions.py
+++ b/sotodlib/site_pipeline/make_hwp_solutions.py
@@ -15,7 +15,7 @@ import sotodlib
 from sotodlib import core
 from sotodlib.hwp.g3thwp import G3tHWP
 from sotodlib.site_pipeline import util
-logger = util.init_logger(__name__, 'make-hwp-solutions: ')
+default_logger = util.init_logger(__name__, 'make-hwp-solutions: ')
 
 def get_parser(parser=None):
     if parser is None:
@@ -69,8 +69,10 @@ def main(
     min_ctime=None,
     max_ctime=None,
     obs_id=None,    
+    logger=None,
  ):
-    
+    if logger is None:
+        logger = default_logger
     logger.info(f"Using context {context} and HWPconfig {HWPconfig}")
     configs = yaml.safe_load(open(HWPconfig, "r"))
     args = parser.parse_args()

--- a/sotodlib/site_pipeline/make_hwp_solutions.py
+++ b/sotodlib/site_pipeline/make_hwp_solutions.py
@@ -76,11 +76,8 @@ def main(
     if logger is None:
         logger = default_logger
     logger.info(f"Using context {context} and HWPconfig {HWPconfig}")
-    configs = yaml.safe_load(open(HWPconfig, "r"))
-    args = parser.parse_args()
-    if args.output_dir is None:
-        args.output_dir = configs["output_dir"]
     
+    configs = yaml.safe_load(open(HWPconfig, "r"))
     logger.info("Starting make_hwp_solutions")
 
     # Specify output directory

--- a/sotodlib/site_pipeline/preprocess_tod.py
+++ b/sotodlib/site_pipeline/preprocess_tod.py
@@ -215,7 +215,8 @@ def get_parser(parser=None):
     parser.add_argument('configs', help="Preprocessing Configuration File")
     parser.add_argument(
         '--query', 
-        help="Query to pass to the observation list",  
+        help="Query to pass to the observation list. Use \\'string\\' to "
+             "pass in strings within the query.",  
         type=str
     )
     parser.add_argument(

--- a/sotodlib/site_pipeline/update_smurf_caldbs.py
+++ b/sotodlib/site_pipeline/update_smurf_caldbs.py
@@ -8,15 +8,16 @@ still non-existant tools.
 Configuration file required::
 
     config = {
-        'context': 'context.yaml',
         'archive': {
             'detset': {
                 'index': 'detset.sqlite',
-                'h5file': 'detset.h5'
+                'h5file': 'detset.h5',
+                'context': 'context.yaml',
             },
             'det_cal': {
                 'index': 'det_cal.sqlite',
-                'h5file': 'det_cal.h5
+                'h5file': 'det_cal.h5,
+                'context': 'context.yaml',
             },
         },
         'g3tsmurf': g3tsmurf_hwp_config.yaml',
@@ -74,7 +75,7 @@ def smurf_detset_info(config: Union[str, dict],
     session = SMURF.Session()
 
     imprinter = Imprinter(config['imprinter'])
-    ctx = core.Context(config['context'])
+    ctx = core.Context(config['archive']['detset']['context'])
 
 
     if not os.path.exists(config['archive']['detset']['index']):
@@ -385,7 +386,7 @@ def run_update_det_caldb(config_path, logger=None, format_exc=False, show_pb=Fal
     with open(config_path, 'r') as f:
         config = yaml.safe_load(f)
 
-    ctx = core.Context(config['context'])
+    ctx = core.Context(config['archive']['det_cal']['context'])
     update_det_caldb(
         ctx, 
         config['archive']['det_cal']['index'],


### PR DESCRIPTION
Next round of bookbinding fixes and setup for smurf calibration databases and hwp angles. Updates include:

1. Implementing a method of checking for duplicate ancillary data and removing it from bookbinding if found (and if we say it's ok to remove it). Associated updates to the imprinter cli to choose to rebind books with flags.
2. Update how we find edges in scanning to deal with slower scans and make it impossible for infinite loops to happen. I have checked this new method versus the old one on 24 hours worth of observations a from satp1 and the new frame edges were never more than 2 samples different from the old frame edges.
3. Change smurf caldb function to accept a context file per type of caldb (det-cal needs detsets but detsets can't use a context that assumes detsets already exist).
4. A small edit to g3thwp I found while testing the setup for make-hwp-solutions