### PR TITLE
ManifestDb HWP logic fix

### DIFF
--- a/sotodlib/hwp/g3thwp.py
+++ b/sotodlib/hwp/g3thwp.py
@@ -535,7 +535,7 @@ class G3tHWP():
         solved: dict
           dict data from analyze
         output: str or None
-          output path + file name, overwrite config file
+          output path + file name, override config file
 
         Notes
         -----------

--- a/sotodlib/hwp/g3thwp.py
+++ b/sotodlib/hwp/g3thwp.py
@@ -535,7 +535,7 @@ class G3tHWP():
         solved: dict
           dict data from analyze
         output: str or None
-          output path + file name, overwirte config file
+          output path + file name, overwrite config file
 
         Notes
         -----------

--- a/sotodlib/io/imprinter_cli.py
+++ b/sotodlib/io/imprinter_cli.py
@@ -6,6 +6,20 @@ books to now be successfully bound), to skip binding those files (push
 timestreams into the stray books), or do nothing.
 
 --action=timecodes: not implemented yet
+
+Additional Arguments for working with system running in a docker image (note
+that if we implement an environment variable prefix for the data-packaging
+system then this setup will be unnecessary):
+
+--g3-config: point directly to the g3tsmurf configuration file. The site setup
+mounts the site-pipeline-configs folder into /config, when running this script
+outside of the docker container you have to override this imprinter configuration.
+
+--output-root: the output root for the books when running outside the docker
+image. The docker container mounts /so/staged into /staged. Means when running
+outside the docker container you have to override this imprinter configuration
+AND fix the path in the imprinter database to match books made inside the docker
+container. 
 """
 import os
 import argparse

--- a/sotodlib/io/imprinter_cli.py
+++ b/sotodlib/io/imprinter_cli.py
@@ -83,16 +83,12 @@ def check_failed_books(imprint:Imprinter):
                 book, ignore_tags=ignore_tags, ancil_drop_duplicates=ancil_drop_duplicates
             )
             if imprint.docker_output_root is not None:
-                session = imprint.get_session()
-                db_book = session.query(Books).filter(
-                    Books.bid == book
-                ).one()
-                db_book.path = db_book.replace(
+                book.path = book.path.replace(
                     imprint.output_root, 
                     imprint.docker_output_root
                 )
-                session.commit()
-                print(f"Updated book path to {db_book.path}")
+                imprinter.get_session().commit()
+                print(f"Updated book path to {book.path}")
         elif resp == 3:
             utils.set_book_wont_bind(imprint, book)
         elif resp == 4:

--- a/sotodlib/io/imprinter_cli.py
+++ b/sotodlib/io/imprinter_cli.py
@@ -87,7 +87,7 @@ def check_failed_books(imprint:Imprinter):
                     imprint.output_root, 
                     imprint.docker_output_root
                 )
-                imprinter.get_session().commit()
+                imprint.get_session().commit()
                 print(f"Updated book path to {book.path}")
         elif resp == 3:
             utils.set_book_wont_bind(imprint, book)

--- a/sotodlib/io/imprinter_utils.py
+++ b/sotodlib/io/imprinter_utils.py
@@ -82,7 +82,7 @@ def set_book_rebind(imprint, book):
         if op.exists(book_dir):
             print(f"Removing all files from {book_dir}")
             shutil.rmtree(book_dir)
-    book.status = 0
+    book.status = UNBOUND
     imprint.get_session().commit()
 
     

--- a/sotodlib/site_pipeline/make_hwp_solutions.py
+++ b/sotodlib/site_pipeline/make_hwp_solutions.py
@@ -154,6 +154,7 @@ def main(
     for obs in run_list:
         h5_address = obs["obs_id"]
         logger.info(f"Calculating Angles for {h5_address}")
+        ctx = core.Context(context)
         tod = ctx.get_obs(obs, no_signal=True)
         
         # make angle solutions

--- a/sotodlib/site_pipeline/make_hwp_solutions.py
+++ b/sotodlib/site_pipeline/make_hwp_solutions.py
@@ -100,18 +100,29 @@ def main(
         
     ctx = core.Context(context)
 
-    scheme = core.metadata.ManifestScheme()
-    scheme.add_exact_match('obs:obs_id')
-    scheme.add_data_field('dataset')
-    man_db = core.metadata.ManifestDb(scheme=scheme)
-    
     # Get file + dataset from policy.
     # policy = util.ArchivePolicy.from_params(config['archive']['policy'])
     # dest_file, dest_dataset = policy.get_dest(obs_id)
     # Use 'output_dir' argument for now    
+    h5_filename = 'hwp_angle.h5'
     man_db_filename = os.path.join(output_dir, 'hwp_angle.sqlite')
-    output_filename = os.path.join(output_dir, 'hwp_angle.h5')
+    output_filename = os.path.join(output_dir, h5_filename)
     
+    if os.path.exists(man_db_filename):
+        logger.info(f"Mapping {man_db_filename} for the "
+                    "archive index.")
+        man_db = core.metadata.ManifestDb(man_db_filename)
+    else: 
+        logger.info(f"Creating {man_db_filename} for the "
+                     "archive index.")
+        scheme = core.metadata.ManifestScheme()
+        scheme.add_exact_match('obs:obs_id')
+        scheme.add_data_field('dataset')
+        man_db = core.metadata.ManifestDb(
+            man_db_filename,
+            scheme=scheme
+        )
+
     # load observation data
     if obs_id is not None:
         tot_query = f"obs_id=='{obs_id}'"
@@ -133,16 +144,11 @@ def main(
     if len(obs_list)==0:
         logger.warning(f"No observations returned from query: {query}")
     run_list = []
+    completed = man_db.get_entries(['dataset'])['dataset']
 
-    if not os.path.exists(man_db_filename):
-        #run on all if database doesn't exist
-        run_list = obs_list
-    else:
-        db = core.metadata.ManifestDb(man_db_filename)
-        for obs in obs_list:
-            x = db.match({'obs:obs_id': obs["obs_id"]}, multi=True)
-            if overwrite or not x:
-                run_list.append(obs)
+    for obs in obs_list:
+        if overwrite or not obs['obs_id'] in completed:
+            run_list.append(obs)
 
     #write solutions
     for obs in run_list:
@@ -161,11 +167,9 @@ def main(
         del g3thwp
         
         # Add an entry to the database
-        man_db.add_entry({'obs:obs_id': obs["obs_id"], 'dataset': h5_address}, filename=output_filename)
-
-        # Commit the ManifestDb to file.
-        man_db.to_file(man_db_filename)
-   
+        man_db.add_entry(
+            {'obs:obs_id': obs["obs_id"], 'dataset': h5_address}, filename=h5_filename,
+        )   
     return
     
     


### PR DESCRIPTION
This fixes the logic for making and/or connecting to ManifestDbs with the HWP angles. Previously the behavior was creating a new database every time it was run. 

Also includes a fix to the Imprinter CLI to account better for an books we bind outside the docker image. 