### PR TITLE
Fix demod mapmaking

### DIFF
--- a/sotodlib/coords/demod.py
+++ b/sotodlib/coords/demod.py
@@ -11,16 +11,26 @@ def make_map(tod,
              dsT=None, demodQ=None, demodU=None,
              cuts=None,
              det_weights=None, det_weights_demod=None,
-             wrong_definition=False, center_on=None):
-    """
-    Generates maps of temperature and polarization from a TOD.
+             center_on=None, flip_gamma=True):
+    """Generates maps of temperature and polarization from demodulated HWP
+    data.  It is assumed that each detector contributes a T signal
+    (which has been low-pass filtered to avoid the modulated signal)
+    stored in dsT, as well as separate Q and U timestreams,
+    corresponding to the cosine-phase (demodQ = Q cos 4 chi) and
+    sine-phase (demodU = U sin 4 chi) response of the HWP.
+
+    The demodQ and demodU signals are assumed to have been computed
+    without regard for the polarization angle of the detector, nor the
+    on-sky parallactic angle.  The impact of these is handled by the
+    projection routines in this function.
 
     Parameters
     ----------
     tod : sotodlib.core.AxisManager
         An AxisManager object
     P : sotodlib.coords.pmat
-        Projection Matrix to be used for mapmaking. If None, it is generated from `wcs_kernel` or `centor_on`.
+        Projection Matrix to be used for mapmaking. If None, it is
+        generated from `wcs_kernel` or `center_on`.
     wcs_kernel : enlib.wcs.WCS or None, optional
         The WCS object used to generate the output map.
         If None, a new WCS object with a Cartesian projection and a resolution of `res` will be created.
@@ -47,6 +57,11 @@ def make_map(tod,
         The detector weights to use in the map-making for the demodulated Q and U timestreams.
         If both of `det_weights` and `det_weights_demod` are None, uniform detector weights will be used.
         If only one of two are provided, the other weight is provided by `det_weights` = 2 * `det_weights_demod`.
+    flip_gamma : bool or None
+        Defaults to True.  When constructing the pointing matrix,
+        reflect the nominal focal plane polarization angles about zero
+        (gamma -> -gamma).  If you pass in your own P, make sure it
+        was constructed with hwp=True.
 
     Returns
     -------
@@ -57,8 +72,8 @@ def make_map(tod,
         The inverse variance weighted map of temperature and polarization
     'weight' : enmap.ndmap
         The map of inverse variance weights used in the map-making process.
-    """
 
+    """
     if dsT is None:
         dsT = tod['dsT']
     if demodQ is None:
@@ -66,14 +81,17 @@ def make_map(tod,
     if demodU is None:
         demodU = tod['demodU']
 
+    if flip_gamma is None:
+        flip_gamma = True
+
     if P is None:
         if center_on is None:
             if wcs_kernel is None:
                 wcs_kernel = coords.get_wcs_kernel('car', 0, 0, res)
             P = coords.P.for_tod(
-                tod=tod, wcs_kernel=wcs_kernel, cuts=cuts, comps='QU')
+                tod=tod, wcs_kernel=wcs_kernel, cuts=cuts, comps='QU', hwp=flip_gamma)
         else:
-            P, X = coords.planets.get_scan_P(tod, planet=center_on, res=res)
+            P, X = coords.planets.get_scan_P(tod, planet=center_on, res=res, hwp=flip_gamma)
             
 
     if det_weights is None:
@@ -94,20 +112,12 @@ def make_map(tod,
                              det_weights=det_weights_demod)
     mU_weighted = P.to_map(tod=tod, signal=demodU, comps='QU',
                              det_weights=det_weights_demod)
+
     mQU_weighted = P.zeros()
-    
-    if wrong_definition == True:
-        # CAUTION: Here the definition of mQU_weighted uses a wrong way of definition, as toast simulation defines that in the wrong way.
-        mQU_weighted[0][:] = mQ_weighted[0] - mU_weighted[1]
-        # (= Q_{flipped detector coord}*cos(2 theta_pa) - U_{flipped detector coord}*sin(2 theta_pa) )
-        mQU_weighted[1][:] = mQ_weighted[1] + mU_weighted[0]
-        # (= Q_{flipped detector coord}*sin(2 theta_pa) + U_{flipped detector coord}*cos(2 theta_pa) )
-    else:
-        #### In field, you should use instead ####
-        mQU_weighted[0][:] = mQ_weighted[0] + mU_weighted[1]
-        # (= Q_{flipped detector coord}*cos(2 theta_pa) + U_{flipped detector coord}*sin(2 theta_pa) )
-        mQU_weighted[1][:] = -mQ_weighted[1] + mU_weighted[0] 
-        # (= -Q_{flipped detector coord}*sin(2 theta_pa) + U_{flipped detector coord}*cos(2 theta_pa) )
+    mQU_weighted[0][:] = mQ_weighted[0] - mU_weighted[1]
+    mQU_weighted[1][:] = mQ_weighted[1] + mU_weighted[0]
+    del mQ_weighted, mU_weighted
+
     wQU = P.to_weights(tod, signal=demodQ, comps='T',
                          det_weights=det_weights_demod)
 

--- a/tests/test_demod_map.py
+++ b/tests/test_demod_map.py
@@ -1,0 +1,132 @@
+from sotodlib import core, hwp, coords
+import so3g
+import numpy as np
+
+import unittest
+
+# Support functions for a simple obs-like AxisManager...
+
+def quick_dets_axis(n_det):
+    return core.LabelAxis('dets', ['det%04i' % i for i in range(n_det)])
+
+def quick_focal_plane(dets, scale=0.5):
+    n_det = dets.count
+    nrow = int(np.ceil((n_det/2)**2))
+    entries = []
+    gamma = 0.
+    for r in range(nrow):
+        y = r * scale
+        for c in range(nrow):
+            x = c * scale
+            entries.extend([(x, y, gamma),
+                            (x, y, gamma + 90)])
+            gamma += 15.
+    entries = entries[(n_det - len(entries)) // 2:]
+    entries = entries[:n_det]
+    fp = core.AxisManager(dets)
+    for k, v in zip(['xi', 'eta', 'gamma'], np.transpose(entries)):
+        v = (v - v.mean()) * coords.DEG
+        fp.wrap(k, v, [(0, 'dets')])
+    return fp
+
+def quick_scan(tod):
+    az_min = 100.
+    az_max = 120.
+    v_az = 2.
+    dt = tod.timestamps - tod.timestamps[0]
+    az = az_min + (v_az * dt) % (az_max - az_min)
+    bs = core.AxisManager(tod.samps)
+    bs.wrap_new('az'  , shape=('samps', ))[:] = az * coords.DEG
+    bs.wrap_new('el'  , shape=('samps', ))[:] = 50 * coords.DEG
+    bs.wrap_new('roll', shape=('samps', ))[:] = 0. * az
+    return bs
+
+def quick_tod(n_det, n_samp):
+    dets = quick_dets_axis(n_det)
+    tod = core.AxisManager(
+        quick_dets_axis(n_det),
+        core.OffsetAxis('samps', n_samp))
+    tod.wrap('focal_plane', quick_focal_plane(tod.dets))
+    DT = .1
+    dt = np.arange(n_samp) * DT
+    tod.wrap_new('timestamps', shape=('samps', ))[:] = 1800000000. + dt
+    f_hwp = 2.
+    n_hwp = np.ceil(DT * n_samp * f_hwp)
+    f_hwp = n_hwp / (DT * n_samp)
+    v = DT * n_samp
+    tod.wrap_new('hwp_angle',  shape=('samps', ))[:] = (dt * f_hwp + 1.32) % (np.pi*2)
+    tod.wrap('boresight', quick_scan(tod))
+    tod.wrap_new('signal', shape=('dets', 'samps'), dtype='float32')
+    return tod
+
+
+class DemodMapmakingTest(unittest.TestCase):
+    def test_00_direct(self):
+        """Test the coords.demod.make_map function on directly generated
+        demodQ and demodU timestreams.
+
+        """
+        # Constant sky components.
+        Q_stream = 1.0
+        U_stream = 0.25
+        TOL = 0.0001
+
+        tod = quick_tod(10, 10000)
+        fp = so3g.proj.FocalPlane.from_xieta(
+            tod.dets.vals, tod.focal_plane.xi, tod.focal_plane.eta, tod.focal_plane.gamma)
+        csl = so3g.proj.CelestialSightLine.az_el(
+            tod.timestamps, tod.boresight.az, tod.boresight.el, roll=tod.boresight.roll,
+            site='so_sat1', weather='toco')
+
+        for k in ['dsT', 'demodQ', 'demodU']:
+            tod.wrap_new(k, shape=('dets', 'samps'), dtype='float32')
+
+        for i, det in enumerate(tod.dets.vals):
+            q_total = csl.Q * fp[det]
+            ra, dec, alpha = so3g.proj.quat.decompose_lonlat(q_total)
+            GAMMA = alpha - 2 * tod.focal_plane.gamma[i]
+            tod.demodQ[i] = Q_stream * np.cos(2 * GAMMA) + U_stream * np.sin(2 * GAMMA)
+            tod.demodU[i] = U_stream * np.cos(2 * GAMMA) - Q_stream * np.sin(2 * GAMMA)
+
+        results = coords.demod.make_map(tod)
+        m0 = results['map']
+        s = m0[1] != 0
+        means = [m[s].mean() for m in m0]
+        print(means)
+        assert(abs(means[1] - Q_stream) < TOL)
+        assert(abs(means[2] - U_stream) < TOL)
+
+    def test_10_mod_demod(self):
+        """Test the coords.demod.make_map function on timestreams starting
+        from the HWP-modulated signal.
+
+        """
+        # Constant sky components.
+        Q_stream = 1.0
+        U_stream = 0.25
+        TOL = .01
+
+        tod = quick_tod(10, 10000)
+        fp = so3g.proj.FocalPlane.from_xieta(
+            tod.dets.vals, tod.focal_plane.xi, tod.focal_plane.eta, tod.focal_plane.gamma)
+        csl = so3g.proj.CelestialSightLine.az_el(
+            tod.timestamps, tod.boresight.az, tod.boresight.el, roll=tod.boresight.roll,
+            site='so_sat1', weather='toco')
+
+        c_4chi, s_4chi = np.cos(tod.hwp_angle * 4), np.sin(tod.hwp_angle * 4)
+        for i, det in enumerate(tod.dets.vals):
+            q_total = csl.Q * fp[det]
+            ra, dec, alpha = so3g.proj.quat.decompose_lonlat(q_total)
+            GAMMA = alpha - 2 * tod.focal_plane.gamma[i]
+            c, s = np.cos(2*GAMMA), np.sin(2*GAMMA)
+            tod.signal[i] = (Q_stream * (c*c_4chi - s*s_4chi) +
+                             U_stream * (s*c_4chi + c*s_4chi))
+
+        hwp.demod_tod(tod)
+        results = coords.demod.make_map(tod)
+        m0 = results['map']
+        s = m0[1] != 0
+        means = [m[s].mean() for m in m0]
+        print(means)
+        assert(abs(means[1] - Q_stream) < TOL)
+        assert(abs(means[2] - U_stream) < TOL)


### PR DESCRIPTION
Addresses problems in coords.demod.make_map identifed by @chervias.

I believe that what was in there before was correct only when the focal plane and celestial coordinates were well aligned; e.g. when looking due north or due south, or in source-scan coordinates.

There's a unit test now.