### PR TITLE
Move process registration to __init__.py in Preprocess.

### DIFF
--- a/sotodlib/preprocess/__init__.py
+++ b/sotodlib/preprocess/__init__.py
@@ -1,1 +1,2 @@
 from .core import _Preprocess, PIPELINE
+from .processes import *


### PR DESCRIPTION
I got a bit tripped up figuring out how to import registered processes, because you first had to import the `processes` module, then `PIPELINE` from `core` in order for it to be populated. I thought doing it this way made more sense, but let me know what you think.

Now you can `from sotodlib.preprocess import PIPELINE` to get the registered processes.