### PR TITLE
[WIP] QA metrics for preprocesstod

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,6 +25,7 @@ Welcome to SOTODLib's documentation!
    site_pipeline.rst
    reference.rst
    dev.rst
+   metrics.rst
 
 Indices and tables
 ==================

--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -1,0 +1,125 @@
+.. py:module:: sotodlib.qa.metrics
+
+.. _metrics-module:
+
+==========
+QA Metrics
+==========
+
+Defines a structure for recording quality assurance (QA) metrics derived from
+data at various stages of processing to an Influx database. It is composed of
+individual metric objects that are associated to a single Influx field. These
+operate on a metadata ``AxisManager`` for a single observation ID, from which
+they calculate and return a quantity to be recorded. A metric for a given source
+should be based on the ``QAMetric`` class, which provides an interface to the
+Influx database. Two abstract methods should be implemented by subclasses: the
+``_process`` method is passed the metadata and should calculate the metric;
+``_get_available_obs`` should return a list of observation ID's that are
+available to be processed (i.e. have an existing metadata entry in the
+``Manifest`` file referenced in the ``Context``).
+
+
+Base Class
+----------
+
+.. autoclass:: sotodlib.qa.metrics.QAMetric
+    :members:
+
+
+Metric-recording Script
+-----------------------
+
+.. autofunction:: sotodlib.site_pipeline.record_qa.main
+
+For a list of metrics provided in a config file, this script determines which
+observation ID's are available and have yet to be recorded in the Influx
+database, loads the metadata defined in the given context file one observation at
+a time, calculates each metric, and records it to Influx. The configuration file
+should contain three blocks:
+
+    ``monitor``
+        Specifies an InfluxDB monitor as defined in
+        :meth:`sotodlib.site_pipeline.monitor.Monitor`
+    ``context_file``
+        The context file that includes all the relevant metadata.
+    ``metrics``
+        A list of metrics, with each entry including at least a ``name`` field
+        giving the name of the class to instantiate, with all other parameters
+        passed to its ``__init__`` method.
+
+For example, a config could look like::
+
+    monitor:
+        host: "daq-dev"
+        port: "8086"
+        database: "pipeline-dev"
+        username: "monitor"
+        password: "crepe-handmade-trio"
+        path: ""
+        ssl: False
+    context_file: "/path/to/context.yaml"
+    metrics:
+      - name: "PreprocessQA"
+        process_name: "det_bias_flags"
+      - name: "HWPSolSuccess"
+        encoder: "1"
+      - name: "HWPSolNumSamples"
+        encoder: "1"
+      - name: "HWPSolNumFlagged"
+        encoder: "1"
+      - name: "HWPSolMeanRate"
+        encoder: "1"
+      - name: "HWPSolMeanTemplate"
+        encoder: "1"
+      - name: "HWPSolSuccess"
+        encoder: "2"
+      - name: "HWPSolNumSamples"
+        encoder: "2"
+      - name: "HWPSolNumFlagged"
+        encoder: "2"
+      - name: "HWPSolMeanRate"
+        encoder: "2"
+      - name: "HWPSolMeanTemplate"
+        encoder: "2"
+      - name: "HWPSolVersion"
+      - name: "HWPSolPrimaryEncoder"
+      - name: "HWPSolOffcenter"
+      - name: "HWPSolOffcenterErr"
+
+In the above config, some of the metrics have parameters like ``process_name``
+or ``encoder`` that are specific to their subclass.
+
+
+Metric Subclasses
+-----------------
+
+Preprocess
+::::::::::
+
+Metrics to be derived from the output of the ``preprocess`` module share a
+generic class. A ``_PreProcess`` subclass that supports QA metrics should
+implement its ``gen_metric`` abstract method to calculate a summary quantity for
+its output. In the ``record_qa`` configuration, the name of the process to
+instantiate for a given metric should be given as the ``process_name`` argument.
+
+.. autoclass:: sotodlib.qa.metrics.PreprocessQA
+    :members:
+
+
+HWP Angle Solution
+::::::::::::::::::
+
+Some HWP solution metrics are derived for both encoder solutions separately, so
+the ``encoder`` argument should be specified in the config.
+
+.. autoclass:: sotodlib.qa.metrics.HWPSolQA
+    :members:
+.. autoclass:: sotodlib.qa.metrics.HWPSolSuccess
+.. autoclass:: sotodlib.qa.metrics.HWPSolNumSamples
+.. autoclass:: sotodlib.qa.metrics.HWPSolNumFlagged
+.. autoclass:: sotodlib.qa.metrics.HWPSolMeanRate
+.. autoclass:: sotodlib.qa.metrics.HWPSolMeanTemplate
+.. autoclass:: sotodlib.qa.metrics.HWPSolVersion
+.. autoclass:: sotodlib.qa.metrics.HWPSolPrimaryEncoder
+.. autoclass:: sotodlib.qa.metrics.HWPSolOffcenter
+.. autoclass:: sotodlib.qa.metrics.HWPSolOffcenterErr

--- a/sotodlib/preprocess/core.py
+++ b/sotodlib/preprocess/core.py
@@ -30,7 +30,7 @@ class _Preprocess(object):
         self.calc_cfgs = step_cfgs.get("calc")
         self.save_cfgs = step_cfgs.get("save")
         self.select_cfgs = step_cfgs.get("select")
-    
+
     def process(self, aman, proc_aman):
         """ This function makes changes to the time ordered data AxisManager.
         Ex: calibrating or detrending the timestreams. This function will use
@@ -114,7 +114,26 @@ class _Preprocess(object):
         if self.select_cfgs is None:
             return meta
         raise NotImplementedError
-    
+
+    @classmethod
+    def gen_metric(cls, meta, proc_aman):
+        """ Generate a QA metric from the output of this process.
+
+        Arguments
+        ---------
+        meta : AxisManager
+            Metadata related to the specific observation
+        proc_aman : AxisManager
+            The output of the preprocessing pipeline.
+
+        Returns
+        -------
+        line : dict
+            InfluxDB line entry elements to be fed to
+            `site_pipeline.monitor.Monitor.record`
+        """
+        raise NotImplementedError
+
     @staticmethod
     def register(process_class):
         """Registers a new modules with the PIPELINE"""
@@ -126,7 +145,6 @@ class _Preprocess(object):
             raise ValueError(
                 f"Preprocess Module of name {name} is already Registered"
             )
-
 
 
 class Pipeline(list):

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -45,6 +45,7 @@ class DetBiasFlags(_Preprocess):
     .. autofunction:: sotodlib.tod_ops.flags.get_det_bias_flags
     """
     name = "det_bias_flags"
+    _influx_field = "det_bias_flags_frac"
 
     def calc_and_save(self, aman, proc_aman):
         msk = tod_ops.flags.get_det_bias_flags(aman, merge=False,
@@ -67,6 +68,43 @@ class DetBiasFlags(_Preprocess):
         keep = ~proc_aman.det_bias_flags.det_bias_flags
         meta.restrict("dets", meta.dets.vals[has_all_cut(keep)])
         return meta
+
+    @classmethod
+    def gen_metric(cls, meta, proc_aman):
+        """ Generate a QA metric from the output of this process.
+
+        Arguments
+        ---------
+        meta : AxisManager
+            The full metadata container.
+        proc_aman : AxisManager
+            The metadata containing just the output of this process.
+
+        Returns
+        -------
+        line : dict
+            InfluxDB line entry elements to be fed to
+            `site_pipeline.monitor.Monitor.record`
+        """
+        # For now just compute the fraction of samples that were flagged
+        # (I think in practice this will be 1 or 0...)
+        # TODO: come up with a more useful metric
+        frac_flagged = np.array([
+            np.dot(r.ranges(), [-1, 1]).sum() / meta.obs_info.n_samples
+            for r in proc_aman.det_bias_flags.det_bias_flags
+        ])
+        obs_time = [meta.obs_info.timestamp] * frac_flagged.size
+        # extract these tags for the metric
+        tag_keys = ["detset", "readout_id", "stream_id", "wafer_slot", "tel_tube", "det_id", "bandpass"]
+        tags = [{k: meta.det_info[k][d] for k in tag_keys if k in meta.det_info} for d in range(meta.dets.count)]
+        tags[0]["telescope"] = meta.obs_info.telescope
+        return {
+            "field": cls._influx_field,
+            "values": frac_flagged,
+            "timestamps": obs_time,
+            "tags": tags,
+        }
+
 
 class Trends(_Preprocess):
     """Calculate the trends in the data to look for unlocked detectors. All

--- a/sotodlib/qa/__init__.py
+++ b/sotodlib/qa/__init__.py
@@ -1,0 +1,1 @@
+from . import metrics

--- a/sotodlib/qa/metrics.py
+++ b/sotodlib/qa/metrics.py
@@ -1,0 +1,141 @@
+from ..core import metadata
+
+
+class QAMetric(object):
+    """ Base class for quality assurance metrics to be recorded in Influx,
+    derived from processed metadata files.
+
+    The base class includes methods for recording a metric value to Influx,
+    checking if a given obs_id has been recorded for this metric, and fetching
+    a list of obs_id's that can be recorded.
+
+    Metrics are labelled by the observation ID they describe, an Influx 'measurement'
+    and 'field', and any number of additional tags. A measurement can have multiple
+    fields associated with it, and here we've tried to organize the metrics so that
+    a source of information (e.g. HWP angle solutions) is a measurement and relevant
+    quantities describing it (e.g. HWP success, mean rate, etc) are fields.
+
+    Subclasses should implement the `_process` and `_get_available_obs` methods to
+    access the source of data they are going to tap, as well as define the
+    `_influx_meas` and `_influx_field` attributes.
+    """
+
+    # these will be defined by child classes
+    _influx_meas = None  # measurement to record to
+    _influx_field = None  # the field to populate
+
+    def __init__(self, context, monitor, log="qa_metrics_log"):
+        """ A QA metric base class.
+
+        Arguments
+        ---------
+        context : core.Context
+            Context that includes all necessary metadata to generate metrics.
+        monitor : site_pipeline.monitor.Monitor
+            InfluxDB connection.
+        log : str
+            InfluxDB measurement that is used to log new entries.
+        """
+
+        self.context = context
+        self.monitor = monitor
+        self._influx_log = log
+
+    def exists(self, obs_id, tags={}):
+        """ Check if a metric exists for this obs_id in Influx.
+
+        Arguments
+        ---------
+        obs_id : str
+            The observation ID to check.
+        tags : dict (optional)
+            Further restrict to given tags.
+
+        Returns
+        -------
+        exists : bool
+            Whether it exists or not.
+        """
+        return self.monitor.check(self._influx_field, obs_id, tags, log=self._influx_log)
+
+    def get_existing_obs(self):
+        """ Get a list of observations already recorded to Influx.
+        """
+        # query influx log measurement for observations of this field
+        res = self.monitor.client.query(
+            f"select {self._influx_field}, observation from {self._influx_log}"
+        ).get_points()
+        return [r["observation"] for r in res]
+
+    def process_and_record(self, obs_id, meta=None):
+        """ Generate a metric for this obs_id and record it to InfluxDB.
+
+        Arguments
+        ---------
+        obs_id : str
+            The observation ID to process.
+        meta : AxisManager (optional)
+            The metadata for this observation ID. If not provided will read from file.
+        """
+        if meta is None:
+            meta = self.context.get_meta(obs_id, ignore_missing=True)
+        if meta.obs_info.obs_id != obs_id:
+            raise Exception(f"Metadata does not correspond to obs_id {obs_id}.")
+        line = self._process(meta)
+        log_tags = {"observation": obs_id}  # used to identify this entry
+        for t in line["tags"]:  # make sure this is also recorded in metric itself
+            t.update(log_tags)
+        self.monitor.record(**line, log=self._influx_log, measurement=self._influx_meas, log_tags=log_tags)
+        self.monitor.write()
+
+    def get_new_obs(self):
+        """ Get a list of available observations not yet recorded to InfluxDB.
+        """
+        # get a list of obs_id to update
+        avail_obs = set(self._get_available_obs())
+        exist_obs = set(self.get_existing_obs())
+        return avail_obs - exist_obs
+
+    def _process(self, meta):
+        """ Implement this to process an actual metric."""
+        raise NotImplementedError
+
+    def _get_available_obs(self):
+        """ Implement this for a given metric."""
+        raise NotImplementedError
+
+
+class PreprocessQA(QAMetric):
+    """ A metric derived from a preprocesstod process.
+    """
+
+    _influx_meas = "preprocesstod"
+
+    def __init__(self, context, monitor, process_name, **kwargs):
+        """ In addition to the context and monitor, pass the name of the
+        preprocess process to record. It should have a `gen_metric` method
+        implemented and `_influx_field` attribute.
+        """
+        super().__init__(context, monitor, **kwargs)
+
+        from sotodlib.preprocess import Pipeline
+        proc = Pipeline.PIPELINE.get(process_name, None)
+        if proc is None:
+            raise Exception(f"No preprocess process with name {process_name}")
+        self._pipe_proc = proc
+
+        # get the field name from the process
+        self._influx_field = self._pipe_proc._influx_field
+
+    def _process(self, meta):
+        return self._pipe_proc.gen_metric(meta, meta.preprocess)
+
+    def _get_available_obs(self):
+        # find preprocess manifest file
+        man_file = [p["db"] for p in self.context["metadata"] if p.get("name", "") == "preprocess"]
+        if len(man_file) == 0:
+            raise Exception(f"No preprocess metadata block in context {self.context.filename}.")
+
+        # load manifest and read available observations
+        man_db = metadata.ManifestDb.from_file(man_file[0])
+        return [o[0] for o in man_db.get_entries(["\"obs:obs_id\""]).asarray()]

--- a/sotodlib/qa/metrics.py
+++ b/sotodlib/qa/metrics.py
@@ -1,3 +1,6 @@
+import re
+import numpy as np
+
 from ..core import metadata
 
 
@@ -139,3 +142,186 @@ class PreprocessQA(QAMetric):
         # load manifest and read available observations
         man_db = metadata.ManifestDb.from_file(man_file[0])
         return [o[0] for o in man_db.get_entries(["\"obs:obs_id\""]).asarray()]
+
+
+class HWPSolQA(QAMetric):
+    """ Base class for metrics derived from HWP angle solutions. Subclasses should
+    implement the `_process` method. Some quantities are derived twice, once for each
+    encoder, and these will require and `encoder` parameter to be provided to select
+    which one to produce a metric for. This is indicated by setting the `_needs_encoder`
+    attribute to `True`.
+    """
+
+    _influx_meas = "hwp_solution"
+    _needs_encoder = False  # set this flag if encoder needs to be specified
+
+    def __init__(self, context, monitor, encoder=None, **kwargs):
+        super().__init__(context, monitor, **kwargs)
+
+        self._encoder = encoder
+        self._tags = {}
+        if encoder is not None:
+            if str(encoder) not in ["1", "2"]:
+                raise Exception(f"Invalid value {encoder} for encoder parameter.")
+            self._tags = {"encoder": self._encoder}
+        elif self._needs_encoder:
+            raise Exception("This metric needs an encoder to be specified on creation.")
+
+    def _get_available_obs(self):
+        # find preprocess manifest file
+        man_file = [p["db"] for p in self.context["metadata"] if p.get("name", "") == "hwp_solution"]
+        if len(man_file) == 0:
+            raise Exception(f"No hwp_solution metadata block in context {self.context.filename}.")
+
+        # load manifest and read available observations
+        man_db = metadata.ManifestDb.from_file(man_file[0])
+        obs_re = re.compile("^obs_*.")
+        return [o[0] for o in man_db.get_entries(["\"obs:obs_id\""]).asarray() if obs_re.match(o[0])]
+
+
+class HWPSolSuccess(HWPSolQA):
+    """ Records success of the HWP angle solution calculation, for each encode."""
+
+    _influx_field = "logger"
+    _needs_encoder = True
+
+    def _process(self, meta):
+        success = [meta.hwp_solution[f"logger_{self._encoder}"] == "Angle calculation succeeded"]
+        obs_time = [meta.obs_info.timestamp]
+        return {
+            "field": self._influx_field,
+            "values": success,
+            "timestamps": obs_time,
+            "tags": [self._tags],
+        }
+
+
+class HWPSolPrimaryEncoder(HWPSolQA):
+    """ The primary encoder used for the HWP angle calculation."""
+
+    _influx_field = "primary_encoder"
+
+    def _process(self, meta):
+        # no tags for this metric
+        return {
+            "field": self._influx_field,
+            "values": [meta.hwp_solution["primary_encoder"]],
+            "timestamps": [meta.obs_info.timestamp],
+            "tags": [self._tags],
+        }
+
+
+class HWPSolVersion(HWPSolQA):
+    """ The version of the solution used for the HWP angle calculation."""
+
+    _influx_field = "version"
+
+    def _process(self, meta):
+        # no tags for this metric
+        return {
+            "field": self._influx_field,
+            "values": [meta.hwp_solution["version"]],
+            "timestamps": [meta.obs_info.timestamp],
+            "tags": [self._tags],
+        }
+
+
+class HWPSolOffcenter(HWPSolQA):
+    """ Calculated offcentering of HWP angle solution."""
+
+    _influx_field = "offcenter"
+
+    def _process(self, meta):
+        # no tags for this metric
+        return {
+            "field": self._influx_field,
+            "values": [meta.hwp_solution["offcenter"][0]],
+            "timestamps": [meta.obs_info.timestamp],
+            "tags": [self._tags],
+        }
+
+
+class HWPSolOffcenterErr(HWPSolQA):
+    """ Standard error on the offcentering of HWP angle solution."""
+
+    _influx_field = "offcenter_err"
+
+    def _process(self, meta):
+        # no tags for this metric
+        return {
+            "field": self._influx_field,
+            "values": [meta.hwp_solution["offcenter"][1]],
+            "timestamps": [meta.obs_info.timestamp],
+            "tags": [self._tags],
+        }
+
+
+class HWPSolNumSamples(HWPSolQA):
+    """ The total number of encoder samples."""
+
+    _influx_field = "num_samples"
+    _needs_encoder = True
+
+    def _process(self, meta):
+        flag_key = f"filled_flag_{self._encoder}"
+        frac = [meta.hwp_solution[flag_key].size]
+        obs_time = [meta.obs_info.timestamp]
+        return {
+            "field": self._influx_field,
+            "values": frac,
+            "timestamps": obs_time,
+            "tags": [self._tags],
+        }
+
+
+class HWPSolNumFlagged(HWPSolQA):
+    """ The number of encoder samples that were flagged."""
+
+    _influx_field = "num_flagged"
+    _needs_encoder = True
+
+    def _process(self, meta):
+        flag_key = f"filled_flag_{self._encoder}"
+        frac = [meta.hwp_solution[flag_key].sum()]
+        obs_time = [meta.obs_info.timestamp]
+        return {
+            "field": self._influx_field,
+            "values": frac,
+            "timestamps": obs_time,
+            "tags": [self._tags],
+        }
+
+
+class HWPSolMeanRate(HWPSolQA):
+    """ The mean calculated HWP angle rate, for each encoder."""
+
+    _influx_field = "mean_rate"
+    _needs_encoder = True
+
+    def _process(self, meta):
+        good_samp = ~meta.hwp_solution[f"filled_flag_{self._encoder}"]
+        nsamp = good_samp.sum()
+        rate = np.nan if nsamp == 0 else (meta.hwp_solution[f"hwp_rate_{self._encoder}"] * good_samp).sum() / nsamp
+        obs_time = [meta.obs_info.timestamp]
+        return {
+            "field": self._influx_field,
+            "values": [rate],
+            "timestamps": obs_time,
+            "tags": [self._tags],
+        }
+
+
+class HWPSolMeanTemplate(HWPSolQA):
+    """ The mean of the calculated template magnitude."""
+
+    _influx_field = "mean_template"
+    _needs_encoder = True
+
+    def _process(self, meta):
+        obs_time = [meta.obs_info.timestamp]
+        return {
+            "field": self._influx_field,
+            "values": [np.mean(np.abs(meta.hwp_solution[f"template_{self._encoder}"]))],
+            "timestamps": obs_time,
+            "tags": [self._tags],
+        }

--- a/sotodlib/site_pipeline/record_qa.py
+++ b/sotodlib/site_pipeline/record_qa.py
@@ -1,0 +1,63 @@
+import yaml
+import argparse
+
+from sotodlib import core
+import sotodlib.site_pipeline.util as sp_util
+from sotodlib.qa import metrics as qa_metrics
+from sotodlib.site_pipeline.monitor import Monitor
+
+logger = sp_util.init_logger("qa_metrics")
+
+
+def main(config):
+    """ Update all metrics specified in the config.
+    """
+    if isinstance(config, str):
+        with open(config, "r") as fh:
+            config = yaml.safe_load(fh)
+
+    monitor = Monitor.from_configs(config["monitor"])
+    context = core.Context(config["context_file"])
+
+    # get a list of metrics from the config
+    metrics = []
+    for m in config["metrics"]:
+        # try to get an instance of this metric
+        name = m.pop("name")
+        try:
+            metric_class = getattr(qa_metrics, name)
+        except AttributeError:
+            raise Exception(f"No metric named {name} was found.")
+        # Instantiate class with remaining elements as kwargs
+        metrics.append(metric_class(context=context, monitor=monitor, **m))
+
+    # get a list of obs_id to process
+    obs_id = []
+    for m in metrics:
+        obs_id.append(m.get_new_obs())
+    all_obs_id = list(set.union(*obs_id))
+
+    logger.info(f"Found {len(all_obs_id)} obs_id with new metrics to record.")
+
+    n = len(all_obs_id)
+    i = 1
+    # process one obs_id at a time
+    for oid in all_obs_id:
+        logger.info(f"Recording metrics for obs_id {oid} ({i}/{n})...")
+        # load metadata once
+        meta = context.get_meta(oid, ignore_missing=True)
+        for m, m_obs in zip(metrics, obs_id):
+            if oid in m_obs:
+                m.process_and_record(oid, meta)
+        i += 1
+
+
+def get_parser(parser=None):
+    if parser is None:
+        parser = argparse.ArgumentParser()
+    parser.add_argument('config', help="Metrics Configuration File")
+    return parser
+
+
+if __name__ == '__main__':
+    sp_util.main_launcher(main, get_parser)


### PR DESCRIPTION
I fleshed out one way that recording QA metrics could work in `preprocesstod`. This is very much a work in progress and I haven't tested anything at all, but I thought it would be useful to get some feedback on whether or not this may be a good approach (and on all the ways I am misunderstanding the codebase!).

I tried to integrate it into the `preprocesstod` flow, while making it possible to run after the fact without loading the data. Not sure if this ends up being awkward in the end... One limitation may be that this results in recording a single `detset` at a time, because this is how `preprocesstod` does it, but otherwise it might be more efficient to load it all at once (?).