### PR TITLE
Fix select in det_bias_cuts process.

### DIFF
--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -53,7 +53,7 @@ class DetBiasFlags(_Preprocess):
             proc_aman.wrap("det_bias_flags", dbc_aman)
 
     def select(self, meta):
-        keep = ~meta.preprocess.det_bias_flags.det_bias_flags
+        keep = ~has_all_cut(meta.preprocess.det_bias_flags.det_bias_flags)
         meta.restrict("dets", meta.dets.vals[keep])
         return meta
 


### PR DESCRIPTION
When we first put in this process we weren't returning ranges matrices so select was not using the has_all_cut function. I've added that here. Hopefully with a single line fix this is an easy review.