### PR TITLE
Split hwp h5 files

### DIFF
--- a/sotodlib/hwp/g3thwp.py
+++ b/sotodlib/hwp/g3thwp.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import os
+import time
 import numpy as np
 import scipy.interpolate
 import h5py
@@ -1074,7 +1075,23 @@ class G3tHWP():
         aman.primary_encoder = primary_encoder
         aman.version = highest_version
 
-        aman.save(output, h5_address, overwrite=True)
+        # save
+        max_trial = 5
+        wait_time = 5
+        for i in range(1, max_trial + 1):
+            try:
+                aman.save(output, h5_address, overwrite=True)
+                logger.info("Saved aman")
+                return
+            except BlockingIOError:
+                logger.warn(f"Cannot save aman because HDF5 is temporary locked, try again in {wait_time} seconds, trial {i}/{max_trial}")
+                time.sleep(wait_time)
+            except Exception as e:
+                logger.error(f"Exception '{e}' thrown while saving aman")
+                print(traceback.format_exc())
+
+        logger.error("Cannot save aman, give up.")
+        return
 
     def _hwp_angle_calculator(
             self,

--- a/sotodlib/site_pipeline/make_hwp_solutions.py
+++ b/sotodlib/site_pipeline/make_hwp_solutions.py
@@ -106,9 +106,7 @@ def main(
     # policy = util.ArchivePolicy.from_params(config['archive']['policy'])
     # dest_file, dest_dataset = policy.get_dest(obs_id)
     # Use 'output_dir' argument for now
-    h5_filename = 'hwp_angle.h5'
     man_db_filename = os.path.join(output_dir, 'hwp_angle.sqlite')
-    output_filename = os.path.join(output_dir, h5_filename)
 
     if os.path.exists(man_db_filename):
         logger.info(f"Mapping {man_db_filename} for the "
@@ -154,6 +152,10 @@ def main(
 
     # write solutions
     for obs in run_list:
+        # split h5 file by first 4 digits of unixtime
+        h5_filename = 'hwp_angle_{}.h5'.format(obs["obs_id"].split('_')[1][:4])
+        output_filename = os.path.join(output_dir, h5_filename)
+
         h5_address = obs["obs_id"]
         logger.info(f"Calculating Angles for {h5_address}")
         ctx = core.Context(context)


### PR DESCRIPTION
To address this issue https://github.com/simonsobs/sotodlib/issues/689
- Split h5 files by first 4 digits of Unix time. This might be temporary solution.
- Make make_hwp_solutions.py robust to temporary IO blocking.

We update the version of `hwp_angles` with this PR. Identifier: `satpX_hwp_angles_240301m`
Documentation: https://simonsobs.atlassian.net/wiki/spaces/PRO/pages/306708481/hwp+angles+Metadata+Version+Log#240301