### PR TITLE
Update eval_angle to be robust against outliers and packet drops

### DIFF
--- a/sotodlib/hwp/g3thwp.py
+++ b/sotodlib/hwp/g3thwp.py
@@ -622,7 +622,7 @@ class G3tHWP():
         average_slit = np.average(template_slit)
         # subtract template, keep raw timestamp
         subtract = np.cumsum(np.roll(np.tile(template_slit-average_slit,
-            len(solved['ref_indexes'+suffix]) + 1), solved['ref_indexes'+suffix][0] + 1)[:len(solved['fast_time'+suffix])])
+            len(solved['ref_indexes'+suffix]) + 1 + self._num_dropped_pkts), solved['ref_indexes'+suffix][0] + 1)[:len(solved['fast_time'+suffix])])
         solved['fast_time_raw'+suffix] = solved['fast_time'+suffix]
         solved['fast_time'+suffix] = solved['fast_time'+suffix] - subtract
 
@@ -1140,7 +1140,7 @@ class G3tHWP():
             # Define mean value as nominal slit distance
             if len(__diff) == 0:
                 continue
-            slit_dist = np.mean(__diff)
+            slit_dist = scipy.stats.trim_mean(__diff, 0.01)
 
             # Conditions for idenfitying the ref slit
             # Slit distance somewhere between 2 slits:

--- a/sotodlib/hwp/g3thwp.py
+++ b/sotodlib/hwp/g3thwp.py
@@ -622,7 +622,7 @@ class G3tHWP():
         average_slit = np.average(template_slit)
         # subtract template, keep raw timestamp
         subtract = np.cumsum(np.roll(np.tile(template_slit-average_slit,
-            len(solved['ref_indexes'+suffix]) + 1 + self._num_dropped_pkts), solved['ref_indexes'+suffix][0] + 1)[:len(solved['fast_time'+suffix])])
+            len(solved['ref_indexes'+suffix]) + 1), solved['ref_indexes'+suffix][0] + 1)[:len(solved['fast_time'+suffix])])
         solved['fast_time_raw'+suffix] = solved['fast_time'+suffix]
         solved['fast_time'+suffix] = solved['fast_time'+suffix] - subtract
 

--- a/sotodlib/hwp/g3thwp.py
+++ b/sotodlib/hwp/g3thwp.py
@@ -4,6 +4,7 @@
 import os
 import numpy as np
 import scipy.interpolate
+import scipy.stats
 import so3g
 from spt3g import core
 import logging
@@ -617,7 +618,7 @@ class G3tHWP():
         # make template
         template_slit = np.diff(ft).reshape(
             len(solved['ref_indexes'+suffix])-2, self._num_edges)
-        template_slit = np.average(template_slit, axis=0)
+        template_slit = scipy.stats.trim_mean(template_slit, 0.01, axis=0)
         average_slit = np.average(template_slit)
         # subtract template, keep raw timestamp
         subtract = np.cumsum(np.roll(np.tile(template_slit-average_slit,

--- a/sotodlib/site_pipeline/make_hwp_solutions.py
+++ b/sotodlib/site_pipeline/make_hwp_solutions.py
@@ -127,7 +127,7 @@ def main(
     obs_list = ctx.obsdb.query(tot_query)
         
     if len(obs_list)==0:
-        logger.warning(f"No observations returned from query: {query}")
+        logger.warning(f"No observations returned from query: {tot_query}")
     run_list = []
 
     if not os.path.exists(man_db_filename):


### PR DESCRIPTION
This pull request suggests modification in `eval_angle`.
Template subtraction is found to be weak against angle jitter in the conventional script. 
Template is evaluated by averaging the one cycle of the angle pattern.
Angle jitter affects to the template evaluation, thus results in jitters appearing every one cycle after the template subtraction.

The new function uses `scipy.stats.trim_mean()` to calculate averaged template without outliers.

supplemental slides (p2-4)
https://docs.google.com/presentation/d/1FyuvC_oyzi4VHhw9ofsP-fmVCFoXpyoEJe7Q_0TOR3E/edit#slide=id.g2ae72945b36_0_16