### PR TITLE
Include error indicator field in HWP ManifestDb

### DIFF
--- a/sotodlib/hwp/g3thwp.py
+++ b/sotodlib/hwp/g3thwp.py
@@ -167,7 +167,6 @@ class G3tHWP():
         if not any(data):
             logger.info('HWP is not spinning in time range {' + str(
                 self._start) + ' - ' + str(self._end) + '}, data is empty')
-
         return data
 
     def load_file(self, file_list=None, instance=None):
@@ -189,7 +188,6 @@ class G3tHWP():
         dict
             {alias[i] : (time[i], data[i])}
         """
-
         if file_list is None and self._file_list is None:
             logger.error('Cannot find input g3 file')
             return {}
@@ -253,7 +251,6 @@ class G3tHWP():
             fields += [self._field_instance_sub + '_full.' + f if 'counter' in f
                        else self._field_instance_sub + '.' + f for f in self._field_list]
             alias += [a + '_2' for a in self._field_list]
-
         return fields, alias
 
     def _data_formatting(self, data, suffix=''):
@@ -375,7 +372,6 @@ class G3tHWP():
         hwp_rate = np.append(slow_hwp_rate, hwp_rate)[slow_idx]
 
         locked[np.where(hwp_rate == 0)] = False
-
         return {'locked': locked, 'stable': stable, 'hwp_rate': hwp_rate, 'slow_time': slow_time}
 
     def analyze(self, data, ratio=None, force_quad=None, mod2pi=True, fast=True):
@@ -422,7 +418,6 @@ class G3tHWP():
                 * the "approximate" HWP spin rate, with sign, in revs / second.
                 * Use placeholder value of 0 for cases when not "stable".
         """
-
         if not any(data):
             logger.info("no HWP field data")
 
@@ -456,7 +451,6 @@ class G3tHWP():
         out = self._slowdata_process(fast_time, d['irig_time'])
         out['fast_time'] = fast_time
         out['angle'] = angle
-
         return out
 
     def eval_angle(self, solved, poly_order=3):
@@ -632,13 +626,10 @@ class G3tHWP():
                 frame['block_names'].append('fast')
                 frame['blocks'].append(fast_block)
                 writer.Process(frame)
-
             start_time += frame_length
-
         return
 
     def _set_empty_axes(self, aman):
-
         aman.wrap_new('timestamps', shape=('samps', ), dtype=np.float64)
         aman.wrap_new('hwp_angle_ver1', shape=('samps', ), dtype=np.float64)
         aman.wrap_new('hwp_angle_ver2', shape=('samps', ), dtype=np.float64)
@@ -647,26 +638,21 @@ class G3tHWP():
         aman.wrap_new('hwp_rate', shape=('samps', ), dtype=np.float16)
         aman.wrap('hwp_angle_ver2_flag', None)
         aman.wrap('hwp_logger', self._write_solution_h5_logger)
-
         return
 
     def _write_empty_solution_h5(self, tod, output=None, h5_address=None):
-        
         logger.info('Writing empty solutions')
         # metadata loader requires a dets axis
         aman = sotodlib.core.AxisManager(tod.dets, tod.samps)
         self._set_empty_axes(aman)
         aman.timestamps[:] = tod.timestamps
         aman.hwp_logger=self._write_solution_h5_logger
-        aman.save(output, h5_address, overwrite=True)
-        
+        aman.save(output, h5_address, overwrite=True)  
         return
 
     def _bool_interpolation(self, timestamp1, data, timestamp2):
-
         interp = scipy.interpolate.interp1d(timestamp1, data, kind='linear', bounds_error=False)(timestamp2)
         result = (interp > 0.999)
-
         return result
 
     def write_solution_h5(self, tod, output=None, h5_address=None):
@@ -791,7 +777,6 @@ class G3tHWP():
         
         aman.hwp_logger=self._write_solution_h5_logger
         aman.save(output, h5_address, overwrite=True)
-
         return
 
     def _hwp_angle_calculator(
@@ -946,7 +931,6 @@ class G3tHWP():
         self._ref_cnt = self._encd_cnt[self._ref_indexes]
         logger.debug('found {} reference points'.format(
             len(self._ref_indexes)))
-
         return 0
 
     def _fill_refs(self):
@@ -1006,7 +990,6 @@ class G3tHWP():
         self._ref_indexes += np.arange(len(self._ref_indexes)
                                        ) * self._ref_edges
         self._ref_cnt = self._encd_cnt[self._ref_indexes]
-
         return
 
     def _flatten_counter(self):
@@ -1043,7 +1026,6 @@ class G3tHWP():
         self._angle = direction * self._angle
         if mod2pi:
             self._angle = self._angle % (2 * np.pi)
-
         return
 
     def _duplication_check(self):

--- a/sotodlib/site_pipeline/make_hwp_solutions.py
+++ b/sotodlib/site_pipeline/make_hwp_solutions.py
@@ -18,6 +18,7 @@ from sotodlib import core
 from sotodlib.hwp.g3thwp import G3tHWP
 from sotodlib.site_pipeline import util
 default_logger = util.init_logger(__name__, 'make-hwp-solutions: ')
+print(sotodlib.hwp.g3thwp.__file__)
 
 def get_parser(parser=None):
     if parser is None:

--- a/sotodlib/site_pipeline/make_hwp_solutions.py
+++ b/sotodlib/site_pipeline/make_hwp_solutions.py
@@ -165,7 +165,6 @@ def main(
             output=output_filename, 
             h5_address=h5_address
         )
-        
         del g3thwp
         
         # Add an entry to the database
@@ -173,9 +172,9 @@ def main(
             {'obs:obs_id': obs["obs_id"], 'dataset': h5_address}, filename=h5_filename,
         )   
     return
-    
-    
+        
 if __name__ == '__main__':
     parser = get_parser(parser=None)
     args = parser.parse_args()
     main(**vars(args))
+    

--- a/sotodlib/site_pipeline/make_hwp_solutions.py
+++ b/sotodlib/site_pipeline/make_hwp_solutions.py
@@ -1,5 +1,5 @@
 """
-Script to make hwp angle of CalDB.
+Script to make hwp angle metadata.
 This script will run:
 1. automatically if data are acquired as preliminary version.
 2. New versions of the metadata can be created as the analysis evolves.

--- a/sotodlib/site_pipeline/make_hwp_solutions.py
+++ b/sotodlib/site_pipeline/make_hwp_solutions.py
@@ -18,7 +18,6 @@ from sotodlib import core
 from sotodlib.hwp.g3thwp import G3tHWP
 from sotodlib.site_pipeline import util
 default_logger = util.init_logger(__name__, 'make-hwp-solutions: ')
-print(sotodlib.hwp.g3thwp.__file__)
 
 def get_parser(parser=None):
     if parser is None:

--- a/sotodlib/site_pipeline/make_hwp_solutions.py
+++ b/sotodlib/site_pipeline/make_hwp_solutions.py
@@ -140,7 +140,6 @@ def main(
 
     logger.debug(f"Sending query to obsdb: {tot_query}")
     obs_list = ctx.obsdb.query(tot_query)
-    print(obs_list['obs_id'])
         
     if len(obs_list)==0:
         logger.warning(f"No observations returned from query: {query}")

--- a/sotodlib/site_pipeline/make_hwp_solutions.py
+++ b/sotodlib/site_pipeline/make_hwp_solutions.py
@@ -140,6 +140,7 @@ def main(
 
     logger.debug(f"Sending query to obsdb: {tot_query}")
     obs_list = ctx.obsdb.query(tot_query)
+    print(obs_list['obs_id'])
         
     if len(obs_list)==0:
         logger.warning(f"No observations returned from query: {query}")


### PR DESCRIPTION
Added a field (`hwp_err`) in HWP ManifestDb to indicate when the HWP angle is all zeros, whether it is a calculation failure or just a lack of L2 HWP data.
Motivated by this issue: #669 