### PR TITLE
Remove unused import that is also difficult dependency

### DIFF
--- a/sotodlib/site_pipeline/make_det_info_wafer.py
+++ b/sotodlib/site_pipeline/make_det_info_wafer.py
@@ -5,7 +5,6 @@ import logging
 import numpy as np
 from argparse import ArgumentParser
 
-from detmap.makemap import MapMaker
 import sotodlib
 from sotodlib import core
 from sotodlib.io.metadata import write_dataset


### PR DESCRIPTION
There are a couple other references to detmap in site-pipeline, but this is the only one referenced in the CLI.