### PR TITLE
G3thwp overflow glitch

### DIFF
--- a/sotodlib/hwp/g3thwp.py
+++ b/sotodlib/hwp/g3thwp.py
@@ -1063,7 +1063,7 @@ class G3tHWP():
             self._rising_edge = np.array([])
 
     def _process_counter_overflow_glitch(self):
-        """ Treat glitches due to 32 bits counter overflow """
+        """ Treat glitches due to 32 bit internal counter overflow """
         idx = np.where(np.diff(self._encd_clk)>2**32)[0] + 1
         for i in idx:
             self._encd_clk[i] -= 2**32

--- a/sotodlib/hwp/g3thwp.py
+++ b/sotodlib/hwp/g3thwp.py
@@ -1064,7 +1064,7 @@ class G3tHWP():
 
     def _process_counter_overflow_glitch(self):
         """ Treat glitches due to 32 bit internal counter overflow """
-        idx = np.where((np.diff(self._encd_clk)>2**32) & (np.diff(self._encd_clk)<2**32+1e6))[0] + 1
+        idx = np.where((np.diff(self._encd_clk)>=2**32-1) & (np.diff(self._encd_clk)<2**32+1e6))[0] + 1
         if len(idx) > 0:
             logger.warning(f'{len(idx)} counter overflow glitches are found, perform correction.')
         for i in idx:

--- a/sotodlib/hwp/g3thwp.py
+++ b/sotodlib/hwp/g3thwp.py
@@ -1064,19 +1064,19 @@ class G3tHWP():
 
     def _process_counter_overflow_glitch(self):
         """ Treat glitches due to 32 bit internal counter overflow """
-        idx = np.where(np.diff(self._encd_clk)>2**32)[0] + 1
+        idx = np.where((np.diff(self._encd_clk)>2**32) & (np.diff(self._encd_clk)<2**32+1e6))[0] + 1
+        if len(idx) > 0:
+            logger.warning(f'{len(idx)} counter overflow glitches are found, perform correction.')
         for i in idx:
             self._encd_clk[i] -= 2**32
-        if len(idx) > 0:
-            logger.warning(f'{len(idx)} counter overflow glitches are found, performed correction.')
 
     def _process_counter_index_reset(self):
         """ Treat counter index reset due to agent reboot """
         idx = np.where(np.diff(self._encd_cnt)<-1e4)[0] + 1
+        if len(idx) > 0:
+            logger.warning(f'{len(idx)} counter resets are found, perform correction.')
         for i in idx:
             self._encd_cnt[i:] = self._encd_cnt[i:] + abs(np.diff(self._encd_cnt)[i-1]) + 1
-        if len(idx) > 0:
-            logger.warning(f'{len(idx)} counter resets are found, performed correction.')
 
     def _fill_dropped_packets(self):
         """ Estimate the number of dropped packets """

--- a/sotodlib/hwp/g3thwp.py
+++ b/sotodlib/hwp/g3thwp.py
@@ -1391,7 +1391,11 @@ class G3tHWP():
             self._rising_edge = np.array([])
 
     def _process_counter_overflow_glitch(self):
-        """ Treat glitches due to 32 bit internal counter overflow """
+        """
+        Treat glitches due to 32 bit internal counter overflow
+        We suspect that this is a glitch caused by the very occasional failure of the encoder counter overflow correction
+        due to latency or other problems on the pc running the encoder agent.
+        """
         idx = np.where((np.diff(self._encd_clk)>=2**32-1) & (np.diff(self._encd_clk)<2**32+1e6))[0] + 1
         if len(idx) > 0:
             logger.warning(f'{len(idx)} counter overflow glitches are found, perform correction.')


### PR DESCRIPTION
Found a hwp angle glitch due to the overflow of the 32 bit internal counter of the bbb in `obs_1704077057_satp3_1111111`, and implemented process to detect and correct this type of hwp angle glitch.

I note that there is another type of glitch due to noisy quad in this observation that is independent from this bug.
We will address in another PR.

![Figure 25](https://github.com/simonsobs/sotodlib/assets/38639108/de7332f8-2661-4fc2-9c16-7b1322643209)
