### PR TITLE
Updates to det-match and site-pipeline-script to create better solutions

### DIFF
--- a/docs/site_pipeline.rst
+++ b/docs/site_pipeline.rst
@@ -277,6 +277,19 @@ match. To disable this, you can run a config file like the following:
   context_path: /path/to/context.yaml
   freq_offset_range_args: None
 
+Below is a more complex config used for SATp1 matching:
+
+.. code-block:: yaml
+  results_path: /so/metadata/satp1/manifests/det_match/satp1_det_match_240220m
+  context_path: /so/metadata/satp1/contexts/smurf_detcal.yaml
+  show_pb: False
+  freq_offset_range_args: NULL
+  apply_solution_pointing: False
+  solution_type: resonator_set
+  resonator_set_dir: /so/metadata/satp1/ancillary/detmatch_solutions/satp1_detmatch_solutions_240219r1
+  match_pars:
+    freq_width: 0.2
+
 Below is the full docs of the configuration class.
 
 .. autoclass:: sotodlib.site_pipeline.update_det_match.UpdateDetMatchesConfig

--- a/docs/site_pipeline.rst
+++ b/docs/site_pipeline.rst
@@ -280,6 +280,7 @@ match. To disable this, you can run a config file like the following:
 Below is a more complex config used for SATp1 matching:
 
 .. code-block:: yaml
+
   results_path: /so/metadata/satp1/manifests/det_match/satp1_det_match_240220m
   context_path: /so/metadata/satp1/contexts/smurf_detcal.yaml
   show_pb: False

--- a/sotodlib/site_pipeline/update_det_match.py
+++ b/sotodlib/site_pipeline/update_det_match.py
@@ -72,7 +72,9 @@ class UpdateDetMatchesConfig:
     resonator_set_dir: Optional[str]
         If ``solution_type`` is 'resonator_set', this must be specified and
         contain the path to the resonator-set solutions. This directory must
-        have a res-set npy file for each stream_id that is expected in the matching.
+        have a res-set npy file for each stream_id that is expected in the
+        matching, formatted like ``<resonator_set_dir>/<stream_id>.npy``, which
+        contains the result from ``np.save(fname, match.merged.as_array())``.
     
     Attributes
     -------------

--- a/sotodlib/site_pipeline/update_det_match.py
+++ b/sotodlib/site_pipeline/update_det_match.py
@@ -63,6 +63,16 @@ class UpdateDetMatchesConfig:
     write_relpath: bool
         If True, will use the relative path to the h5 file (relative to the db
         path) when writing to the manifestdb
+    solution_type: str
+        Type of solutions to use. Must be one of ['kaiwen_handmade',
+        'resonator_set'].  If 'kaiwen_handmade', will use the handmade solutions
+        from Kaiwen pulled from the wafer_map file in the site-pipeline-configs.
+        If `resonator_set`, must also specify the ``resonator_set_dir`` to pull
+        solutions from.
+    resonator_set_dir: Optional[str]
+        If ``solution_type`` is 'resonator_set', this must be specified and
+        contain the path to the resonator-set solutions. This directory must
+        have a res-set npy file for each stream_id that is expected in the matching.
     
     Attributes
     -------------
@@ -81,6 +91,8 @@ class UpdateDetMatchesConfig:
     show_pb: bool = False
     apply_solution_pointing: bool = True
     write_relpath: bool = True
+    solution_type: str = 'kaiwen_handmade'
+    resonator_set_dir: Optional[str] = None
 
     def __post_init__(self):
         if self.site_pipeline_root is None:
@@ -100,6 +112,15 @@ class UpdateDetMatchesConfig:
 
         if not os.path.exists(self.results_path):
             raise FileNotFoundError(f"Results dir does not exist: {self.results_path}")
+        
+        allowed_solution_types = ['kaiwen_handmade', 'resonator_set']
+        if self.solution_type not in allowed_solution_types:
+            raise ValueError(
+                f"Solution type ({self.solution_type}) must be a member of: {allowed_solution_types}")
+        
+        if self.solution_type == 'resonator_set':
+            if self.resonator_set_dir is None:
+                raise ValueError("Must specify resonator_set_dir for solution_type='resonator_set'")
 
 
 class Runner:
@@ -142,6 +163,28 @@ class Runner:
         run_match(self, remaining_detsets[0])
         return True
 
+def load_solution_set(runner: Runner, stream_id: str, wafer_slot=None):
+    cfg = runner.cfg
+    if cfg.solution_type == 'kaiwen_handmade':
+        sol_file = os.path.join(
+            os.path.dirname(runner.cfg.wafer_map_path),
+            runner.wafer_map[stream_id]['solution']
+        )
+        teltype = runner.wafer_map[stream_id]['tel_type']
+        if wafer_slot is None:  # Pull from detmapping cfg
+            wafer_slot = runner.wafer_map[stream_id]['wafer_slot']
+        fp_pars = optics.get_ufm_to_fp_pars(teltype, wafer_slot, runner.ufm_to_fp_file)
+        rs = det_match.ResSet.from_solutions(sol_file, fp_pars=fp_pars, platform=teltype)
+        rs.name = 'sol'
+        return rs
+
+    elif cfg.solution_type == 'resonator_set':
+        sol_file = os.path.join(cfg.resonator_set_dir, f"{stream_id}.npy")
+        rs_arr = np.load(sol_file)
+        rs = det_match.ResSet.from_array(rs_arr)
+        rs.name = 'sol'
+        return rs
+
 def add_to_failed_cache(cache_file, detset, msg):
     if os.path.exists(cache_file):
         with open(cache_file, 'r') as f:
@@ -164,19 +207,11 @@ def get_failed_detsets(cache_file):
 
 def run_match_aman(runner: Runner, aman, detset, wafer_slot=None):
     stream_id = aman.det_info.stream_id[aman.det_info.detset == detset][0]
-    sol_file = os.path.join(
-        os.path.dirname(runner.cfg.wafer_map_path),
-        runner.wafer_map[stream_id]['solution']
-    )
 
     rs0 = det_match.ResSet.from_aman(aman, stream_id)
     rs0.name = 'meas'
 
-    teltype = runner.wafer_map[stream_id]['tel_type']
-    if wafer_slot is None:  # Pull from detmapping cfg
-        wafer_slot = runner.wafer_map[stream_id]['wafer_slot']
-    fp_pars = optics.get_ufm_to_fp_pars(teltype, wafer_slot, runner.ufm_to_fp_file)
-    rs1 = det_match.ResSet.from_solutions(sol_file, fp_pars=fp_pars, platform=teltype)
+    rs1 = load_solution_set(runner, stream_id, wafer_slot=wafer_slot)
     rs1.name = 'sol'
 
     match_pars = det_match.MatchParams(**runner.cfg.match_pars)


### PR DESCRIPTION
A few updates to `det_match` and `update_det_match` that I added when creating new solutions and a new manifestdb for sat1 wafers.

Detmatch changes:
- PointingConfig class used to help with generating pointing from an optics model
- `ResSet.from_wafer_info_file` fn to load a resonator set with resonator design info based on Matthew's wafer_info file.
- In `ResSet.from_array`, adds option to ignore extra field, which lets you load older ResSet data after the Resonator interface has changed.
- Bug fixes in the `get_stats` fn.

update_det_match change:
- Begins to support different "solution-set" configurations. Adds some solution configuration that allows you to base matches off of a dir of npy ResSet files instead of kaiwen's solutions in site-pipeline-configs. I expect this to evolve as we begin to understand more about what we need from solutions and how long they remain applicable for (I can see us wanting to use different solutions for different cooldowns/tunes for example)

This is needed for the corresponding PR in site-pipeline-configs that creates the `update_det_match_config` file: https://github.com/simonsobs/site-pipeline-configs/pull/40