### PR TITLE
Failed file cache and relative paths in smurf_caldbs

### DIFF
--- a/sotodlib/site_pipeline/update_smurf_caldbs.py
+++ b/sotodlib/site_pipeline/update_smurf_caldbs.py
@@ -10,14 +10,19 @@ Configuration file required::
     config = {
         'archive': {
             'detset': {
+                'root_dir': /path/to/detset/root,
                 'index': 'detset.sqlite',
                 'h5file': 'detset.h5',
                 'context': 'context.yaml',
+                'write_relpath': True
             },
             'det_cal': {
+                'root_dir': /path/to/det_cal/root,
                 'index': 'det_cal.sqlite',
                 'h5file': 'det_cal.h5,
                 'context': 'context.yaml',
+                'failed_obsid_cache': 'failed_obsids.yaml',
+                'write_relpath': True
             },
         },
         'g3tsmurf': g3tsmurf_hwp_config.yaml',
@@ -50,13 +55,17 @@ DEFAULT_pA_per_phi0 = 9e6
 default_logger = logging.getLogger('smurf_caldbs')
 if not default_logger.hasHandlers():
     sp_util.init_logger('smurf_caldbs')
+default_logger.setLevel(logging.DEBUG)
+
 
 
 def main(config: Union[str, dict], 
         overwrite:Optional[bool]=False,
-        logger=None):
-    smurf_detset_info(config, overwrite, logger)
-    run_update_det_caldb(config, logger=logger, overwrite=overwrite)
+        logger=None, skip_detset=False, skip_detcal=False):
+    if not skip_detset:
+        smurf_detset_info(config, overwrite, logger)
+    if not skip_detcal:
+        run_update_det_caldb(config, logger=logger, overwrite=overwrite)
 
 def smurf_detset_info(config: Union[str, dict], 
         overwrite:Optional[bool]=False,
@@ -71,25 +80,30 @@ def smurf_detset_info(config: Union[str, dict],
     if type(config) == str:
         config = yaml.safe_load(open(config, 'r'))
 
+    h5_path = config['archive']['detset']['h5file']
+    idx_path = config['archive']['detset']['index']
+    root_dir = config['archive']['detset'].get('root_dir')
+    if root_dir is not None:
+        h5_path = os.path.join(root_dir, h5_path)
+        idx_path = os.path.join(root_dir, idx_path)
+    h5_relpath = os.path.relpath(h5_path, start=os.path.dirname(idx_path))
+
     SMURF = G3tSmurf.from_configs(config['g3tsmurf'])
     session = SMURF.Session()
 
     imprinter = Imprinter(config['imprinter'])
     ctx = core.Context(config['archive']['detset']['context'])
 
-
-    if not os.path.exists(config['archive']['detset']['index']):
+    if not os.path.exists(idx_path):
         scheme = core.metadata.ManifestScheme()
         scheme.add_exact_match('dets:detset')
         scheme.add_data_field('dataset')
         db = core.metadata.ManifestDb( 
-            config['archive']['detset']['index'], 
+            idx_path,
             scheme=scheme
         )
     else:
-        db = core.metadata.ManifestDb( 
-            config['archive']['detset']['index'],
-        )
+        db = core.metadata.ManifestDb(idx_path)
 
     keys = [
         "dets:readout_id",
@@ -109,7 +123,6 @@ def smurf_detset_info(config: Union[str, dict],
     c = ctx.obsfiledb.conn.execute('select distinct name from detsets')
     ctx_detsets = [r[0] for r in c]
     added_detsets = db.get_entries(['dataset'])['dataset']
-
     detsets = session.query(TuneSets).all()
 
     for ts in detsets:
@@ -131,16 +144,17 @@ def smurf_detset_info(config: Union[str, dict],
                 'dets:tel_tube':stream_maps[ts.stream_id][1],
             })
         write_dataset(
-            det_rs, 
-            config['archive']['detset']['h5file'], 
+            det_rs, h5_path,
             ts.name, 
             overwrite,
         )
         # add new entries to database
+        write_relpath = config['archive']['detset'].get('write_relpath', True)
         if ts.name not in added_detsets:
             db_data = {'dets:detset': ts.name,
                     'dataset': ts.name}
-            db.add_entry(db_data, config['archive']['detset']['h5file'])
+            path = h5_relpath if write_relpath else h5_path
+            db.add_entry(db_data, filename=path)
 
 
 # Dtype for calibration set
@@ -211,6 +225,8 @@ class CalInfo:
     r_n: float = np.nan  
     p_sat: float = np.nan   # J
 
+class MissingSmurfInfo(Exception):
+    pass
 
 def get_cal_resset(ctx: core.Context, obs_id, logger=None):
     """
@@ -223,6 +239,8 @@ def get_cal_resset(ctx: core.Context, obs_id, logger=None):
 
     am = ctx.get_obs(obs_id, samples=(0, 1), ignore_missing=True, no_signal=True)
     cals = [CalInfo(rid) for rid in am.det_info.readout_id]
+    if 'smurf' not in am.det_info:
+        raise MissingSmurfInfo(f"Missing smurf info for {obs_id}")
 
     iv_obsids = get_cal_obsids(ctx, obs_id, 'iv')
 
@@ -338,10 +356,74 @@ def get_obs_with_detsets(ctx, detset_idx):
     return obs_ids
 
 
+def add_to_failed_cache(obs_id, cache_path, msg):
+    logger = default_logger
+    logger.info(f"Adding {obs_id} to failed obsid cache with msg: {msg}")
+    if os.path.exists(cache_path):
+        with open(cache_path, 'r') as f:
+            cache = yaml.safe_load(f)
+    else:
+        cache = {}
+
+    cache[str(obs_id)] = msg
+    with open(cache_path, 'w') as f:
+        yaml.safe_dump(cache, f)
+
+def get_failed_obsids(cache_path):
+    if cache_path is None:
+        return set([])
+    if not os.path.exists(cache_path):
+        return set([])
+    with open(cache_path, 'r') as f:
+        cache = yaml.safe_load(f)
+    return set(cache.keys())
+
 def update_det_caldb(ctx, idx_path, detset_idx, h5_path, logger=None, 
-                     show_pb=False, format_exc=False, overwrite=False):
+                     show_pb=False, format_exc=False, overwrite=False,
+                     failed_obsid_cache=None, root_dir=None, write_relpath=True):
+    """
+    Updates the detector caldb with new observations. This will find calibration
+    data for all observations that have detset data and are not in the
+    failed_obsid_cache if specified.
+
+    Args
+    -----
+    ctx: core.Context
+        Context object, must contain detset metadata
+    idx_path: str
+        Path to det_cal sqlite manifest db
+    detset_idx: str
+        Path to detset manifestdb
+    h5_path: str
+        Path to h5 file to write results set.
+    logger: logging.Logger
+        Logger to use. If not set will use default.
+    show_pb: bool
+        If True, will show progress bar and time remaining
+    format_exc: bool
+        If true, will log the full traceback whenever an exception is thrown.
+    overwrite: bool
+        If True, will overwrite existing entries in the h5 file.
+    failed_obsid_cache: str
+        Path to store failed obs-ids to avoid re-running them. If None, will not
+        use a failed obsid cache and will attempt to add calibration info for all
+        observations with detset data that are not in the det_cal manifest.
+    root_dir: str
+        Root directory of det_cal dbs. If true, will interpret ``idx_path``,
+        ``h5_path``, and ``failed_obsid_cache`` relative to the root_dir.
+    write_relpath: bool
+        If true, when adding entries to the manifestdb, will use the h5 path relative
+        to the idx_path.
+    """
+
     if logger is None:
         logger = default_logger
+
+    if root_dir is not None:
+        h5_path = os.path.join(root_dir, h5_path)
+        idx_path = os.path.join(root_dir, idx_path)
+        failed_obsid_cache = os.path.join(root_dir, failed_obsid_cache)
+    h5_relpath = os.path.relpath(h5_path, start=os.path.dirname(idx_path))
 
     if not os.path.exists(idx_path):
         scheme = core.metadata.ManifestScheme()
@@ -353,7 +435,9 @@ def update_det_caldb(ctx, idx_path, detset_idx, h5_path, logger=None,
     
     # detset_db = metadata.Manifest(detset_idx)
     obsids_with_detsets = get_obs_with_detsets(ctx, detset_idx)
-    obsids_with_obs = set(ctx.obsdb.query("type=='obs'")['obs_id'])
+    failed_obsids = get_failed_obsids(failed_obsid_cache)
+    obsids_with_obs = set(ctx.obsdb.query("type=='obs'")['obs_id']) - failed_obsids
+
 
     remaining_obsids = obsids_with_detsets.intersection(obsids_with_obs)
     if not overwrite: 
@@ -365,9 +449,15 @@ def update_det_caldb(ctx, idx_path, detset_idx, h5_path, logger=None,
                               key=(lambda s: s.split('_')[1]))
 
     logger.info("%d datasets to add", len(remaining_obsids))
+    # failed_obsid_cache = config['archive']['det_cal'].get('failed_obsid_cache')
     for obs_id in tqdm(remaining_obsids, disable=(not show_pb)):
         try:
             rset = get_cal_resset(ctx, obs_id)
+        except MissingSmurfInfo:
+            logger.error("Missing smurf info for %s", obs_id)
+            if failed_obsid_cache is not None:
+                add_to_failed_cache(obs_id, failed_obsid_cache, 'MISSING_SMURF_INFO')
+            continue
         except Exception as e:
             logger.error("Failed on %s: %s", obs_id, e)
             if format_exc:
@@ -376,26 +466,37 @@ def update_det_caldb(ctx, idx_path, detset_idx, h5_path, logger=None,
 
         logger.info("Writing metadata for %s", obs_id)
         write_dataset(rset, h5_path, obs_id, overwrite=overwrite)
+
+        path = h5_relpath if write_relpath else h5_path
         db.add_entry({
             'obs:obs_id': obs_id,
             'dataset': obs_id,
-        }, filename=h5_path, replace=overwrite)
+        }, filename=path, replace=overwrite)
 
 
-def run_update_det_caldb(config_path, logger=None, format_exc=False, show_pb=False, overwrite=False):
+def run_update_det_caldb(config_path, logger=None, overwrite=False):
     with open(config_path, 'r') as f:
         config = yaml.safe_load(f)
+
+    format_exc = config['archive']['det_cal'].get('format_exc', False)
+    detset_idx = config['archive']['detset']['index']
+    detset_root_path = config['archive']['detset'].get('root_dir')
+    if detset_root_path is not None:
+        detset_idx = os.path.join(detset_root_path, detset_idx)
 
     ctx = core.Context(config['archive']['det_cal']['context'])
     update_det_caldb(
         ctx, 
         config['archive']['det_cal']['index'],
-        config['archive']['detset']['index'],
+        detset_idx,
         config['archive']['det_cal']['h5file'],
-        show_pb=show_pb,
+        show_pb=config['archive']['det_cal'].get('show_pb', False),
         logger=logger,
         format_exc=format_exc,
-        overwrite=overwrite
+        overwrite=overwrite,
+        failed_obsid_cache=config['archive']['det_cal'].get('failed_obsid_cache'),
+        root_dir=config['archive']['det_cal'].get('root_dir'),
+        write_relpath=config['archive']['det_cal'].get('write_relpath', True),
     )
 
 
@@ -404,6 +505,12 @@ def get_parser(parser=None):
         parser = argparse.ArgumentParser()
     parser.add_argument(
         '--config', type=str, help="configuration file"
+    )
+    parser.add_argument(
+        '--skip-detset', action='store_true', help="Skip detset update"
+    )
+    parser.add_argument(
+        '--skip-detcal', action='store_true', help="Skip detcal update"
     )
     parser.add_argument(
         '--overwrite', action='store_true',

--- a/sotodlib/site_pipeline/update_smurf_caldbs.py
+++ b/sotodlib/site_pipeline/update_smurf_caldbs.py
@@ -55,7 +55,6 @@ DEFAULT_pA_per_phi0 = 9e6
 default_logger = logging.getLogger('smurf_caldbs')
 if not default_logger.hasHandlers():
     sp_util.init_logger('smurf_caldbs')
-default_logger.setLevel(logging.DEBUG)
 
 
 


### PR DESCRIPTION
This adds a few things to the `update_smurf_caldbs` script to:
- Cache failed obsids in the update_detcal function
- Adds option to write the h5path relative to the dbpath in both detset and detcal dbs. This makes it so that we can simply copy the h5 and sqlite files to a new location and don't have to re-root.
- Adds `root_dir` param to config, so you can update that once instead of changing the path for the h5files and dbfiles separately when testing in a new directory.
- Adds `--skip-detsets` and `--skip-detcal` args for testing