### PR TITLE
remove logger arg of the main function in site_pipeline scripts

### DIFF
--- a/sotodlib/site_pipeline/analyze_bright_ptsrc.py
+++ b/sotodlib/site_pipeline/analyze_bright_ptsrc.py
@@ -25,6 +25,8 @@ matplotlib.use('agg')
 
 opj = os.path.join
 
+logger = util.init_logger(__name__)
+
 
 def get_xieta_src_centered(ctime, az, el, data, sso_name, threshold):
     """Create a planet centered coordinate system for single detector data
@@ -521,7 +523,6 @@ def main(
     representative_dets,
     test_mode=False,
     plot_results=False,
-    logger=None,
 ):
     """
     Initiate an MPI environment and fit a simulation in the time domain
@@ -539,8 +540,6 @@ def main(
 
     kwargs['img_dir'] = img_dir
 
-    if logger is None:
-        logger = util.init_logger(__name__)
     t1 = time.time()
 
     comm = MPI.COMM_WORLD

--- a/sotodlib/site_pipeline/check_book.py
+++ b/sotodlib/site_pipeline/check_book.py
@@ -104,9 +104,8 @@ def get_parser(parser=None):
     return parser
 
 
-def main(book_dir, config=None, add=None, overwrite=None, logger=None):
-    if logger is None:
-        logger = util.init_logger(__name__, 'check_book: ')
+def main(book_dir, config=None, add=None, overwrite=None):
+    logger = util.init_logger(__name__, 'check_book: ')
 
     logger.info(f'Examining {book_dir}')
 

--- a/sotodlib/site_pipeline/make_book.py
+++ b/sotodlib/site_pipeline/make_book.py
@@ -5,12 +5,12 @@ import argparse
 from sotodlib.io.imprinter import Imprinter
 
 
-def main(config: str, logger=None):
+def main(config: str):
     """Make books based on imprinter db
     
     Parameters
     ----------
-    im_config : str
+    config : str
         path to imprinter configuration file
     """
     imprinter = Imprinter(config, db_args={'connect_args': {'check_same_thread': False}})

--- a/sotodlib/site_pipeline/make_hwp_solutions.py
+++ b/sotodlib/site_pipeline/make_hwp_solutions.py
@@ -13,7 +13,7 @@ from typing import Optional
 from sotodlib import core
 from sotodlib.hwp.g3thwp import G3tHWP
 from sotodlib.site_pipeline import util
-default_logger = util.init_logger(__name__, 'make-hwp-solutions: ')
+logger = util.init_logger(__name__, 'make-hwp-solutions: ')
 
 def get_parser(parser=None):
     if parser is None:
@@ -73,10 +73,7 @@ def main(
     max_ctime: Optional[float] = None,
     obs_id: Optional[str] = None,
     load_h5: Optional[bool] = False,
-    logger = None,
  ):
-    if logger is None:
-        logger = default_logger
     logger.info(f"Using context {context} and HWPconfig {HWPconfig}")
 
     configs = yaml.safe_load(open(HWPconfig, "r"))

--- a/sotodlib/site_pipeline/preprocess_tod.py
+++ b/sotodlib/site_pipeline/preprocess_tod.py
@@ -220,12 +220,9 @@ def main(
     overwrite=False,
     min_ctime=None,
     max_ctime=None,
-    logger=None,
  ):
     configs, context = _get_preprocess_context(configs)
-    if logger is None: 
-        logger = sp_util.init_logger("preprocess")
-    globals()['logger'] = logger
+    logger = sp_util.init_logger("preprocess")
 
     if obs_id is not None:
         tot_query = f"obs_id=='{obs_id}'"

--- a/sotodlib/site_pipeline/update_book_plan.py
+++ b/sotodlib/site_pipeline/update_book_plan.py
@@ -5,6 +5,9 @@ from typing import Optional
 
 from sotodlib.io.imprinter import Imprinter
 from sotodlib.site_pipeline.monitor import Monitor
+from sotodlib.site_pipeline.util import init_logger
+
+logger = init_logger(__name__, "update_book_plan: ")
 
 def main(
     config: str,
@@ -49,9 +52,11 @@ def main(
     """
     if stream_ids is not None:
         stream_ids = stream_ids.split(",")
+
     imprinter = Imprinter(
         config, 
         db_args={'connect_args': {'check_same_thread': False}},
+        logger=logger
     )
     
     # leaving min_ctime and max_ctime as None will go through all available 
@@ -99,13 +104,13 @@ def main(
 
     monitor = None
     if "monitor" in imprinter.config:
-        imprinter.logger.info("Will send monitor information to Influx")
+        logger.info("Will send monitor information to Influx")
         try:
             monitor = Monitor.from_configs(
                 imprinter.config["monitor"]["connect_configs"]
             )
         except Exception as e:
-            imprinter.logger.error(f"Monitor connectioned failed {e}")
+            logger.error(f"Monitor connectioned failed {e}")
             monitor = None
 
     if monitor is not None:

--- a/sotodlib/site_pipeline/update_book_plan.py
+++ b/sotodlib/site_pipeline/update_book_plan.py
@@ -17,7 +17,6 @@ def main(
     min_ctime_timecodes: Optional[float] = None,
     max_ctime_timecodes: Optional[float] = None,
     from_scratch: bool = False,
-    logger = None
     ):
     """
     Update the book plan database with new data from the g3tsmurf database.
@@ -45,7 +44,6 @@ def main(
         The minimum ctime to include in the book plan for timecode (hk, smurf, stray) books, by default None
     max_ctime_timecodes : Optional[float], optional
         The maximum ctime to include in the book planor timecode (hk, smurf, stray) books, by default None
-
     from_scratch : bool, optional
         If True, start to search from beginning of time, by default False
     """
@@ -54,7 +52,6 @@ def main(
     imprinter = Imprinter(
         config, 
         db_args={'connect_args': {'check_same_thread': False}},
-        logger=logger,
     )
     
     # leaving min_ctime and max_ctime as None will go through all available 

--- a/sotodlib/site_pipeline/update_g3thk_database.py
+++ b/sotodlib/site_pipeline/update_g3thk_database.py
@@ -11,15 +11,13 @@ import argparse
 import logging
 from sqlalchemy import not_, or_, and_, desc
 
-from sotodlib.io.g3thk_db import G3tHk, HKFiles, logger as default_logger
+from sotodlib.io.g3thk_db import G3tHk, HKFiles, logger
 
 
-def main(config=None, from_scratch=False, verbosity=2, logger=None):
+def main(config=None, from_scratch=False, verbosity=2):
 
     show_pb = True if verbosity > 1 else False
 
-    if logger is None:
-        logger = default_logger
     if verbosity == 0:
         logger.setLevel(logging.ERROR)
     elif verbosity == 1:

--- a/sotodlib/site_pipeline/update_g3tsmurf_db.py
+++ b/sotodlib/site_pipeline/update_g3tsmurf_db.py
@@ -13,12 +13,12 @@ from sqlalchemy import not_, or_, and_
 from typing import Optional
 
 from sotodlib.site_pipeline.monitor import Monitor
-from sotodlib.io.load_smurf import G3tSmurf, Observations, logger as default_logger
+from sotodlib.io.load_smurf import G3tSmurf, Observations, logger
 
 
 def main(config: Optional[str] = None, update_delay: float = 2, 
          from_scratch: bool = False, verbosity: int = 2,
-         index_via_actions: bool=False, logger=None):
+         index_via_actions: bool=False):
     """
     Arguments
     ---------
@@ -31,19 +31,14 @@ def main(config: Optional[str] = None, update_delay: float = 2,
         overrides update_delay
     verbosity: int
         0-3, higher numbers = more printouts
-    logger: logging.logger
-        allows passing another longer to execution functions
     index_via_actions: bool
         if True, will look through action folders to create observations, this
         will be necessary for data older than Oct 2022 but creates concurancy 
         issues on systems (like the site) running automatic deletion of level 2 
         data.
     """
-
     show_pb = True if verbosity > 1 else False
 
-    if logger is None:
-        logger = default_logger
     if verbosity == 0:
         logger.setLevel(logging.ERROR)
     elif verbosity == 1:

--- a/sotodlib/site_pipeline/update_librarian.py
+++ b/sotodlib/site_pipeline/update_librarian.py
@@ -5,7 +5,7 @@ from typing import Optional
 from sotodlib.io.imprinter import Imprinter, BOUND, UPLOADED
 
 
-def main( config: str, logger=None):
+def main(config: str):
     """
     Update the book plan database with new data from the g3tsmurf database.
 
@@ -18,7 +18,6 @@ def main( config: str, logger=None):
     imprinter = Imprinter(
         config, 
         db_args={'connect_args': {'check_same_thread': False}},
-        logger=logger,
     )
 
     session = imprinter.get_session()

--- a/sotodlib/site_pipeline/update_obsdb.py
+++ b/sotodlib/site_pipeline/update_obsdb.py
@@ -85,8 +85,7 @@ def main(config: str,
         recency: float = None, 
         booktype: Optional[str] = "both",
         verbosity: Optional[int] = 2,
-        overwrite: Optional[bool] = False,
-        logger=None):
+        overwrite: Optional[bool] = False):
 
     """
     Create or update an obsdb for observation or operations data.
@@ -104,16 +103,7 @@ def main(config: str,
         Output verbosity. 0:Error, 1:Warning, 2:Info(default), 3:Debug
     overwrite : bool
         if False, do not re-check existing entries
-    logger : logging
-        When to output the print statements
-
-
     """
-
-    if logger is None:
-        logger = globals()['logger']
-    else:
-        globals()['logger'] = logger
     if verbosity == 0:
         logger.setLevel(logging.ERROR)
     elif verbosity == 1:
@@ -187,7 +177,7 @@ def main(config: str,
                 #obsfiledb creation
                 checkbook(
                     bookpath, config, add=True, 
-                    overwrite=True, logger=logger
+                    overwrite=True
                 )
             except Exception as e:
                 if config_dict["skip_bad_books"]:

--- a/sotodlib/site_pipeline/update_smurf_caldbs.py
+++ b/sotodlib/site_pipeline/update_smurf_caldbs.py
@@ -52,30 +52,25 @@ import sotodlib.site_pipeline.util as sp_util
 DEFAULT_RTM_BIT_TO_VOLT = 10 / 2**19
 DEFAULT_pA_per_phi0 = 9e6
 
-default_logger = logging.getLogger('smurf_caldbs')
-if not default_logger.hasHandlers():
+logger = logging.getLogger('smurf_caldbs')
+if not logger.hasHandlers():
     sp_util.init_logger('smurf_caldbs')
 
 
 
 def main(config: Union[str, dict], 
         overwrite:Optional[bool]=False,
-        skip_detset=False, skip_detcal=False, logger=None):
+        skip_detset=False, skip_detcal=False):
     if not skip_detset:
-        smurf_detset_info(config, overwrite, logger)
+        smurf_detset_info(config, overwrite)
     if not skip_detcal:
-        run_update_det_caldb(config, logger=logger, overwrite=overwrite)
+        run_update_det_caldb(config, overwrite=overwrite)
 
 def smurf_detset_info(config: Union[str, dict], 
-        overwrite:Optional[bool]=False,
-        logger=None):
+        overwrite:Optional[bool]=False):
     """Write out the updates for the manifest database with information about
     the readout ids present inside each detset.
     """
-
-    if logger is None:
-        logger = default_logger
-
     if type(config) == str:
         config = yaml.safe_load(open(config, 'r'))
 
@@ -227,15 +222,12 @@ class CalInfo:
 class MissingSmurfInfo(Exception):
     pass
 
-def get_cal_resset(ctx: core.Context, obs_id, logger=None):
+def get_cal_resset(ctx: core.Context, obs_id):
     """
     Returns calibration ResultSet for a given ObsId. This pulls IV and bias step
     data for each detset in the observation, and uses that to compute CalInfo
     for each detector in the observation
     """
-    if logger is None:
-        logger=default_logger
-
     am = ctx.get_obs(obs_id, samples=(0, 1), ignore_missing=True, no_signal=True)
     cals = [CalInfo(rid) for rid in am.det_info.readout_id]
     if 'smurf' not in am.det_info:
@@ -356,7 +348,6 @@ def get_obs_with_detsets(ctx, detset_idx):
 
 
 def add_to_failed_cache(obs_id, cache_path, msg):
-    logger = default_logger
     logger.info(f"Adding {obs_id} to failed obsid cache with msg: {msg}")
     if os.path.exists(cache_path):
         with open(cache_path, 'r') as f:
@@ -377,7 +368,7 @@ def get_failed_obsids(cache_path):
         cache = yaml.safe_load(f)
     return set(cache.keys())
 
-def update_det_caldb(ctx, idx_path, detset_idx, h5_path, logger=None, 
+def update_det_caldb(ctx, idx_path, detset_idx, h5_path,
                      show_pb=False, format_exc=False, overwrite=False,
                      failed_obsid_cache=None, root_dir=None, write_relpath=True):
     """
@@ -395,8 +386,6 @@ def update_det_caldb(ctx, idx_path, detset_idx, h5_path, logger=None,
         Path to detset manifestdb
     h5_path: str
         Path to h5 file to write results set.
-    logger: logging.Logger
-        Logger to use. If not set will use default.
     show_pb: bool
         If True, will show progress bar and time remaining
     format_exc: bool
@@ -414,10 +403,6 @@ def update_det_caldb(ctx, idx_path, detset_idx, h5_path, logger=None,
         If true, when adding entries to the manifestdb, will use the h5 path relative
         to the idx_path.
     """
-
-    if logger is None:
-        logger = default_logger
-
     if root_dir is not None:
         h5_path = os.path.join(root_dir, h5_path)
         idx_path = os.path.join(root_dir, idx_path)
@@ -474,7 +459,7 @@ def update_det_caldb(ctx, idx_path, detset_idx, h5_path, logger=None,
         }, filename=path, replace=overwrite)
 
 
-def run_update_det_caldb(config_path, logger=None, overwrite=False):
+def run_update_det_caldb(config_path, overwrite=False):
     with open(config_path, 'r') as f:
         config = yaml.safe_load(f)
 
@@ -491,7 +476,6 @@ def run_update_det_caldb(config_path, logger=None, overwrite=False):
         detset_idx,
         config['archive']['det_cal']['h5file'],
         show_pb=config['archive']['det_cal'].get('show_pb', False),
-        logger=logger,
         format_exc=format_exc,
         overwrite=overwrite,
         failed_obsid_cache=config['archive']['det_cal'].get('failed_obsid_cache'),

--- a/sotodlib/site_pipeline/util.py
+++ b/sotodlib/site_pipeline/util.py
@@ -251,15 +251,18 @@ def init_logger(name, announce=''):
 
     """
     logger = logging.getLogger(name)
+
+    # add handler only if it doesn't exist
+    if len(logger.handlers) == 0:
+      ch = logging.StreamHandler(sys.stdout)
+      formatter = _ReltimeFormatter('%(asctime)s: %(message)s (%(levelname)s)')
+
+      ch.setLevel(logging.INFO)
+      ch.setFormatter(formatter)
+      logger.addHandler(ch)
+
     logger.propagate = False
     logger.setLevel(logging.DEBUG)
-
-    ch = logging.StreamHandler(sys.stdout)
-    formatter = _ReltimeFormatter('%(asctime)s: %(message)s (%(levelname)s)')
-
-    ch.setLevel(logging.INFO)
-    ch.setFormatter(formatter)
-    logger.addHandler(ch)
 
     i, r = formatter.start_time // 1, formatter.start_time % 1
     text = (time.strftime('%Y-%m-%d %H:%M:%S', time.gmtime(i))


### PR DESCRIPTION
logger arg in main functions of each site_pipeline script is to provide a way to pass prefect logger into the script. Now we are using stream capture, so directly passing in logger is no longer required. Directly modifying function signature is also somewhat unstable. This PR is meant to go along with the incoming update in prefect wrapper: https://github.com/simonsobs/so-workflow/pull/33 