### PR TITLE
Compress h5 output of axisman.save

### DIFF
--- a/sotodlib/core/axisman.py
+++ b/sotodlib/core/axisman.py
@@ -821,7 +821,7 @@ class AxisManager:
             self._assignments.update(aman._assignments)
         return self
 
-    def save(self, dest, group=None, overwrite=False):
+    def save(self, dest, group=None, overwrite=False, compression=None):
         """Write this AxisManager data to an HDF5 group.  This is an
         experimental feature primarily intended to assist with
         debugging.  The schema is subject to change, and it's possible
@@ -835,6 +835,7 @@ class AxisManager:
             dest).
           overwrite (bool): If True, remove any existing thing at the
             specified address before writing there.
+          compression (str ot None): Compression filter to apply.
 
         Notes:
           If dest is a string, it is taken to be an HDF5 filename and
@@ -868,7 +869,7 @@ class AxisManager:
 
         """
         from .axisman_io import _save_axisman
-        return _save_axisman(self, dest, group=group, overwrite=overwrite)
+        return _save_axisman(self, dest, group=group, overwrite=overwrite, compression=compression)
 
     @classmethod
     def load(cls, src, group=None):

--- a/sotodlib/core/axisman.py
+++ b/sotodlib/core/axisman.py
@@ -835,7 +835,9 @@ class AxisManager:
             dest).
           overwrite (bool): If True, remove any existing thing at the
             specified address before writing there.
-          compression (str ot None): Compression filter to apply.
+          compression (str or None): Compression filter to apply. E.g.
+            'gzip'. This string is passed directly to HDF5 dataset
+            routines.
 
         Notes:
           If dest is a string, it is taken to be an HDF5 filename and

--- a/sotodlib/core/axisman_io.py
+++ b/sotodlib/core/axisman_io.py
@@ -123,7 +123,7 @@ def _safe_scalars(x):
     # Must be fine then!
     return x
 
-def _save_axisman(axisman, dest, group=None, overwrite=False):
+def _save_axisman(axisman, dest, group=None, overwrite=False, compression='gzip'):
     """
     See AxisManager.save.
     """
@@ -214,7 +214,6 @@ def _save_axisman(axisman, dest, group=None, overwrite=False):
         })
     scalars = {}
     units = {}
-    compression = 'gzip'
 
     for item in schema:
         data = axisman[item['name']]

--- a/sotodlib/core/axisman_io.py
+++ b/sotodlib/core/axisman_io.py
@@ -237,7 +237,7 @@ def _save_axisman(axisman, dest, group=None, overwrite=False, compression=None):
                 g.create_dataset(k, data=v, compression=compression)
         elif item['encoding'] == 'axisman':
             g = dest.create_group(item['name'])
-            _save_axisman(data, g)
+            _save_axisman(data, g, compression=compression)
         elif item['encoding'] == 'axis':
             pass #
         else:

--- a/sotodlib/core/axisman_io.py
+++ b/sotodlib/core/axisman_io.py
@@ -123,7 +123,7 @@ def _safe_scalars(x):
     # Must be fine then!
     return x
 
-def _save_axisman(axisman, dest, group=None, overwrite=False, compression='gzip'):
+def _save_axisman(axisman, dest, group=None, overwrite=False, compression=None):
     """
     See AxisManager.save.
     """

--- a/sotodlib/core/axisman_io.py
+++ b/sotodlib/core/axisman_io.py
@@ -214,15 +214,16 @@ def _save_axisman(axisman, dest, group=None, overwrite=False):
         })
     scalars = {}
     units = {}
+    compression = 'gzip'
 
     for item in schema:
         data = axisman[item['name']]
         if item['encoding'] == 'scalar':
             scalars[item['name']] = data
         elif item['encoding'] == 'ndarray':
-            dest.create_dataset(item['name'], data=_retype_for_write(data))
+            dest.create_dataset(item['name'], data=_retype_for_write(data), compression=compression)
         elif item['encoding'] == 'quantity':
-            dest.create_dataset(item['name'], data=_retype_for_write(data))
+            dest.create_dataset(item['name'], data=_retype_for_write(data), compression=compression)
             units[item['name']] = data.unit.to_string()
         elif item['encoding'] == 'scalar_quantity':
             scalars[item['name']] = data.value
@@ -230,11 +231,11 @@ def _save_axisman(axisman, dest, group=None, overwrite=False):
         elif item['encoding'] == 'rangesmatrix':
             g = dest.create_group(item['name'])
             for k, v in flatten_RangesMatrix(data).items():
-                g.create_dataset(k, data=v)
+                g.create_dataset(k, data=v, compression=compression)
         elif item['encoding'] == 'csrarray':
             g = dest.create_group(item['name'])
             for k, v in flatten_csr_array(data).items():
-                g.create_dataset(k, data=v)
+                g.create_dataset(k, data=v, compression=compression)
         elif item['encoding'] == 'axisman':
             g = dest.create_group(item['name'])
             _save_axisman(data, g)

--- a/sotodlib/hwp/g3thwp.py
+++ b/sotodlib/hwp/g3thwp.py
@@ -937,7 +937,6 @@ class G3tHWP():
         # write solution, metadata loader requires a dets axis
         aman = sotodlib.core.AxisManager(tod.dets, tod.samps)
         aman.wrap_new('timestamps', ('samps', ))[:] = tod.timestamps
-        self._set_empty_axes(aman)
 
         start = int(tod.timestamps[0])-self._margin
         end = int(tod.timestamps[-1])+self._margin
@@ -956,7 +955,7 @@ class G3tHWP():
                 data = self.load_data(start, end)
 
             if 'pid_direction' in data.keys():
-                aman['pid_direction'] = np.nanmedian(data['pid_direction'][1])*2 - 1
+                aman.pid_direction = np.nanmedian(data['pid_direction'][1])*2 - 1
 
             logger.info('Saving raw encoder data')
             self._set_raw_axes(aman, data)
@@ -968,6 +967,7 @@ class G3tHWP():
             print(traceback.format_exc())
 
         solved = {}
+        self._set_empty_axes(aman)
         for suffix in self._suffixes:
             logger.info('Start analyzing encoder'+suffix)
             self._set_empty_axes(aman, suffix)
@@ -1023,10 +1023,7 @@ class G3tHWP():
                     method = self._method_direction + '_direction'
                     if self._method_direction == 'quad':
                         method += suffix
-                    if aman[method] == 0:
-                        logger.warning(f'Rotation direction by {self._method_direction} is not available. Skip.')
-                    else:
-                        solved['angle'+suffix] *= aman[method]
+                    solved['angle'+suffix] *= aman[method]
                 except Exception as e:
                     logger.error(f"Exception '{e}' thrown while correcting rotation direction. Skip.")
                     print(traceback.format_exc())

--- a/sotodlib/hwp/g3thwp.py
+++ b/sotodlib/hwp/g3thwp.py
@@ -937,6 +937,7 @@ class G3tHWP():
         # write solution, metadata loader requires a dets axis
         aman = sotodlib.core.AxisManager(tod.dets, tod.samps)
         aman.wrap_new('timestamps', ('samps', ))[:] = tod.timestamps
+        self._set_empty_axes(aman)
 
         start = int(tod.timestamps[0])-self._margin
         end = int(tod.timestamps[-1])+self._margin
@@ -955,7 +956,7 @@ class G3tHWP():
                 data = self.load_data(start, end)
 
             if 'pid_direction' in data.keys():
-                aman.pid_direction = np.nanmedian(data['pid_direction'][1])*2 - 1
+                aman['pid_direction'] = np.nanmedian(data['pid_direction'][1])*2 - 1
 
             logger.info('Saving raw encoder data')
             self._set_raw_axes(aman, data)
@@ -967,7 +968,6 @@ class G3tHWP():
             print(traceback.format_exc())
 
         solved = {}
-        self._set_empty_axes(aman)
         for suffix in self._suffixes:
             logger.info('Start analyzing encoder'+suffix)
             self._set_empty_axes(aman, suffix)
@@ -1023,7 +1023,10 @@ class G3tHWP():
                     method = self._method_direction + '_direction'
                     if self._method_direction == 'quad':
                         method += suffix
-                    solved['angle'+suffix] *= aman[method]
+                    if aman[method] == 0:
+                        logger.warning(f'Rotation direction by {self._method_direction} is not available. Skip.')
+                    else:
+                        solved['angle'+suffix] *= aman[method]
                 except Exception as e:
                     logger.error(f"Exception '{e}' thrown while correcting rotation direction. Skip.")
                     print(traceback.format_exc())

--- a/sotodlib/hwp/g3thwp.py
+++ b/sotodlib/hwp/g3thwp.py
@@ -1071,7 +1071,7 @@ class G3tHWP():
         aman.primary_encoder = primary_encoder
         aman.version = highest_version
 
-        aman.save(output, h5_address, overwrite=True)
+        aman.save(output, h5_address, overwrite=True, compression='gzip')
 
     def _hwp_angle_calculator(
             self,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -389,6 +389,8 @@ class TestAxisManager(unittest.TestCase):
                 aman.save(filename, dataset)
                 # Overwrite
                 aman.save(filename, dataset, overwrite=True)
+                # Compress and Overwrite
+                aman.save(filename, dataset, overwrite=True, compression='gzip')
                 # Refuse to overwrite
                 with self.assertRaises(RuntimeError):
                     aman.save(filename, dataset)


### PR DESCRIPTION
Compress h5 output of axisman.save.
I chose gzip with default compression level as default. This is lossless compression and available with every installation of HDF5.
https://docs.h5py.org/en/stable/high/dataset.html#lossless-compression-filters

I tested this compression on satp3 hwp angle files. The data size reduces by factor of ~4.

Before
-rw-r--r-- 1 site-pipeline so       138G Feb 12 20:06 hwp_angle.h5

After
total 32G
-rw-r--r-- 1 ykyohei so 608K Feb 24 15:33 hwp_angle.sqlite
-rw-r--r-- 1 ykyohei so 2.2G Feb 24 05:17 hwp_angle_1701.h5
-rw-r--r-- 1 ykyohei so 1.2G Feb 24 06:16 hwp_angle_1702.h5
-rw-r--r-- 1 ykyohei so 3.9G Feb 24 08:32 hwp_angle_1703.h5
-rw-r--r-- 1 ykyohei so  27G Feb 24 13:08 hwp_angle_1704.h5
-rw-r--r-- 1 ykyohei so 1.4G Feb 24 14:57 hwp_angle_1707.h5
-rw-r--r-- 1 ykyohei so 159M Feb 24 15:33 hwp_angle_1708.h5