### PR TITLE
Update g3thwp.py to calculate hwp off-center

### DIFF
--- a/sotodlib/hwp/g3thwp.py
+++ b/sotodlib/hwp/g3thwp.py
@@ -586,10 +586,12 @@ class G3tHWP():
         if not ('fast_time' and 'fast_time_2') in solved.keys():
             logger.warning('Offcentering calculation is only available when two encoders are operating. Skipped.')
             return None
-        # Run the template subtraction if not completed yet.
+        # Run the template subtraction if not processed yet.
         if not 'fast_time_raw' in solved.keys():
-            logger.info('Running the template subtraction.')
+            logger.info('Running the template subtraction for the 1st encoder.')
             self.eval_angle(solved, poly_order=3, suffix='')
+        if not 'fast_time_raw_2' in solved.keys():
+            logger.info('Running the template subtraction for the 2nd encoder.')
             self.eval_angle(solved, poly_order=3, suffix='_2')
 
         # Calculate offcentering from where the first reference slot was detected by the 2nd encoder. 

--- a/sotodlib/hwp/g3thwp.py
+++ b/sotodlib/hwp/g3thwp.py
@@ -88,6 +88,9 @@ class G3tHWP():
         # Threshoild for outlier data to calculate nominal slit width
         self._slit_width_lim = self.configs.get('slit_width_lim', 0.1)
 
+        # The distance from the hwp center to the fine encoder slots (mm)
+        self._encoder_disk_radius = 346.25
+
         # force to quad value
         # 0: use readout quad value (default)
         # 1: positive rotation direction, -1: negative rotation direction

--- a/sotodlib/hwp/g3thwp.py
+++ b/sotodlib/hwp/g3thwp.py
@@ -655,11 +655,11 @@ class G3tHWP():
         # Skip the correction when the offcentering estimation doesn't exist.
         if offcentering == None:
             logger.warning('Offcentering input does not exist. Offcentering correction is skipped.')
-            return solved
+            return
         # Skip the calculation when the correction is already done.
         elif 'fast_time_v2' in solved.keys():
             logger.info('The offcentring correction is already completed. Skipped.')
-            return solved
+            return
         
         idx1 = offcentering['idx1']
         idx2 = offcentering['idx2']
@@ -678,7 +678,7 @@ class G3tHWP():
         solved['angle_2'] = solved['angle_2'][idx2]
         solved['offcentering'] = offcentering['offcentering']
 
-        return solved
+        return
 
     def write_solution(self, solved, output=None):
         """


### PR DESCRIPTION
This update enables handling two encoders at one time and estimating the HWP off-centering.
This also enables correcting the angle offset arises from the off-centering.
[This page](https://simonsobs.atlassian.net/wiki/spaces/~61f38f961bda70006e21bbfb/pages/229575081/hwp+off-centering+correction) shows the demonstration of off-center evaluation.

`write_solution_h5` publishes the angle data. The keys will be:
`['hwp_angle', 'hwp_angle_2', 'hwp_angle_ver1', 'hwp_angle_ver1_2', 'hwp_angle_ver2', 'hwp_angle_ver2_2', 'hwp_rate', 'hwp_rate_2', 'locked', 'locked_2', 'stable', 'stable_2', 'timestamps', 'version', 'version_2']`,
while keys with _2 means the second encoder. 

`version` indicates how `hwp_angle` is processed.
- version ==1:
`hwp_angle` is the raw angle before template subtraction. `hwp_angle_ver1`, `hwp_angle_ver2` are empty.
This version will be published when the encoder signal is too noisy to run the template subtraction.

- version ==2:
`hwp_angle` is the template subtracted angle. `hwp_angle_ver1` is the raw angle before the template subtraction. `hwp_angle_ver2` is empty.
This version will be published when the encoder signal is clear but the second encoder data is empty.

- version == 3:
`hwp_angle` is the template and off-centering subtracted angle. `hwp_angle_ver1` is the raw angle before the template subtraction. `hwp_angle_ver2` is the template subtracted angle.
This version will be published when the encoder data is clear and two encoders are available.

I would like to discuss if this format is comfortable for us. 