### PR TITLE
Keeping metadata shape even with preprocess select=True.

### DIFF
--- a/sotodlib/hwp/hwp.py
+++ b/sotodlib/hwp/hwp.py
@@ -7,7 +7,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def get_hwpss(aman, signal=None, hwp_angle=None, bin_signal=True, bins=360,
+def get_hwpss(aman, signal_name=None, hwp_angle=None, bin_signal=True, bins=360,
               lin_reg=True, modes=[1, 2, 3, 4, 6, 8], apply_prefilt=True,
               prefilt_cfg=None, prefilt_detrend='linear', flags=None,
               merge_stats=True, hwpss_stats_name='hwpss_stats',
@@ -23,8 +23,9 @@ def get_hwpss(aman, signal=None, hwp_angle=None, bin_signal=True, bins=360,
     ----------
     aman : AxisManager object
         The TOD to extract HWPSS from.
-    signal : array-like, optional
-        The TOD signal to use. If not provided, `aman.signal` will be used.
+    signal_name : str
+        The field name in the axis manager to use for the TOD signal.
+        If not provided, ``signal`` will be used.
     hwp_angle : array-like, optional
         The HWP angle for each sample in `aman`. If not provided, `aman.hwp_angle` will be used.
     bin_signal : bool, optional
@@ -81,23 +82,23 @@ def get_hwpss(aman, signal=None, hwp_angle=None, bin_signal=True, bins=360,
 
             - **sigma_tod** (n_dets) : estimate of the standard deviation of the signal using function ``estimate_sigma_tod``
     """
+    if prefilt_cfg is None:
+        prefilt_cfg = {'type': 'sine2', 'cutoff': 1.0, 'trans_width': 1.0}
 
-    if signal is None:
+    prefilt = filters.get_hpf(prefilt_cfg)
+
+    if signal_name is None:
         if apply_prefilt:
-            if prefilt_cfg is None:
-                prefilt_cfg = {'type': 'sine2', 'cutoff': 1.0, 'trans_width': 1.0}
-            prefilt = filters.get_hpf(prefilt_cfg)
             signal = np.array(tod_ops.fourier_filter(
                 aman, prefilt, detrend=prefilt_detrend, signal_name='signal'))
         else:
             signal = aman.signal
     else:
         if apply_prefilt:
-            raise ValueError('filters module does not support'+
-                    ' passing an axis other than aman.signal, you must'+
-                    ' run with apply_prefilt=False, signal=<your signal>'+
-                    ' apply_prefilt=True, signal=None, or apply_prefilt'+
-                    '=False, signal=None.')
+            signal = np.array(tod_ops.fourier_filter(
+                aman, prefilt, detrend=prefilt_detrend, signal_name=signal_name))
+        else:
+            signal = aman[signal_name]
 
     if hwp_angle is None:
         hwp_angle = aman.hwp_angle

--- a/sotodlib/preprocess/core.py
+++ b/sotodlib/preprocess/core.py
@@ -218,6 +218,11 @@ class Pipeline(list):
         """
         if proc_aman is None:
             proc_aman = core.AxisManager( aman.dets, aman.samps)
+            fman = core.AxisManager(core.LabelAxis(name='fdets', vals=aman.dets.vals), 
+                                    core.OffsetAxis('fsamps', count=aman.samps.count,
+                                                    offset=aman.samps.offset, 
+                                                    origin_tag=aman.samps.origin_tag))
+            proc_aman.merge(fman)
             run_calc = True
         else:
             if aman.dets.count != proc_aman.dets.count or not np.all(aman.dets.vals == proc_aman.dets.vals):

--- a/sotodlib/preprocess/core.py
+++ b/sotodlib/preprocess/core.py
@@ -184,8 +184,8 @@ def expand_proc_aman(calc_aman, proc_aman, flag_fill_val=False,
             if isinstance(calc_aman[fld][0], bool):
                 fill_value = flag_fill_val
         else:
-            raise ValueError('Data type in axis manager not supported '+
-                            'in expand_proc_aman')
+            raise ValueError(f"Data type {type(calc_aman[fld])} in axis manager"
+                            " not supported in expand_proc_aman")
 
         if np.any(np.isin(axes, ['dets', 'samps'])):
             out_aman.wrap_new('f'+fld, faxes, cls=np.full, fill_value=fill_value)

--- a/sotodlib/preprocess/core.py
+++ b/sotodlib/preprocess/core.py
@@ -157,8 +157,10 @@ def expand_proc_aman(calc_aman, proc_aman, flag_fill_val=False,
         and samps in calc_aman padded to fdets, fsamps shape.
     """
     assn = calc_aman._assignments
-    out_aman = core.AxisManager(*[proc_aman['f'+x] if x in ['dets','samps'] \
-                                  else calc_aman[x] for x in calc_aman._axes])
+    oaxes = [proc_aman['f'+x] if x in ['dets','samps'] \
+                                  else calc_aman[x] for x in calc_aman._axes]
+    oaxes += [proc_aman[x] for x in calc_aman._axes if x in ['dets','samps']]
+    out_aman = core.AxisManager(*oaxes)
     
     _, _, fmdets = np.intersect1d(proc_aman.dets.vals,
                                     proc_aman.fdets.vals,
@@ -189,9 +191,9 @@ def expand_proc_aman(calc_aman, proc_aman, flag_fill_val=False,
         out_aman.wrap(fld, calc_aman[fld], list(enumerate(axes)))
         d = {'dets': fmdets, 'samps': fmsamps}
         slices = [d.get(a, slice(None)) for a in axes]
-        if isinstance(calc_aman[fld], RangesMatrix)
+        if isinstance(calc_aman[fld], RangesMatrix):
             out_aman['f'+fld][tuple(slices)]=calc_aman[fld].mask()
-            out_aman['f'+fld] = RangesMatrix.from_mask(out_aman[fld])
+            out_aman['f'+fld] = RangesMatrix.from_mask(out_aman['f'+fld])
         else:
             out_aman['f'+fld][tuple(slices)]=calc_aman[fld]
     return out_aman
@@ -225,7 +227,7 @@ def collape_proc_aman(proc_aman):
         if np.any(np.isin(axes, ['dets', 'samps'])):
             continue
         naxes = [a.strip('f') if a in ['fdets', 'fsamps'] else a for a in axes]
-        out_aman.wrap(fld, proc_aman[fld], list(enumerate(naxes)))
+        out_aman.wrap(fld[1:], proc_aman[fld], list(enumerate(naxes)))
     return out_aman
 
 class Pipeline(list):

--- a/sotodlib/preprocess/core.py
+++ b/sotodlib/preprocess/core.py
@@ -2,6 +2,7 @@
 import logging
 import numpy as np
 from .. import core
+from so3g.proj import RangesMatrix
 
 class _Preprocess(object):
     """The base class for Preprocessing modules which defines the required
@@ -127,7 +128,79 @@ class _Preprocess(object):
                 f"Preprocess Module of name {name} is already Registered"
             )
 
+def expand_proc_aman(calc_aman, proc_aman, flag_fill_val=False,
+                     flt_fill_val=np.nan, int_fill_val=2**32-1):
+    """
+    Helper function to expand the size of calculated products to match the 
+    precut dets and samps shape.
+    Arguments:
+    ----------
+    calc_aman: AxisManager
+        AxisManager returned from calc step.
+    proc_aman: AxisManager
+        AxisManager passed between processes.
+    fill_value:
+        Value to fill missing indices with.
+    """
+    if (proc_aman.dets.count < proc_aman.fdets.count) or \
+       (proc_aman.samps.count < proc_aman.fsamps.count):
+        _, mdets, fmdets = np.intersect1d(proc_aman.dets.vals,
+                                          proc_aman.fdets.vals,
+                                          return_indices=True)
+        fmsamps = slice(proc_aman.samps.offset,
+                        proc_aman.samps.offset+proc_aman.samps.count)
+    
+    out_aman = core.AxisManager(proc_aman.fdets, proc_aman.fsamps)
+    for fld in calc_aman._fields:
+        dat = calc_aman[fld]
+        dax, sax = None, None
+        axes = calc_aman.shape_str(fld).split(',')
+        maxes = np.isin(axes, ['dets', 'samps'])
+        axismap = [(i, a) for i, a in enumerate(axes)]
+        faxismap = [(i, 'f'+a) if m else (i, a) for i, [a, m] in enumerate(list(zip(axes, maxes)))]
+        if np.all(~maxes):
+            out_aman.wrap(fld, dat, axismap)
+        else:
+            if np.isin(type(np.hstack(dat)[0]), [so3g.RangesInt32, bool]):
+                fill_value = flag_fill_val
+                if isinstance(dat, RangesMatrix):
+                    dat = dat.mask()
+            if np.isin(type(np.hstack(dat)[0]), [np.int64, np.int32, int]):
+                fill_value = int_fill_val
+            if np.isin(type(np.hstack(dat)[0]), [np.float64, np.float32, float]):
+                fill_value = flt_fill_val
 
+            shape = tuple([proc_aman[am].count if m else calc_aman[fld].count for am, m in zip(axismap, maxes)])
+            fdat = np.full(shape, fill_value)
+
+            if ('dets' in axes) and not('samps' in axes):
+                dax = np.where(axes == 'dets')[0]
+                dat = np.moveaxis(dat, dax, 0)
+                fdat = np.moveaxis(fdat, dax, 0) 
+                fdat[fmdets] = dat
+                dat = np.moveaxis(dat, 0, dax)
+                fdat = np.moveaxis(fdat, 0, dax)
+            elif ('samps' in axes) and not('dets' in axes):
+                sax = np.where(axes == 'samps')[0]
+                dat = np.moveaxis(dat, sax, 0)
+                fdat = np.moveaxis(fdat, sax, 0)
+                fdat[fmsamps] = dat
+                dat = np.moveaxis(dat, 0, sax)
+                fdat = np.moveaxis(fdat, 0, sax)
+            else:
+                dax = np.where(axes == 'dets')[0]
+                sax = np.where(axes == 'samps')[0]
+                dat = np.moveaxis(dat, (dax, sax), (0,1))
+                fdat = np.moveaxis(fdat, (dax, sax), (0,1))
+                fdat[fmdets, fmsamps] = dat
+                dat = np.moveaxis(dat, (0,1), dax, sax)
+                fdat = np.moveaxis(fdat, (0,1), (dax, sax))
+            
+            if isinstance(fill_value, bool):
+                fdat = RangesMatrix.from_mask(fdat)
+                dat = RangesMatrix.from_mask(dat)
+            out_aman.wrap(fld, dat, axismap)
+            out_aman.wrap(fld, fdat, faxismap)
 
 class Pipeline(list):
     """This class is designed to create and run pipelines out of a series of

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -49,8 +49,8 @@ class DetBiasFlags(_Preprocess):
     def calc_and_save(self, aman, proc_aman):
         m = tod_ops.flags.get_det_bias_flags(aman, merge=False,
                                                **self.calc_cfgs)
-        calc_aman = core.AxisManager(proc_aman.fdets, proc_aman.fsamps)
-        calc_aman.wrap('det_bias_flags', msk, [(0, 'dets'), (1, 'samps')])
+        calc_aman = core.AxisManager(proc_aman.dets, proc_aman.samps)
+        calc_aman.wrap('det_bias_flags', m, [(0, 'dets'), (1, 'samps')])
         dbc_aman = expand_proc_aman(calc_aman, proc_aman)
         del calc_aman
         self.save(proc_aman, dbc_aman)
@@ -427,8 +427,8 @@ class EstimateHWPSS(_Preprocess):
     Example config block::
 
       - "name : "estimate_hwpss"
-        "signal: "signal" # optional
         "calc":
+          "signal_name": "signal" # optional
           "hwpss_stats_name": "hwpss_stats"
         "save": True
 
@@ -436,20 +436,8 @@ class EstimateHWPSS(_Preprocess):
     """
     name = "estimate_hwpss"
 
-    def __init__(self, step_cfgs):
-        self.signal = step_cfgs.get('signal', 'signal')
-
-        super().__init__(step_cfgs)
-
     def calc_and_save(self, aman, proc_aman):
-        _prefilt = (self.signal == 'signal')
-        if not _prefilt:
-            print("WARNING: apply_prefilt defaulting to False because " +
-                  f"{self.signal} != 'signal'.")
-        calc_aman = hwp.get_hwpss(aman,
-                                    signal=aman[self.signal],
-                                    apply_prefilt=_prefilt,
-                                    **self.calc_cfgs)
+        calc_aman = hwp.get_hwpss(aman, **self.calc_cfgs)
         hwpss_stats = expand_proc_aman(calc_aman, proc_aman)
         self.save(proc_aman, hwpss_stats)
 

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -11,6 +11,60 @@ from sotodlib.core.flagman import (has_any_cuts, has_all_cut,
 
 from .core import _Preprocess
 
+def expand_proc_aman(calc_aman, proc_aman, flag_fill_val=False,
+                     flt_fill_val=np.nan, int_fill_val=2**32-1):
+    """
+    Helper function to expand the size of calculated products to match the 
+    precut dets and samps shape.
+    Arguments:
+    ----------
+    calc_aman: AxisManager
+        AxisManager returned from calc step.
+    proc_aman: AxisManager
+        AxisManager passed between processes.
+    fill_value:
+        Value to fill missing indices with.
+    """
+    if (proc_aman.dets.count < proc_aman.fdets.count) or \
+       (proc_aman.samps.count < proc_aman.fsamps.count):
+        _, mdets, fmdets = np.intersect1d(proc_aman.dets.vals,
+                                          proc_aman.fdets.vals,
+                                          return_indices=True)
+        msamps = slice(proc_aman.samps.offset,
+                       proc_aman.samps.offset+proc_aman.samps.count)
+    
+    out_aman = core.AxisManager(proc_aman.fdets, proc_aman.fsamps)
+    for fld in calc_aman._fields:
+        dat = calc_aman[fld]
+        axes = calc_aman.shape_str(fld).split(',')
+        maxes = np.isin(axes, ['dets', 'samps'])
+        axismap = [(i, a) for i, a in enumerate(axes)]
+        faxismap = [(i, 'f'+a) if m else (i, a) for i, [a, m] in enumerate(list(zip(axes, maxes)))]
+        if np.all(~maxes):
+            out_aman.wrap(fld, dat, axismap)
+        else:
+            if np.isin(type(np.hstack(dat)[0]), [so3g.RangesInt32, bool]):
+                fill_value = flag_fill_val
+                dat = dat.mask()
+            if np.isin(type(np.hstack(dat)[0]), [np.int64, np.int32, int]):
+                fill_value = int_fill_val
+            if np.isin(type(np.hstack(dat)[0]), [np.float64, np.float32, float]):
+                fill_value = flt_fill_val
+            shape = tuple([proc_aman[am].count if m else calc_aman[fld].count for am, m in zip(axismap, maxes)])
+            fdat = np.full(shape, fill_value)
+
+            # Need to figure out how to do this slicing.
+            # I think I need to enforce axis ordering to be dets_axis x samps_axis x any other axis
+            # Then this should be reasonably straightforward.
+            fdat[fmdets,msamps] = dat[mdets]
+
+            if isinstance(fill_value, bool):
+                fdat = RangesMatrix.from_mask(fdat)
+                dat = RangesMatrix.from_mask(dat)
+            out_aman.wrap(fld, dat, axismap)
+            out_aman.wrap(fld, fdat, faxismap)
+
+    return
 
 class FFTTrim(_Preprocess):
     """Trim the AxisManager to optimize for faster FFTs later in the pipeline.
@@ -58,7 +112,7 @@ class DetBiasFlags(_Preprocess):
                                        return_indices=True)
             msk[d2,proc_aman.samps.offset:proc_aman.samps.offset+proc_aman.samps.count] = \
                 m.mask()[d1]
-            msk = RangesMatrix(msk)
+            msk = RangesMatrix.from_mask(msk)
         else:
             msk = m
         dbc_aman.wrap('det_bias_flags', m, [(0, 'dets'), (1, 'samps')])
@@ -114,6 +168,9 @@ class Trends(_Preprocess):
         _, trend_aman = tod_ops.flags.get_trending_flags(
             aman, merge=False, full_output=True,
             signal=aman[self.signal], **self.calc_cfgs)
+        taman = core.AxisManager(proc_aman.fdets, proc_aman.fsamps,
+                                 trend_aman.trend_bins)
+        
         aman.wrap("trends", trend_aman)
         self.save(proc_aman, trend_aman)
     

--- a/sotodlib/tod_ops/fft_ops.py
+++ b/sotodlib/tod_ops/fft_ops.py
@@ -248,14 +248,14 @@ def calc_psd(
         **kwargs
     )
     if merge:
-        aman.merge( core.AxisManager(core.OffsetAxis("fsamps", len(freqs))))
+        aman.merge( core.AxisManager(core.OffsetAxis("nusamps", len(freqs))))
         if overwrite:
             if "freqs" in aman._fields:
                 aman.move("freqs", None)
             if "Pxx" in aman._fields:
                 aman.move("Pxx", None)
-        aman.wrap("freqs", freqs, [(0,"fsamps")])
-        aman.wrap("Pxx", Pxx, [(0,"dets"),(1,"fsamps")])
+        aman.wrap("freqs", freqs, [(0,"nusamps")])
+        aman.wrap("Pxx", Pxx, [(0,"dets"),(1,"nusamps")])
     return freqs, Pxx
 
 def calc_wn(aman, pxx=None, freqs=None, low_f=5, high_f=10):


### PR DESCRIPTION
This PR amounts to adding a full samps -- `fsamps` and full dets -- `fdets` which we fill with a nominal value at the beginning before calculating anything in preprocess. Then as preprocess proceeds and the dets or samps axis gets restricted the data is sliced into the full dets and full samps so that it's not further restricted as the pipeline proceeds. This amounts to keeping all of the calculated values and flags at the shape the data was when the calculation was run.