### PR TITLE
Setting `source_flags` as optional.

### DIFF
--- a/sotodlib/mapmaking/utilities.py
+++ b/sotodlib/mapmaking/utilities.py
@@ -508,9 +508,16 @@ def downsample_obs(obs, down):
         bore.wrap(key, getattr(obs.boresight, key)[::down], [(0, "samps")])
     res.wrap("boresight", bore)
     res.wrap("signal", resample.resample_fft_simple(obs.signal, onsamp), [(0,"dets"),(1,"samps")])
+
     # The cuts
-    for key in ["glitch_flags", "source_flags"]:
+    cut_keys = ["glitch_flag"]
+
+    if "source_flags" in obs:
+        cut_keys.append("source_flags")
+
+    for key in cut_keys:
         res.wrap(key, downsample_cut(getattr(obs, key), down), [(0,"dets"),(1,"samps")])
+
     # Not sure how to deal with flags. Some sort of or-binning operation? But it
     # doesn't matter anyway
     return res

--- a/sotodlib/mapmaking/utilities.py
+++ b/sotodlib/mapmaking/utilities.py
@@ -510,6 +510,8 @@ def downsample_obs(obs, down):
     res.wrap("signal", resample.resample_fft_simple(obs.signal, onsamp), [(0,"dets"),(1,"samps")])
 
     # The cuts
+    # TODO: The TOD will include a Flagmanager with all the flags. Update this part
+    # accordingly.
     cut_keys = ["glitch_flag"]
 
     if "source_flags" in obs:


### PR DESCRIPTION
This PR fixes the following error:
```python
  0    0.38  3.85  4.93  8.59 Downsampling 1,1
  0    0.38  3.85  4.93  8.59 Active downsampling 1
Traceback (most recent call last):
  File "/scratch/gpfs/ip8725/tmp/mapmaker.py", line 286, in <module>
    obs = mapmaking.downsample_obs(obs, passinfo.downsample)
  File "/home/ip8725/.local/lib/python3.10/site-packages/sotodlib/mapmaking/utilities.py", line 513, in downsample_obs
    res.wrap(key, downsample_cut(getattr(obs, key), down), [(0,"dets"),(1,"samps")])
  File "/home/ip8725/.local/lib/python3.10/site-packages/sotodlib/core/axisman.py", line 375, in __getattr__
    return self[name]
  File "/home/ip8725/.local/lib/python3.10/site-packages/sotodlib/core/axisman.py", line 356, in __getitem__
    raise KeyError(name)
KeyError: 'source_flags'
```
