### PR TITLE
Add signal arg to `EstimateHWPSS`

### DIFF
--- a/sotodlib/hwp/hwp.py
+++ b/sotodlib/hwp/hwp.py
@@ -38,6 +38,7 @@ def get_hwpss(aman, signal=None, hwp_angle=None, bin_signal=True, bins=360,
         The HWPSS harmonic modes to extract. Default is [1, 2, 3, 4, 6, 8].
     apply_prefilt : bool, optional
         Whether to apply a high-pass filter to signal before extracting HWPSS. Default is `True`.
+        If run through preprocess and `signal` is not `aman.signal` then default to `False`.
     prefilt_cfg : dict, optional
         The configuration of the high-pass filter, in Hz. Only used if `apply_prefilt` is `True`.
         Default is sine2 filter of with cutoff frequency of 1.0 Hz and trans_width of 1.0 Hz.

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -426,8 +426,17 @@ class EstimateHWPSS(_Preprocess):
     """
     name = "estimate_hwpss"
 
+    def __init__(self, step_cfgs):
+        self.signal = step_cfgs.get('signal', 'signal')
+
+        super().__init__(step_cfgs)
+
     def calc_and_save(self, aman, proc_aman):
-        hwpss_stats = hwp.get_hwpss(aman, **self.calc_cfgs)
+        _prefilt = (self.signal == 'signal')
+        hwpss_stats = hwp.get_hwpss(aman,
+                                    signal=aman[self.signal],
+                                    apply_prefilt=_prefilt,
+                                    **self.calc_cfgs)
         self.save(proc_aman, hwpss_stats)
 
     def save(self, proc_aman, hwpss_stats):

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -420,7 +420,16 @@ class Calibrate(_Preprocess):
 class EstimateHWPSS(_Preprocess):
     """
     Builds a HWPSS Template. Calc configs go to ``hwpss_model``.
-    Results of fitting saved if field specified by calc["name"]
+    Results of fitting saved if field specified by calc["name"].
+    Example config dictionary::
+
+        {
+            "name : "estimate_hwpss"
+            "signal: "signal" # optional
+            "calc":
+                "hwpss_stats_name": "hwpss_stats"
+            "save": True
+        }
 
     .. autofunction:: sotodlib.hwp.hwp.get_hwpss
     """

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -433,6 +433,9 @@ class EstimateHWPSS(_Preprocess):
 
     def calc_and_save(self, aman, proc_aman):
         _prefilt = (self.signal == 'signal')
+        if not _prefilt:
+            print("WARNING: apply_prefilt defaulting to False because " +
+                  f"{self.signal} != 'signal'.")
         hwpss_stats = hwp.get_hwpss(aman,
                                     signal=aman[self.signal],
                                     apply_prefilt=_prefilt,


### PR DESCRIPTION
This allows the signal argument to be passed to the `EstimateHWPSS` class. The check for a signal that disables the prefilter is needed because the [filters module does not support other axes](https://github.com/simonsobs/sotodlib/blob/c65acf976e0bd2a6f190187478c1de34f6964ddc/sotodlib/hwp/hwp.py#L94-L99).

I tested this with this script:
```python
import yaml
import numpy as np
from sotodlib import core, preprocess

# Load pipeline config
configs="/so/home/koopman/hackathon/preprocess_config_cmb_240301.yaml"
configs = yaml.safe_load(open(configs, "r"))

# Load context
ctx = core.Context('/so/home/msilvafe/shared_files/contexts/satp1_scr3_context_20240125.yaml')
aman = ctx.get_obs('obs_1704770693_satp1_1111111', dets={'wafer_slot':'ws0'})

# Restrict to 10 detectors
aman.restrict('dets', aman.dets.vals[:10])

# Create fake HWP signal
x = np.ones(shape)*np.sin(2*aman.hwp_angle)
aman.wrap('test', x, [(0, 'dets'), (1, 'samps')])

# Run pipeline
pipe = preprocess.Pipeline(configs["process_pipe"])
proc_aman = pipe.run(aman)

# View output
print(proc_aman.hwpss_stats.coeffs)
```

Output went from this (i.e. running on 'signal'):
```
[[-2.94455024e-06  5.91858415e-06  7.72687634e-06 -1.05366595e-05
  -6.25068440e-07  9.18997903e-07  7.11252628e-05  2.69432703e-04
   1.46935422e-05  4.71317297e-06  1.22938786e-04  1.14738851e-04]
 [-3.66489253e-04 -4.04393110e-03 -6.04566398e-03  6.11566323e-02
   3.77546782e-04 -4.06992379e-04 -9.21515043e-01  3.28528987e-01
   1.48215986e-03  4.68978025e-04  3.71613327e-03  6.79638022e-03]
 [-9.45576714e-03 -3.66164105e-03 -1.12054830e-02 -3.06231364e-02
  -1.72121222e-04 -8.88164355e-04 -5.90605154e-01 -8.93244249e-01
   2.48884720e-05 -2.69333438e-03 -3.11583964e-02 -3.20172650e-02]
 [-2.07310543e-03 -3.99492672e-03 -1.80829865e-02  1.59432259e-02
  -1.00324593e-03 -5.87748398e-04 -1.16589866e+00  6.07542837e-01
   9.94603344e-04 -1.10343466e-03  9.94965679e-03  1.22940028e-02]
 [-1.17446011e-02 -3.15257760e-03  1.78690740e-02  3.70996919e-02
   8.19536279e-04  1.50595912e-03  9.05058107e-01 -3.99005515e-01
  -1.81524305e-03  4.52877636e-04  6.43456782e-03  1.02387264e-02]
 [ 5.55992264e-06  1.69041064e-05 -2.76867143e-05 -3.75897678e-06
   1.17477394e-05  1.22825885e-05  8.89497208e-04 -3.45171693e-04
  -4.97277286e-05  1.23853228e-06 -4.04340265e-04 -4.16391209e-04]
 [-1.30193184e-03  1.68240862e-04  1.84857817e-03  1.74079226e-03
  -1.71644908e-04  1.95308579e-04  6.17723107e-02  4.64586413e-02
  -3.05976314e-04  2.33431300e-04 -4.03466254e-03  2.02218941e-03]
 [ 2.52399991e+01 -7.41447576e+00 -1.11702095e+01  6.66102685e+00
   6.07862516e+00 -6.04170541e+00 -3.79546809e+00  5.70094579e+00
  -3.69308252e-02  4.35813790e+00  1.46712895e+00  3.09774623e+00]
 [-4.11546568e-03  4.02427435e-03 -1.78187478e-02 -9.36668967e-03
   9.38850569e-05  2.27070270e-03 -9.32621092e-01  4.08000636e-01
   9.64016256e-04  1.51318031e-03  6.56780900e-03  1.04506110e-02]
 [-9.69075181e-03 -3.58539678e-03  2.38410953e-02 -1.71101806e-02
   4.66249088e-04  5.16347303e-04  1.09027376e+00 -5.63434819e-01
   5.34802641e-04  1.87902404e-03  1.14464282e-02  1.30612795e-02]]
```

to this (i.e. running with the 'test' signal):
```
[[ 2.10912912e-07  3.02709220e-06  9.99948255e-01 -1.90283046e-06
   5.34514585e-06  2.76829272e-06 -4.65745656e-06  2.41172695e-06
  -3.22277072e-07 -5.01531282e-06 -8.05474297e-06  6.98209160e-06]
 [ 2.10912912e-07  3.02709220e-06  9.99948255e-01 -1.90283046e-06
   5.34514585e-06  2.76829272e-06 -4.65745656e-06  2.41172695e-06
  -3.22277072e-07 -5.01531282e-06 -8.05474297e-06  6.98209160e-06]
 [ 2.10912912e-07  3.02709220e-06  9.99948255e-01 -1.90283046e-06
   5.34514585e-06  2.76829272e-06 -4.65745656e-06  2.41172695e-06
  -3.22277072e-07 -5.01531282e-06 -8.05474297e-06  6.98209160e-06]
 [ 2.10912912e-07  3.02709220e-06  9.99948255e-01 -1.90283046e-06
   5.34514585e-06  2.76829272e-06 -4.65745656e-06  2.41172695e-06
  -3.22277072e-07 -5.01531282e-06 -8.05474297e-06  6.98209160e-06]
 [ 2.10912912e-07  3.02709220e-06  9.99948255e-01 -1.90283046e-06
   5.34514585e-06  2.76829272e-06 -4.65745656e-06  2.41172695e-06
  -3.22277072e-07 -5.01531282e-06 -8.05474297e-06  6.98209160e-06]
 [ 2.10912912e-07  3.02709220e-06  9.99948255e-01 -1.90283046e-06
   5.34514585e-06  2.76829272e-06 -4.65745656e-06  2.41172695e-06
  -3.22277072e-07 -5.01531282e-06 -8.05474297e-06  6.98209160e-06]
 [ 2.10912912e-07  3.02709220e-06  9.99948255e-01 -1.90283046e-06
   5.34514585e-06  2.76829272e-06 -4.65745656e-06  2.41172695e-06
  -3.22277072e-07 -5.01531282e-06 -8.05474297e-06  6.98209160e-06]
 [ 2.10912912e-07  3.02709220e-06  9.99948255e-01 -1.90283046e-06
   5.34514585e-06  2.76829272e-06 -4.65745656e-06  2.41172695e-06
  -3.22277072e-07 -5.01531282e-06 -8.05474297e-06  6.98209160e-06]
 [ 2.10912912e-07  3.02709220e-06  9.99948255e-01 -1.90283046e-06
   5.34514585e-06  2.76829272e-06 -4.65745656e-06  2.41172695e-06
  -3.22277072e-07 -5.01531282e-06 -8.05474297e-06  6.98209160e-06]
 [ 2.10912912e-07  3.02709220e-06  9.99948255e-01 -1.90283046e-06
   5.34514585e-06  2.76829272e-06 -4.65745656e-06  2.41172695e-06
  -3.22277072e-07 -5.01531282e-06 -8.05474297e-06  6.98209160e-06]]
```

My "/so/home/koopman/hackathon/preprocess_config_cmb_240301.yaml" config script is:
```yaml
context_file: '/so/home/msilvafe/shared_files/contexts/satp1_scr3_context_20240125.yaml'

subobs:
  use: wafer_slot
  label: wafer_slot

archive:
  index: '/so/home/msilvafe/shared_files/preprocess/process_archive.sqlite'
  policy:
    type: 'simple'
    filename: '/so/home/msilvafe/shared_files/preprocess/preprocess_archive.h5'

process_pipe:
    - name: "estimate_hwpss"
      signal: "test"  # aman["glitched_filled"] instead of aman["signal"]
      calc:
        hwpss_stats_name: "hwpss_stats"
      save: True
```