### PR TITLE
make_det_info_wafer: use site-pipeline wafer_map.yaml

### DIFF
--- a/docs/site_pipeline.rst
+++ b/docs/site_pipeline.rst
@@ -135,26 +135,36 @@ resulting ManifestDbs should work for both level 2 and level 3 SMuRf data.
 
 make_det_info_wafer
 ```````````````````
-This script uses based array construction inputs to build detector IDs for a set of
-UFMs and save them in a ManifestDb / HDF5 file. The formatting of the ResultSet 
-saved in HDF5 file will map all this information into ``det_info.wafer`` when used 
-with a correctly formatted context file and a readout to detector id mapping.
-The detector info mapping created by this script will be stable as long as the
-same UFMs are used in the same optics tube positions, meaning it only needs to
-be re-made if the physical hardware setup changes. 
 
-Although the full config presented for ``make_read_det_match`` will
-work, here's a more basic example that will work::
+This script uses basic array construction inputs to assemble a table
+of information about each the UFMs in a telescope and save them to an
+HDF5 file.  The resulting datasets may be used to populate
+``det_info.wafer``, once the ``det_id`` of the readout channels is
+known.  The detector info mapping created by this script is re-usable
+as long as the UFM continues to be associated with the same
+``stream_id``.
 
-  det_db: "./det_info_wafer.db"
-  det_info: "./det_info_wafer.h5"
+Here is a basic configuration file::
+
+  det_db: "./wafer_info.sqlite"
+  det_info: "./wafer_info.h5"
   array_info_dir: "/home/so/git/site-pipeline-configs/shared/detmapping/design/"
+  wafer_map_file: "/home/so/git/site-pipeline-configs/shared/detmapping/wafer_map.yaml"
+  tel_tubes: ["satp1"]
 
-  arrays:
-    - name: mv7
-      stream_id: ufm_mv7
-    - name: mv9
-      stream_id: ufm_mv9
+The ``wafer_map_file`` is used to get a list of UFMs.  All it needs to
+contain is a dict with stream_id as key and values that are dicts that
+includes ``array_name`` and ``tel_tube``; e.g.::
+
+  ufm_mv19:
+    array_name: Mv19
+    tel_tube: satp1
+
+If the ``tel_tube`` is not defined or does not match the list in
+specified in the main config file, the entry will be skipped.  (This
+is so that the shared ``wafer_map.yaml`` can contain UFM descriptions
+for multiple telescopes even if we want the ``det_info`` metadata
+to be kept separately per telescope tube.)
 
 
 make_read_det_match

--- a/sotodlib/io/so_ufm.py
+++ b/sotodlib/io/so_ufm.py
@@ -9,7 +9,8 @@ def get_wafer_info(array_name, base_config={}, array_config={}, raw=False,
     csv files and tracing the connections between them.
 
     Args:
-      array_name (str): e.g. 'mv7'.
+      array_name (str): e.g. 'Mv7'.  Capitalization is important, as
+        this is used in filenames.
       base_config (dict): Used to find ``array_info_dir``; if not
         found then ./ will be used.
       array_config (dict): Used to override names of specific input
@@ -32,9 +33,6 @@ def get_wafer_info(array_name, base_config={}, array_config={}, raw=False,
       absolute.  See source code for default filenames.
 
     """
-    # Tradition has been to use "Mv7" for array_name here.
-    array_name = array_name.capitalize()
-
     # Figure out the filenames and read the csv.
     base_dir = base_config.get('array_info_dir', './')
     filenames = [

--- a/sotodlib/site_pipeline/make_det_info_wafer.py
+++ b/sotodlib/site_pipeline/make_det_info_wafer.py
@@ -19,13 +19,15 @@ def get_parser(parser=None):
         parser = ArgumentParser()
     parser.add_argument('config_file',
         help="Configuration file name.")
+    parser.add_argument('target', nargs='*', default=None,
+                        help="Target override: array_name stream_id.")
     parser.add_argument('--overwrite', action='store_true', 
         help="Overwrite existing entries.")
     parser.add_argument('--debug', action='store_true')
     parser.add_argument('--log-file', help="Output log filename")
     return parser
 
-def main(config_file=None, overwrite=False, debug=False, log_file=None):
+def main(config_file=None, target=None, overwrite=False, debug=False, log_file=None):
     if debug:
         logger.setLevel("DEBUG")
     
@@ -36,34 +38,43 @@ def main(config_file=None, overwrite=False, debug=False, log_file=None):
         file_handler.setFormatter(formatter)
         logger.addHandler(file_handler)
 
-    configs = yaml.safe_load(open(config_file, "r"))
-    array_names = [array["name"] for array in configs["arrays"]]
-    logger.info(f"Creating Det Info for UFMs-{','.join([array for array in array_names])}")
+    config = yaml.safe_load(open(config_file, "r"))
 
-    if os.path.exists(configs["det_db"]):
-        logger.info(f"Det Info {configs['det_db']} exists, looking for updates")
-        db = core.metadata.ManifestDb(configs["det_db"])
+    if target is not None and len(target) > 0:
+        assert(len(target) == 2)  # array_name stream_id
+        targets = [tuple(target)]
+    else:
+        wafer_dict = yaml.safe_load(open(config['wafer_map_file'], 'rb'))
+        targets = [(v['array_name'], k) for k, v in wafer_dict.items()
+                   if v.get('tel_tube') in config['tel_tubes']]
+
+    array_names = [target[0] for target in targets]
+    logger.info(f"Requested Det Info for UFMs: {','.join([array for array in array_names])}")
+
+    if os.path.exists(config["det_db"]):
+        logger.info(f"Det Info {config['det_db']} exists, looking for updates")
+        db = core.metadata.ManifestDb(config["det_db"])
         existing = list(db.get_entries(["dataset"])["dataset"])
     else:
-        logger.info(f"Creating Det Info {configs['det_db']}.")
+        logger.info(f"Creating Det Info {config['det_db']}.")
         scheme = core.metadata.ManifestScheme()
         scheme.add_data_field('dets:stream_id')
         scheme.add_data_field('dataset')
-        db = core.metadata.ManifestDb(configs["det_db"], scheme=scheme)
+        db = core.metadata.ManifestDb(config["det_db"], scheme=scheme)
         existing = []
 
-    for array_cfg in configs['arrays']:
-        array_name = array_cfg['name']
-        stream_id = array_cfg['stream_id']
+    for array_name, stream_id in targets:
 
         # make result set per array
         if array_name in existing and not overwrite:
             logger.info(f"{array_name} exists in database, pass --overwrite to"
             " overwrite existing information.")
             continue
+        else:
+            logger.info(f"Creating entry for {array_name}.")
 
         # Get one row per resonator
-        rows = so_ufm.get_wafer_info(array_name, configs, array_cfg,
+        rows = so_ufm.get_wafer_info(array_name, config, {},
                                      include_no_match=True)
 
         # Output key names are formatted for det_info consumption.
@@ -79,13 +90,13 @@ def main(config_file=None, overwrite=False, debug=False, log_file=None):
         for row in rows:
             det_rs.append({key_map[k]: v for k, v in row.items()})
 
-        write_dataset(det_rs, configs["det_info"], array_name, overwrite)
+        write_dataset(det_rs, config["det_info"], array_name, overwrite)
 
         # Update the index if it's a new entry
         if not array_name in existing:
             db_data = {'dets:stream_id': stream_id,
                        'dataset': array_name}
-            db.add_entry(db_data, configs["det_info"])
+            db.add_entry(db_data, config["det_info"])
 
 
 def replace_none(val, replace_val=np.nan):


### PR DESCRIPTION
Mostly cosmetic change, trying to reduce duplication of config info.

Instead of requiring a custom list of stream_id -> array_name in the config file, use wafer_map.yaml from shared config repo.  (You can override on command line though.)

Relies on "array_name" being added to that wafer_map config.