### PR TITLE
Adds bias wave metadata to metadata index

### DIFF
--- a/sotodlib/io/imprinter.py
+++ b/sotodlib/io/imprinter.py
@@ -1469,6 +1469,8 @@ class Imprinter:
                 meta_files["bias_steps"] = basename
             elif f.endswith("take_noise.npy"):
                 meta_files["noise"] = basename
+            elif f.endswith("bias_wave_analysis.npy"):
+                meta_files["bias_wave"] = basename
 
         return files, meta_files
 


### PR DESCRIPTION
Looked into the code, and turns out the bookbinder just copies every npy file into the book, so I think that should not be a problem with bias waves: https://github.com/simonsobs/sotodlib/blob/468bd7f75eddb2b324a40a0c17917056221b21f4/sotodlib/io/bookbinder.py#L1157-L1160

The added lines just correctly point to the copied bias_waves file in M_index yaml file.