### PR TITLE
Metadata - on_missing

### DIFF
--- a/docs/context.rst
+++ b/docs/context.rst
@@ -208,32 +208,11 @@ Context system:
     :func:`sotodlib.core.context.obsloader_template`.
 
 ``metadata``
-
-    A list of metadata specs.  For more detailed description, see the
+    A list of metadata specs.  For a detailed description, see the
     docstring for
-    :func:`SuperLoader.load_raw<metadata.SuperLoader.load_raw>`.  But
-    briefly each metadata spec is a dictionary with the following
-    entries:
-
-    ``db``
-        The path to a ManifestDb.
-
-    ``name``
-
-        A string describing what field to extract from the metadata,
-        and where to store it in the output AxisManager.  For details
-        on the syntax, see
-        :func:`Unpacker.decode<metadata.Unpacker.decode>`.
-
-    ``loader``
-        The name of the metadata loader function to use; these
-        functions must be registered in module variable
-        sotodlib.core.metadata.REGISTRY.  This is optional; if absent
-        it will default to 'HdfPerDetector' or (more likely) to
-        whatever is specified in the ManifestDb.
+    :func:`SuperLoader.load_one<metadata.SuperLoader.load_one>`.
 
 ``context_hooks``
-
     A string that identifies a set of functions to hook into
     particular parts of the Context system.  See uses of _call_hook()
     in the Context code, for any implemented hook function names and
@@ -263,20 +242,6 @@ storage format.  The API is documented in the ``obsloader_template``
 function:
 
 .. autofunction:: sotodlib.core.context.obsloader_template
-
-SuperLoader
------------
-
-.. autoclass:: sotodlib.core.metadata.SuperLoader
-   :special-members: __init__
-   :members:
-
-Unpacker
---------
-
-.. autoclass:: sotodlib.core.metadata.Unpacker
-   :special-members: __init__
-   :members:
 
 
 .. py:module:: sotodlib.core.metadata
@@ -988,6 +953,50 @@ However, it is expected that in most cases either ``readout_id`` or
 ``det_id`` will be used to label det_info contributions.
 
 
+Metadata System APIs
+====================
+
+SuperLoader
+-----------
+
+.. autoclass:: SuperLoader
+   :special-members: __init__
+   :members:
+
+Unpacker
+--------
+
+.. autoclass:: Unpacker
+   :special-members: __init__
+   :members:
+
+ResultSet
+---------
+
+.. autoclass:: ResultSet
+   :special-members: __init__
+   :members:
+
+sotodlib.io.metadata
+--------------------
+
+This module contains functions for working with ResultSet in HDF5.
+
+Here's the docstring for ``write_dataset``:
+
+.. autofunction:: sotodlib.io.metadata.write_dataset
+
+Here's the docstring for ``read_dataset``:
+
+.. autofunction:: sotodlib.io.metadata.read_dataset
+
+Here's the class documentation for ResultSetHdfLoader:
+
+.. autoclass:: sotodlib.io.metadata.ResultSetHdfLoader
+   :inherited-members: __init__
+   :members:
+
+
 ------------------------------------
 DetDb: Detector Information Database
 ------------------------------------
@@ -1632,36 +1641,6 @@ Class Documentation
    :special-members: __init__
    :members:
 
-
----------
-ResultSet
----------
-
-Auto-generated documentation should appear here.
-
-.. autoclass:: ResultSet
-   :special-members: __init__
-   :members:
-
---------------------
-sotodlib.io.metadata
---------------------
-
-This module contains functions for working with ResultSet in HDF5.
-
-Here's the docstring for ``write_dataset``:
-
-.. autofunction:: sotodlib.io.metadata.write_dataset
-
-Here's the docstring for ``read_dataset``:
-
-.. autofunction:: sotodlib.io.metadata.read_dataset
-
-Here's the class documentation for ResultSetHdfLoader:
-
-.. autoclass:: sotodlib.io.metadata.ResultSetHdfLoader
-   :inherited-members: __init__
-   :members:
 
 -----------------
 Command Line Tool

--- a/docs/context.rst
+++ b/docs/context.rst
@@ -208,9 +208,8 @@ Context system:
     :func:`sotodlib.core.context.obsloader_template`.
 
 ``metadata``
-    A list of metadata specs.  For a detailed description, see the
-    docstring for
-    :func:`SuperLoader.load_one<metadata.SuperLoader.load_one>`.
+    A list of metadata specs.  Each metadata spec is a dict with the
+    schema as described by :class:`metadata.MetadataSpec`.
 
 ``context_hooks``
     A string that identifies a set of functions to hook into
@@ -956,6 +955,24 @@ However, it is expected that in most cases either ``readout_id`` or
 Metadata System APIs
 ====================
 
+load_metadata
+-------------
+
+*This function provides a way to load metadata for an AxisManager,
+from a ManifestDb, without having to encode the result in a
+context.yaml metadata entry.*
+
+.. autofunction:: load_metadata
+
+
+MetadataSpec
+------------
+
+.. autoclass:: MetadataSpec
+   :special-members: __init__
+   :members:
+
+
 SuperLoader
 -----------
 
@@ -963,12 +980,6 @@ SuperLoader
    :special-members: __init__
    :members:
 
-Unpacker
---------
-
-.. autoclass:: Unpacker
-   :special-members: __init__
-   :members:
 
 ResultSet
 ---------

--- a/docs/context.rst
+++ b/docs/context.rst
@@ -119,20 +119,20 @@ annotated example.
   # specified in the database.
   metadata:
     - db: "{metadata_lib}/cuts_s17_c11_200327_cuts.sqlite"
-      name: "glitch_flags&flags"
+      unpack: "glitch_flags&flags"
     - db: "{metadata_lib}/cuts_s17_c11_200327_planet_cuts.sqlite"
-      name: "source_flags&flags"
+      unpack: "source_flags&flags"
     - db: "{metadata_lib}/cal_s17_c11_200327.sqlite"
-      name: "relcal&cal"
+      unpack: "relcal&cal"
     - db: "{metadata_lib}/timeconst_200327.sqlite"
-      name: "timeconst&"
+      unpack: "timeconst&"
       loader: "PerDetectorHdf5"
     - db: "{metadata_lib}/abscal_190126.sqlite"
-      name: "abscal&cal"
+      unpack: "abscal&cal"
     - db: "{metadata_lib}/detofs_200218.sqlite"
-      name: "focal_plane"
+      unpack: "focal_plane"
     - db: "{metadata_lib}/pointofs_200218.sqlite"
-      name: "pointofs"
+      unpack: "pointofs"
 
 
 With a context like the one above, a user can load a TOD and its
@@ -250,8 +250,8 @@ function:
 Metadata
 --------
 
-Overview and Examples
-=====================
+Background
+==========
 
 The "metadata" we are talking about here consists of things like
 detector pointing offsets, calibration factors, detector time
@@ -282,6 +282,12 @@ observations and the wafer for each detector), the system can support
 resolving the metadata request, loading the results, and broadcasting
 them to their intended targets.
 
+
+Examples
+========
+
+These examples demonstrate the creation of a metadata archive and
+index, and adding an entry to the context.yaml metadata list.
 
 Example 1
 ---------
@@ -323,8 +329,8 @@ metadata index::
 Then have a new context file that includes::
 
     metadata:
-        - db : 'thing_db.gz'
-          name : 'thing'
+        - db: 'thing_db.gz'
+          unpack: 'thing'
 
 Using that context file::
 
@@ -397,7 +403,7 @@ a metadata list that includes::
 
     metadata:
       - db: 'my_new_info.sqlite'
-        name: 'new_info'
+        unpack: 'new_info'
 
 If you want to load the single vector ``my_special_vector`` into the
 top level of the AxisManager, under name ``special``, use this
@@ -405,7 +411,7 @@ syntax::
 
     metadata:
       - db: 'my_new_info.sqlite'
-        name: 'special&my_special_vector'
+        unpack: 'special&my_special_vector'
 
 
 Tips
@@ -782,7 +788,7 @@ The context.yaml metadata entry would probably look like this::
   metadata:
     ...
     - db: '{metadata_lib}/cal_bad_det_issue.gz'
-      name: 'cal_remove_bad&cal'
+      unpack: 'cal_remove_bad&cal'
     ...
 
 
@@ -878,6 +884,62 @@ steps are performed:
    field from the result, for example).
 
 
+Incomplete or missing metadata
+------------------------------
+
+Metadata is considered "incomplete" for a particular request, if any
+of the following are true:
+
+- No endpoints were returned from the query to the ManifestDb;
+  i.e. the database has no records of what files contain data
+  pertinent to the request.
+- The results loaded from the metadata archive do not cover the
+  requested sample range or detector set completely (this includes the
+  case where there is zero overlap).
+
+When a metadata result is incomplete, the metadata loader code will
+take one of the following actions:
+
+- `trim`: take the limited metadata result, and trim the merged data
+  object down so it contains only the detectors and samples that are
+  found in the metadata result.
+- `skip`: discard this metadata result; do not include it in the
+  merged data object.
+- `fail`: raise an error.
+
+In the metadata list in ``context.yaml``, each metadata entry can
+declare a preferred action using the ``on_missing`` key.  For
+example::
+
+  metadata:
+    - label: optional_relcal
+      on_missing: skip
+      db: "relcal1.sqlite"
+      unpack: "optional_relcal&cal"
+    - label: critical_relcal
+      on_missing: fail
+      db: "relcal2.sqlite"
+      unpack: "critical_relcal&cal"
+
+The default behavior is ``trim``.  The behavior specified in
+``context.yaml`` can be overridden through the call to
+:func:`Context.get_obs()<sotodlib.core.Context.get_obs>` or
+:func:`Context.get_meta()<sotodlib.core.Context.get_meta>`; just use
+the ``on_missing`` argument to specify what should happen for metadata
+with a specific label.  Examples::
+
+  # Suppose this fails because relcal2.sqlite does not cover the obs ...
+  tod = ctx.get_obs(obs_id)
+
+  # This will instead ignore the result, and not populate critical_relcal.
+  tod = ctx.get_obs(obs_id, on_missing={'critical_relcal': 'skip'})
+
+
+Note that "skipping" can have confusing downstream consequences, such
+as when a ``det_info`` entry doesn't get added and then some metadata
+product tries to use it as an index field.
+
+
 Rules for augmenting and using det_info
 ---------------------------------------
 
@@ -911,7 +973,7 @@ following additional steps will usually be performed to augment the
 
 Special metadata entries in context.yaml are used to augment the
 ``det_info``.  table; these are marked with ``det_info: true`` and do
-not have a ``name: ...`` field.  For example::
+not have a ``unpack: ...`` field.  For example::
 
   metadata:
   - ...

--- a/sotodlib/core/context.py
+++ b/sotodlib/core/context.py
@@ -177,6 +177,7 @@ class Context(odict):
                 detsets=None,
                 meta=None,
                 ignore_missing=None,
+                on_missing=None,
                 free_tags=None,
                 no_signal=None,
                 loader_type=None,
@@ -211,6 +212,10 @@ class Context(odict):
             obs_colon_tags fields for detector restrictions.
           ignore_missing (bool): If True, don't fail when a metadata
             item can't be loaded, just try to proceed without it.
+          on_missing (dict): If a metadata entry has a label that
+            matches a key in this dict, the corresponding value in
+            this dict will override the on_missing setting from the
+            metadata entry.
           no_signal (bool): If True, the .signal will be set to None.
             This is a way to get the axes and pointing info without
             the (large) TOD blob.  Not all loaders may support this.
@@ -279,7 +284,8 @@ class Context(odict):
         """
         meta = self.get_meta(obs_id=obs_id, dets=dets, samples=samples,
                              filename=filename, detsets=detsets, meta=meta,
-                             free_tags=free_tags, ignore_missing=ignore_missing)
+                             free_tags=free_tags, ignore_missing=ignore_missing,
+                             on_missing=on_missing)
 
         # Use the obs_id, dets, and samples from meta.
         obs_id = meta['obs_info']['obs_id']
@@ -335,14 +341,16 @@ class Context(odict):
                  free_tags=None,
                  check=False,
                  ignore_missing=False,
+                 on_missing=None,
                  det_info_scan=False):
         """Load supporting metadata for an observation and return it in an
         AxisManager.
 
         The arguments shared with :func:`get_obs` (``obs_id``,
-        ``dets``, ``samples`, ``filename``, ``detsets`, ``meta``,
-        ``free_tags``) have the same meaning as in that function and
-        are treated in the same way.
+        ``dets``, ``samples``, ``filename``, ``detsets``, ``meta``,
+        ``free_tags``, ``ignore_missing``, ``on_missing``) have the
+        same meaning as in that function and are treated in the same
+        way.
 
         Args:
           check (bool): If True, run in a check mode where an attempt
@@ -471,7 +479,8 @@ class Context(odict):
         metadata_list = self._get_warn_missing('metadata', [])
         meta = self.loader.load(metadata_list, request, det_info=det_info, check=check,
                                 free_tags=free_tags, free_tag_fields=free_tag_fields,
-                                det_info_scan=det_info_scan, ignore_missing=ignore_missing)
+                                det_info_scan=det_info_scan, ignore_missing=ignore_missing,
+                                on_missing=on_missing)
         if check:
             return meta
 
@@ -492,7 +501,8 @@ class Context(odict):
                      filename=None,
                      detsets=None,
                      meta=None,
-                     free_tags=None):
+                     free_tags=None,
+                     on_missing=None):
         """Pass all arguments to :func:`get_meta(det_info_scan=True)`, and
         then return only the det_info, as a ResultSet.
 
@@ -500,7 +510,7 @@ class Context(odict):
         if meta is None:
             meta = self.get_meta(obs_id=obs_id, dets=dets, samples=samples,
                                  filename=filename, detsets=detsets, free_tags=free_tags,
-                                 det_info_scan=True)
+                                 on_missing=on_missing, det_info_scan=True)
         # Convert
         def _unpack(aman):
             items = []

--- a/sotodlib/core/context.py
+++ b/sotodlib/core/context.py
@@ -177,7 +177,6 @@ class Context(odict):
                 detsets=None,
                 meta=None,
                 ignore_missing=None,
-                ignore_missing_dets=False,
                 free_tags=None,
                 no_signal=None,
                 loader_type=None,
@@ -212,8 +211,6 @@ class Context(odict):
             obs_colon_tags fields for detector restrictions.
           ignore_missing (bool): If True, don't fail when a metadata
             item can't be loaded, just try to proceed without it.
-          ignore_missing_dets (bool): If True, don't fail when metadata entries
-            are missing information for a subset of detectors.
           no_signal (bool): If True, the .signal will be set to None.
             This is a way to get the axes and pointing info without
             the (large) TOD blob.  Not all loaders may support this.
@@ -282,8 +279,7 @@ class Context(odict):
         """
         meta = self.get_meta(obs_id=obs_id, dets=dets, samples=samples,
                              filename=filename, detsets=detsets, meta=meta,
-                             free_tags=free_tags, ignore_missing=ignore_missing,
-                             ignore_missing_dets=ignore_missing_dets)
+                             free_tags=free_tags, ignore_missing=ignore_missing)
 
         # Use the obs_id, dets, and samples from meta.
         obs_id = meta['obs_info']['obs_id']
@@ -339,7 +335,6 @@ class Context(odict):
                  free_tags=None,
                  check=False,
                  ignore_missing=False,
-                 ignore_missing_dets=False,
                  det_info_scan=False):
         """Load supporting metadata for an observation and return it in an
         AxisManager.
@@ -476,8 +471,7 @@ class Context(odict):
         metadata_list = self._get_warn_missing('metadata', [])
         meta = self.loader.load(metadata_list, request, det_info=det_info, check=check,
                                 free_tags=free_tags, free_tag_fields=free_tag_fields,
-                                det_info_scan=det_info_scan,ignore_missing=ignore_missing,
-                                ignore_missing_dets=ignore_missing_dets)
+                                det_info_scan=det_info_scan, ignore_missing=ignore_missing)
         if check:
             return meta
 

--- a/sotodlib/core/metadata/__init__.py
+++ b/sotodlib/core/metadata/__init__.py
@@ -8,7 +8,10 @@ from .detdb import DetDb
 from .obsdb import ObsDb
 from .obsfiledb import ObsFileDb
 from .manifest import ManifestDb, ManifestScheme
-from .loader import SuperLoader, LoaderInterface, Unpacker, merge_det_info
+from .loader import (
+    SuperLoader, LoaderInterface, MetadataSpec,
+    merge_det_info, load_metadata,
+)
 from . import cli
 
 def get_example(db_type, *args, **kwargs):

--- a/sotodlib/core/metadata/cli.py
+++ b/sotodlib/core/metadata/cli.py
@@ -114,6 +114,8 @@ def main(args=None):
             name = entry.get('name')
             if name is None:
                 name = '(unnamed)'
+            if not isinstance(name, str):  # it could be a list!
+                name = str(name)
             if entry.get('det_info'):
                 name += ' -- [det_info]'
             print(f'  {name:<30}: {db_path}')

--- a/sotodlib/core/metadata/loader.py
+++ b/sotodlib/core/metadata/loader.py
@@ -327,7 +327,7 @@ class SuperLoader:
           ignore_missing (bool): If True, don't fail when a metadata
             item can't be loaded, just try to proceed without it.
           ignore_missing_dets (bool): If True, don't fail with a metadata
-            entry _that is not used for detector selection_ does not contain
+            entry *that is not used for detector selection* does not contain
             information for any subset of detectors.
         Returns:
           In normal mode, an AxisManager containing the metadata

--- a/sotodlib/core/metadata/loader.py
+++ b/sotodlib/core/metadata/loader.py
@@ -459,8 +459,10 @@ class SuperLoader:
                 if len(det_info) < n_dets:
                     if ignore_missing_dets:
                         logger.warning(f"{n_dets-len(det_info)} detectors are "
-                                       f"missing metadata information in "
+                                       f"missing det_info information in "
                                        f"spec={spec}. ")
+                        # reset count so warning doesn't propagate
+                        n_dets = len(det_info) 
                     else:
                         raise ValueError(f"{n_dets-len(det_info)} detectors are "
                                          f"missing metadata information in "
@@ -498,6 +500,8 @@ class SuperLoader:
                     logger.warning(f"{n_dets-dest.dets.count} detectors are "
                                    f"missing metadata information in "
                                    f"spec={spec}. ")
+                    # reset count so warning doesn't propagate
+                    n_dets = dest.dets.count 
                 else:
                     raise ValueError(f"{n_dets-dest.dets.count} detectors are "
                                      f"missing metadata information in "

--- a/sotodlib/core/metadata/loader.py
+++ b/sotodlib/core/metadata/loader.py
@@ -315,7 +315,7 @@ class SuperLoader:
 
     def load(self, spec_list, request, det_info=None, free_tags=[],
              free_tag_fields=[], dest=None, check=False, det_info_scan=False,
-             ignore_missing=False, on_missing={}):
+             ignore_missing=False, on_missing=None):
         """Loads metadata objects and processes them into a single
         AxisManager.
 
@@ -359,6 +359,9 @@ class SuperLoader:
         # Augmented request -- note that dets:* restrictions from
         # request will be added back into this by check tags.
         aug_request = _filter_items('obs:', request, False)
+
+        if on_missing is None:
+            on_missing = {}
 
         if self.obsdb is not None and 'obs:obs_id' in request:
             if dest is None:
@@ -442,10 +445,10 @@ class SuperLoader:
             logger.debug(f'Processing metadata spec={spec} with augmented '
                          f'request={aug_request}')
 
-            label = spec.get('label', spec.get('name'), None)
+            label = spec.get('label', spec.get('name', None))
             _on_missing = spec.get('on_missing', 'trim')
             if label is not None and label in on_missing:
-                _on_missing = on_missing['label']
+                _on_missing = on_missing[label]
                 logger.debug(f'User overrides on_missing={_on_missing} for {label}')
 
             assert _on_missing in ['trim', 'skip', 'fail']

--- a/sotodlib/core/metadata/loader.py
+++ b/sotodlib/core/metadata/loader.py
@@ -90,13 +90,26 @@ class SuperLoader:
           The metadata ``spec`` dict has the following schema:
 
             ``db`` (str)
-                The path to a ManifestDb file.
+                The path to a ManifestDb file.  (For testing and other
+                purposes, this may be passed as a ManifestDb object
+                instead.)
 
             ``name`` (str)
-                Naively, the name to give to the extracted data.  But
-                the string may encode more complicated instructions,
-                which are understood by the Unpacker class in this
-                module.
+                Address in the containing AxisManager to which the
+                data should be unpacked.  This string may encode more
+                complicated instructions; see the Unpacker class in
+                this module.
+
+            ``on_missing`` (str)
+                An optional string describing how to proceed in the event that
+                the metadata is incomplete (or missing entirely) for the
+                target Observation.  The value should one of 'trim', 'skip',
+                or 'fail'.  The default is 'trim'.
+
+            ``label`` (str)
+                A short string describing the metadata (optional).  This is
+                used to target the entry when overriding the default
+                ``on_missing`` behavior.  If absent, defaults to ``name``.
 
             ``loader`` (str, optional)
                 The name of the loader class to use when loading the

--- a/sotodlib/core/metadata/loader.py
+++ b/sotodlib/core/metadata/loader.py
@@ -941,3 +941,38 @@ class LoaderInterface:
 
         """
         return [self.from_loadspec(p) for p in load_params]
+
+
+def load_metadata(tod, spec):
+    """Process a metadata entry for an AxisManager.
+
+    Args:
+
+      tod (AxisManager): The data structure from which to source any
+        obs_info and det_info that are needed to process the metadata
+        specification.  This
+      spec (dict): a metadata specification, such as one might find as
+        an element of the "metadata" list in a context.yaml file.
+
+    Returns:
+      The loaded metadata item, which could be an AxisManager or
+      ResultSet.  In the AxisManager case, the axes have likely not
+      been resolved against the provided `tod`, so the sample count
+      and detector count / ordering may be different.  (The caller can
+      merge after the fact.)
+
+    Notes:
+
+      The ``tod`` container needs to contain ``obs_info`` and
+      ``det_info`` (including the ``dets`` axis), in order to follow
+      any branching instructions for loading the metadata.  This would
+      normally be an AxisManager returned by ``Context.get_obs()`` or
+      ``get_meta()``.
+
+    """
+    loader = SuperLoader()
+    det_info = unconvert_det_info(tod.det_info)
+    request = {}
+    for k, v in tod.obs_info._fields.items():
+        request[f'obs:{k}'] = v
+    return loader.load_one(spec, request, det_info)

--- a/sotodlib/site_pipeline/preprocess_tod.py
+++ b/sotodlib/site_pipeline/preprocess_tod.py
@@ -97,7 +97,7 @@ def preprocess_tod(obs_id, configs, overwrite=False, logger=None):
                      "archive index.")
         scheme = core.metadata.ManifestScheme()
         scheme.add_exact_match('obs:obs_id')
-        scheme.add_data_field('dets:' + group_by)
+        scheme.add_exact_match('dets:' + group_by)
         scheme.add_data_field('dataset')
         db = core.metadata.ManifestDb(
             configs['archive']['index'],
@@ -118,14 +118,15 @@ def preprocess_tod(obs_id, configs, overwrite=False, logger=None):
             dest_dataset += '_' + group
         else:
             dest_dataset += "_" + group_by + "_" + str(group)
+        logger.info(f"Saving data to {dest_file}:{dest_dataset}")
         proc_aman.save(dest_file, dest_dataset, overwrite=overwrite)
 
-        logger.info("Saving to database")
         # Update the index.
         db_data = {'obs:obs_id': obs_id,
                    'dataset': dest_dataset}
         db_data['dets:'+group_by] = group
         
+        logger.info(f"Saving to database under {db_data}")
         if db.match(db_data) is None:
             db.add_entry(db_data, dest_file)
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -309,7 +309,8 @@ class ContextTest(unittest.TestCase):
         for spec in ctx['metadata']:
             item = metadata.loader.load_metadata(tod, spec)
             assert(item is not None)
-
+            item = metadata.loader.load_metadata(tod, spec, unpack=True)
+            assert(item is not None)
 
 class DatasetSim:
     """Provide in-RAM Context objects and tod/metadata loader functions

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -53,10 +53,12 @@ class ContextTest(unittest.TestCase):
         return name
 
     def test_000_smoke(self):
+        """Test basic instantiation of Context and basic DBs from files."""
         ctx_file = self._write_context(MINIMAL_CONTEXT)
         ctx = Context(ctx_file)
+        metadata.cli.main(args=['context', ctx_file])
+        del ctx, ctx_file
 
-    def test_001_dbs(self):
         # Does context populate obsdb, detdb, obsfiledb from file?
         for key, cls in [
                 ('obsdb', metadata.ObsDb),
@@ -70,7 +72,8 @@ class ContextTest(unittest.TestCase):
             cd[key] = name
             ctx_file = self._write_context(cd)
             ctx = Context(ctx_file)
-            self.assertIsInstance(getattr(ctx, key), cls)
+            self.assertIsInstance(getattr(ctx, key), cls,
+                                  msg=f"Instantiating '{key}'")
             metadata.cli.main(args=['context', ctx_file])
 
     def test_010_cli(self):
@@ -171,19 +174,68 @@ class ContextTest(unittest.TestCase):
             ctx.get_meta(obs_id)
         ctx.get_meta(obs_id, ignore_missing=True)
 
-        # Check detector info with missing entries
-        ctx = dataset_sim.get_context(with_bad_det_info_data=True)
-        with self.assertRaises(Exception):
-            ctx.get_meta(obs_id)
-        ctx.get_meta(obs_id, ignore_missing_dets=True)
+        # Check det_info with acceptable partial coverage.
+        ctx = dataset_sim.get_context(with_incomplete_det_info='trim')
+        meta = ctx.get_meta(obs_id)
+        self.assertTrue('newcal' in meta.det_info)
+        self.assertLess(meta.dets.count, 8)
 
-        # Check missing metadata
-        ctx = dataset_sim.get_context(with_incomplete_metadata=True)
-        with self.assertRaises(Exception):
-            ctx.get_meta('obs_number_12')
+        ctx = dataset_sim.get_context(with_incomplete_det_info='skip')
+        meta = ctx.get_meta(obs_id)
+        self.assertFalse('newcal' in meta.det_info)
+        self.assertEqual(meta.dets.count, 8)
+
+        ctx = dataset_sim.get_context(with_incomplete_det_info='trim',
+                                      with_dependent_metadata='trim')
+        meta = ctx.get_meta(obs_id)
+        self.assertTrue('depends' in meta)
+
+        # ... but skip should fail if dependent metadata requires what
+        # it is providing.
+        for dep in ['fail', 'skip', 'trim']:
+            # arguably this could be asked to not raise, for dep =
+            # skip or trim.
+            ctx = dataset_sim.get_context(with_incomplete_det_info='skip',
+                                          with_dependent_metadata=dep)
+            with self.assertRaises(metadata.loader.IncompleteDetInfoError):
+                meta = ctx.get_meta(obs_id)
+
+        # Check det_info with unacceptable partial coverage.
+        ctx = dataset_sim.get_context(with_incomplete_det_info='fail')
+        with self.assertRaises(metadata.loader.IncompleteMetadataError):
+            ctx.get_meta(obs_id)
+        # manual override.
+        ##ctx.get_meta(obs_id, )#ignore_missing_dets=True)
+        ##self.assertTrue('newcal' in meta.det_info)
+        ##self.assertLess(meta.dets.count, 8)
+        ##ctx.get_meta(obs_id, )#ignore_missing_dets=True)
+        ##self.assertFalse('newcal' in meta.det_info)
+        ##self.assertEqual(meta.dets.count, 8)
+
+        # Check metadata with acceptable partial coverage.
+        ctx = dataset_sim.get_context(with_incomplete_metadata='trim')
+        meta = ctx.get_meta(obs_id)
+        self.assertTrue('othercal' in meta)
+        self.assertLess(meta.dets.count, 8)
+
+        dataset_sim = DatasetSim()
+        obs_id = dataset_sim.obss['obs_id'][1]
+
+        ctx = dataset_sim.get_context(with_incomplete_metadata='skip')
+        meta = ctx.get_meta(obs_id)
+        self.assertEqual(meta.dets.count, 8)
+        self.assertFalse('othercal' in meta)
+
+        # Check metadata with unacceptable partial coverage.
+        ctx = dataset_sim.get_context(with_incomplete_metadata='fail')
+        with self.assertRaises(metadata.loader.IncompleteMetadataError):
+            m = ctx.get_meta(obs_id)
+        # manual overrides .
+        ## ctx.get_meta('obs_number_12', )# ignore_missing_dets=True)
+        ## ...
+
+        # Nothing wrong with good old obs 13 though
         ctx.get_meta('obs_number_13')
-        ctx.get_meta('obs_number_12', ignore_missing_dets=True)
-        ctx.get_meta('obs_number_13', ignore_missing_dets=True)
 
     def test_110_more_loads(self):
         dataset_sim = DatasetSim()
@@ -272,8 +324,23 @@ class DatasetSim:
         metadata.SuperLoader.register_metadata('unittest_loader', _TestML)
 
     def get_context(self, with_detdb=True, with_metadata=True,
-                    with_bad_metadata=False, with_bad_det_info_data=False,
-                    with_incomplete_metadata=False):
+                    with_bad_metadata=False, with_incomplete_det_info=False,
+                    with_dependent_metadata=False,
+                    with_incomplete_metadata=False, on_missing='trim'):
+        """Args:
+          with_detdb: if False, no detdb is included.
+          with_metadata: if False, no metadata are included.
+
+          with_bad_metadata: if True, an entry that refers to a
+            non-existant sqlite database is included.
+
+          with_incomplete_det_info: if True, include det_info entries
+            that are missing some dets, or a complete detset.
+
+          with_incomplete_metadata: if True, include entries that are
+            missing some dets, or a complete detset.
+
+        """
         detdb = metadata.DetDb()
         detdb.create_table('base', ['readout_id string',
                                     'pol_code string',
@@ -311,40 +378,47 @@ class DatasetSim:
         if not with_metadata:
             return ctx
 
-        # metadata: bands.h5
-        _scheme = metadata.ManifestScheme() \
-                  .add_data_field('loader') \
-                  .add_range_match('obs:timestamp')
-        bands_db = metadata.ManifestDb(scheme=_scheme)
-        bands_db.add_entry(
-            {'obs:timestamp': [0, 2e9], 'loader': 'unittest_loader'},
-            'bands.h5')
+        class _ManifestDb(metadata.ManifestDb):
+            def __init__(self, filename='unnamed', **kwargs):
+                super().__init__(**kwargs)
+                self._filename = filename
+            def __repr__(self):
+                return f'ManifestDb[{self._filename}]'
 
-        # metadata: det_id.h5
-        _scheme = metadata.ManifestScheme() \
-                  .add_data_field('loader') \
-                  .add_range_match('obs:timestamp')
-        det_id_db = metadata.ManifestDb(scheme=_scheme)
-        det_id_db.add_entry(
-            {'obs:timestamp': [0, 2e9], 'loader': 'unittest_loader'},
-            'det_id.h5')
+        def _db_single_dataset(filename):
+            # Many dbs map all obs to a single file, based on
+            # timestamp I guess.
+            scheme = metadata.ManifestScheme() \
+                             .add_data_field('loader') \
+                             .add_range_match('obs:timestamp')
+            db = _ManifestDb(scheme=scheme, filename=filename)
+            db.add_entry(
+                {'obs:timestamp': [0, 2e9], 'loader': 'unittest_loader'},
+                filename)
+            return db
 
-        # metadata: det_param.h5
-        _scheme = metadata.ManifestScheme() \
-                  .add_data_field('loader') \
-                  .add_range_match('obs:timestamp')
-        det_par_db = metadata.ManifestDb(scheme=_scheme)
-        det_par_db.add_entry(
-            {'obs:timestamp': [0, 2e9], 'loader': 'unittest_loader'},
-            'det_param.h5')
+        def _db_multi_dataset(filename, detsets=['neard', 'fard']):
+            # ... while others are to a single file but by detset, using dataset=detset data arg.
+            scheme = metadata.ManifestScheme() \
+                      .add_data_field('dataset') \
+                      .add_exact_match('dets:detset') \
+                      .add_data_field('loader')
+            db = _ManifestDb(scheme=scheme, filename=filename)
+            for detset in detsets:
+                db.add_entry(
+                    {'loader': 'unittest_loader',
+                     'dataset': detset,
+                     'dets:detset': detset,
+                     }, filename)
+            return db
 
-        # metadata: abscals.h5
+        # metadata: abscal.h5
         _scheme = metadata.ManifestScheme() \
                   .add_range_match('obs:timestamp') \
                   .add_data_field('loader') \
                   .add_data_field('dataset') \
                   .add_data_field('dets:band')
-        abscal_db = metadata.ManifestDb(scheme=_scheme)
+        abscal_db = _ManifestDb(scheme=_scheme, filename='abscal.h5')
         for band in ['f090', 'f150']:
             abscal_db.add_entry(
                 {'obs:timestamp': [0, 2e9],
@@ -360,7 +434,7 @@ class DatasetSim:
                   .add_data_field('loader') \
                   .add_data_field('frame_index', 'int') \
                   .add_data_field('dets:band')
-        flags_db = metadata.ManifestDb(scheme=_scheme)
+        flags_db = _ManifestDb(scheme=_scheme, filename='some_flags.g3')
         for frame, band in enumerate(['f090', 'f150', 'f220']):
             flags_db.add_entry(
                 {'obs:timestamp': [0, 2e9],
@@ -369,69 +443,27 @@ class DatasetSim:
                  'dets:band': band
                  }, 'some_flags.g3')
 
-        # metadata: some_detset_info.h5
-        ## This matches purely based on dets:* properties.
-        _scheme = metadata.ManifestScheme() \
-                  .add_data_field('dataset') \
-                  .add_exact_match('dets:detset') \
-                  .add_data_field('loader')
-        info_db = metadata.ManifestDb(scheme=_scheme)
-        for detset in ['neard', 'fard']:
-            info_db.add_entry(
-                {'loader': 'unittest_loader',
-                 'dataset': detset,
-                 'dets:detset': detset,
-                 }, 'some_detset_info.h5')
-
-        # metadata: detinfo_multimatch.h5
-        _scheme = metadata.ManifestScheme() \
-                  .add_data_field('dataset') \
-                  .add_exact_match('dets:detset') \
-                  .add_data_field('loader')
-        detinfo_db1 = metadata.ManifestDb(scheme=_scheme)
-        for detset in ['neard', 'fard']:
-            detinfo_db1.add_entry(
-                {'loader': 'unittest_loader',
-                 'dataset': detset,
-                 'dets:detset': detset,
-                 }, 'detinfo_multimatch.h5')
-
-        # metadata: detinfo_nomatch.h5
-        _scheme = metadata.ManifestScheme() \
-                  .add_data_field('dataset') \
-                  .add_exact_match('dets:detset') \
-                  .add_data_field('loader')
-        detinfo_db2 = metadata.ManifestDb(scheme=_scheme)
-        for detset in ['neard', 'fard']:
-            detinfo_db2.add_entry(
-                {'loader': 'unittest_loader',
-                 'dataset': detset,
-                 'dets:detset': detset,
-                 }, 'detinfo_nomatch.h5')
-
         # metadata into context.
         ctx['metadata'] = [
-            {'db': bands_db,
-             'det_info': True,
-            },
-            {'db': det_id_db,
-             'det_info': True,
-            },
+            {'db': _db_single_dataset('bands.h5'),
+             'det_info': True},
+            {'db': _db_single_dataset('det_id.h5'),
+             'det_info': True},
             {'db': abscal_db,
-             'name': 'cal&abscal'},
+             'name': 'cal&abscal',
+             'on_missing': 'fail'}, #on_missing},
             {'db': flags_db,
-             'name': 'flags&'},
-            {'db': info_db,
-             'name': 'focal_plane'},
-            {'db': det_par_db,
-             'det_info': True,
-            },
-            {'db': detinfo_db1,
-             'det_info': True,
-            },
-            {'db': detinfo_db2,
-             'det_info': True,
-            },
+             'name': 'flags&',
+             'on_missing': on_missing},
+            {'db': _db_multi_dataset('some_detset_info.h5'),
+             'name': 'focal_plane',
+             'on_missing': on_missing},
+            {'db': _db_single_dataset('det_param.h5'),
+             'det_info': True},
+            {'db': _db_multi_dataset('detinfo_multimatch.h5'),
+             'det_info': True},
+            {'db': _db_multi_dataset('detinfo_nomatch.h5'),
+             'det_info': True},
         ]
 
         if with_bad_metadata:
@@ -440,24 +472,24 @@ class DatasetSim:
                 'db': 'not-a-file.sqlite',
                 'name': 'important_info&',
             })
-        
-        if with_bad_det_info_data:
-            # metadata: incomplete_det_info.h5
-            ## This is an incomplete dataset.
-            _scheme = metadata.ManifestScheme() \
-                      .add_range_match('obs:timestamp') \
-                      .add_data_field('loader')
-            bad_det_info_db = metadata.ManifestDb(scheme=_scheme)
-            bad_det_info_db.add_entry(
-                {'obs:timestamp': [0, 2e9], 'loader': 'unittest_loader'},
-                 'incomplete_det_info.h5'
-            )
-            # This should cause metadata load error
+
+        if with_incomplete_det_info:
+            # det_info -- incomplete dataset; for key obs only a few
+            ## dets will have field defined.
             ctx['metadata'].insert(0, {
-                'db': bad_det_info_db,
+                'db': _db_single_dataset('incomplete_det_info.h5'),
                 'det_info': True,
-                'name': 'newcal' 
-            })    
+                'on_missing': with_incomplete_det_info,
+            })
+
+            if with_dependent_metadata:
+                # metadata -- loads in association with det_info
+                # fields defined through incomplete_det_info.
+                ctx['metadata'].insert(1, {
+                    'db': _db_single_dataset('dependent_metadata.h5'),
+                    'on_missing': with_dependent_metadata,
+                    'name': 'depends',
+                })
 
         if with_incomplete_metadata:
             # metadata: incomplete_metadata.h5
@@ -474,13 +506,16 @@ class DatasetSim:
                 {'obs:obs_id': 'obs_number_13', 'loader': 'unittest_loader'},
                  'incomplete_metadata.h5'
             )
-            # This should cause metadata load error
+            # This entry has incomplete metadata, which will cause a
+            # failure, a trim, or omission of the product depending on
+            # the value of with_incomplete_metadata.
             ctx['metadata'].insert(0, {
                 'db': bad_meta_db,
-                'name': 'othercal'
-            })    
+                'name': 'othercal',
+                'on_missing': with_incomplete_metadata,
+            })
 
-        return ctx 
+        return ctx
 
 
     def metadata_loader(self, kw):
@@ -564,31 +599,37 @@ class DatasetSim:
             for row in self.dets.subset(rows=self.dets['detset'] == kw['dataset']):
                 rs.append({'dets:det_id': row['det_id'],
                            'dets:farness': farness})
+            return rs
         elif filename == 'incomplete_det_info.h5':
             rs = metadata.ResultSet(['dets:readout_id', 'dets:newcal'])
             for row in self.dets.subset(rows=[0,1,2]):
                 rs.append({'dets:readout_id': row['readout_id'],
                            'dets:newcal':20})
             return rs
+        elif filename == 'dependent_metadata.h5':
+            rs = metadata.ResultSet(['dets:newcal', 'newcal_number'])
+            rs.append({'dets:newcal': 20,
+                       'newcal_number': 'twenty'})
+            return rs
         elif filename == 'incomplete_metadata.h5':
             rs = metadata.ResultSet([
                 'obs:obs_id',
-                'dets:readout_id', 
+                'dets:readout_id',
                 'othercal'
             ])
-            if kw['obs:obs_id']=='obs_number_12': 
+            if kw['obs:obs_id']=='obs_number_12':
                 for row in self.dets.subset(rows=[0,1,2]):
                     rs.append({'obs:obs_id': 'obs_number_12',
                                'dets:readout_id': row['readout_id'],
                                'othercal':40})
-            elif kw['obs:obs_id'] =='obs_number_13': 
+            elif kw['obs:obs_id'] =='obs_number_13':
                 for row in self.dets:
                     rs.append({'obs:obs_id': 'obs_number_13',
                                'dets:readout_id': row['readout_id'],
                                'othercal':40})
             return rs
-        else:
-            raise ValueError(f'metadata request for "{filename}"')
+
+        raise ValueError(f'metadata request for "{filename}"')
 
     def tod_loader(self, obsfiledb, obs_id, dets=None, prefix=None,
                    samples=None, no_signal=None,

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -295,6 +295,17 @@ class ContextTest(unittest.TestCase):
         tod = ctx.get_obs(obs_id, dets=det_info)
         self.assertEqual(tod.signal.shape, (n_det // 2, n_samp))
 
+    def test_200_load_metadata(self):
+        """Test the simple metadata load wrapper."""
+        dataset_sim = DatasetSim()
+        obs_id = dataset_sim.obss['obs_id'][1]
+
+        ctx = dataset_sim.get_context()
+        tod = ctx.get_meta(obs_id)
+        for spec in ctx['metadata']:
+            item = metadata.loader.load_metadata(tod, spec)
+            assert(item is not None)
+
 
 class DatasetSim:
     """Provide in-RAM Context objects and tod/metadata loader functions

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -263,9 +263,10 @@ class ContextTest(unittest.TestCase):
         # Check if NO_MATCH det_id seemed to broadcast propertly ...
         self.assertEqual(list(tod.det_info['det_param'] == -1),
                          list(dataset_sim.dets['det_id'] == 'NO_MATCH'))
-        for di, ds, AB in zip(tod.det_info.det_id, tod.det_info.detset,
-                              tod.focal_plane2.AB):
-            self.assertEqual(AB, len(ds) * (di == 'NO_MATCH'))
+        for di, ds, AB1, AB2 in zip(tod.det_info.det_id, tod.det_info.detset,
+                                    tod.XY, tod.focal_plane2.AB):
+            self.assertEqual(AB1, len(ds) * (di == 'NO_MATCH'))
+            self.assertEqual(AB2, len(ds) * (di == 'NO_MATCH'))
 
         tod = ctx.get_obs(obs_id + ':f090')
         self.assertEqual(tod.signal.shape, (n_det // 2, n_samp))
@@ -478,7 +479,11 @@ class DatasetSim:
              'name': 'focal_plane',
              'on_missing': on_missing},
             {'db': _db_multi_dataset('more_detset_info.h5'),
-             'name': 'focal_plane2',
+             'label': 'focal_plane2',
+             'unpack': [
+                 'focal_plane2',
+                 'XY&AB',
+                 ],
              'on_missing': on_missing},
             {'db': _db_single_dataset('det_param.h5'),
              'det_info': True},
@@ -536,8 +541,7 @@ class DatasetSim:
                 'db': bad_meta_db,
                 'name': 'othercal',
                 'on_missing': with_incomplete_metadata,
-                ## leave label unset here; should fall back on name.
-                #'label': 'othercal',
+                'label': 'othercal',
             })
 
         return ctx


### PR DESCRIPTION
This updates the metadata handling system in Context to be more flexible in how missing data are treated.  This builds on the system started in #460 and the discussion there.

Main features:
- New `load_metadata` function can be used to load a result from a ManifestDb, starting from only an AxisManager and a metadata spec.
- Format of metadata entries in Context is modified (and features extended):
  - new `on_missing` = `trim`, `skip`, `fail` option
  - "name" is deprecated in favor of "unpack" and "label"
  - You can "unpack" into multiple places
- The on_missing for an entry can be overridden when calling Context get_obs or get_meta.

Also:
- Documentation of the metadata system is reorganized a fair bit.  This could still use some work, but it's better.
- More tests of metadata loading for incomplete data cases.
- Updates to `preprocess_tod` from @kmharrington so individual groups (data subsets) can be analyzed.

The logging might be too verbose still -- cf #661; let's talk about what most useful.  It might be that almost all `logger.warning` should be `logger.debug`. 