### PR TITLE
Remove negative sign in front of focal-plane theta in det-match

### DIFF
--- a/sotodlib/coords/det_match.py
+++ b/sotodlib/coords/det_match.py
@@ -300,7 +300,7 @@ class ResSet:
         resonances = []
 
         if fp_pars is not None:
-            theta = -np.deg2rad(fp_pars['theta'])
+            theta = np.deg2rad(fp_pars['theta'])
             dx, dy = fp_pars['dx'], fp_pars['dy']
 
         with open(sol_file, 'r') as f:


### PR DESCRIPTION
This is required in order for det-match solution pointing to be aligned with measurements, since this PR in site-pipeline-configs: https://github.com/simonsobs/site-pipeline-configs/pull/21/files