### PR TITLE
Convert example preprocess configs to valid yaml

### DIFF
--- a/docs/preprocess.rst
+++ b/docs/preprocess.rst
@@ -139,11 +139,14 @@ TOD Operations
 .. autoclass:: sotodlib.preprocess.processes.Calibrate
 .. autoclass:: sotodlib.preprocess.processes.Apodize
 .. autoclass:: sotodlib.preprocess.processes.SubPolyf
+.. autoclass:: sotodlib.preprocess.processes.Jumps
+.. autoclass:: sotodlib.preprocess.processes.FixJumps
 
 Flagging and Products
 :::::::::::::::::::::
 .. autoclass:: sotodlib.preprocess.processes.Trends
 .. autoclass:: sotodlib.preprocess.processes.GlitchDetection
+.. autoclass:: sotodlib.preprocess.processes.GlitchFill
 .. autoclass:: sotodlib.preprocess.processes.Noise
 .. autoclass:: sotodlib.preprocess.processes.FlagTurnarounds
 

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -76,7 +76,7 @@ class Trends(_Preprocess):
 
     Data selection can have key "kind" equal to "any" or "all."
 
-     Example config dictionary::
+     Example config block::
 
         - name : "trends"
           signal: "signal" # optional
@@ -133,7 +133,7 @@ class GlitchDetection(_Preprocess):
     Data section should define a glitch significant "sig_glitch" and a maximum
     number of glitches "max_n_glitch."
 
-    Example configuration dictionary::
+    Example configuration block::
         
       - name: "glitches"
         signal: "hwpss_remove"
@@ -186,7 +186,7 @@ class FixJumps(_Preprocess):
     """
     Repairs the jump heights given a set of jump flags and heights.
 
-    Example config dictionary::
+    Example config block::
 
       - name: "fix_jumps"
         signal: "signal" # optional
@@ -220,7 +220,7 @@ class Jumps(_Preprocess):
 
     Data section should define a maximum number of jumps "max_n_jumps".
 
-    Example config dictionary::
+    Example config block::
 
       - name: "jumps"
         signal: "hwpss_remove"
@@ -281,7 +281,7 @@ class PSDCalc(_Preprocess):
     """ Calculate the PSD of the data and add it to the AxisManager under the
     "psd" field.
 
-    Example config dictionary::
+    Example config block::
 
       - "name : "psd"
         "signal: "signal" # optional
@@ -414,7 +414,7 @@ class EstimateHWPSS(_Preprocess):
     Builds a HWPSS Template. Calc configs go to ``hwpss_model``.
     Results of fitting saved if field specified by calc["name"].
 
-    Example config dictionary::
+    Example config block::
 
       - "name : "estimate_hwpss"
         "signal: "signal" # optional
@@ -506,7 +506,7 @@ class EstimateAzSS(_Preprocess):
 class GlitchFill(_Preprocess):
     """Fill glitches. All process configs go to `fill_glitches`.
 
-    Example configuration dictionary::
+    Example configuration block::
 
       - name: "glitchfill"
         signal: "hwpss_remove"

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -78,16 +78,14 @@ class Trends(_Preprocess):
 
      Example config dictionary::
 
-        {
-            name : "trends"
-            signal: "signal" # optional
-            calc:
-                max_trend: 2.5
-                n_pieces: 10
-            save: True
-            select:
-                kind: "any"     
-        }
+        - name : "trends"
+          signal: "signal" # optional
+          calc:
+            max_trend: 2.5
+            n_pieces: 10
+          save: True
+          select:
+            kind: "any"
     
     .. autofunction:: sotodlib.tod_ops.flags.get_trending_flags
     """
@@ -137,18 +135,16 @@ class GlitchDetection(_Preprocess):
 
     Example configuration dictionary::
         
-        {
-            name: "glitches"
-            signal: "hwpss_remove"
-            calc:
-                t_glitch: 0.00001
-                buffer: 10
-                hp_fc: 1
-                n_sig: 10
-            save: True
-            select:
-                max_n_glitch: 10
-        }
+      - name: "glitches"
+        signal: "hwpss_remove"
+        calc:
+          t_glitch: 0.00001
+          buffer: 10
+          hp_fc: 1
+          n_sig: 10
+        save: True
+        select:
+          max_n_glitch: 10
 
     .. autofunction:: sotodlib.tod_ops.flags.get_glitch_flags
     """
@@ -192,12 +188,10 @@ class FixJumps(_Preprocess):
 
     Example config dictionary::
 
-        {
-            name: "fix_jumps"
-            signal: "signal" # optional
-            process:
-            jumps_aman: "jumps_2pi"
-        }
+      - name: "fix_jumps"
+        signal: "signal" # optional
+        process:
+        jumps_aman: "jumps_2pi"
 
     .. autofunction:: sotodlib.tod_ops.jumps.jumpfix_subtract_heights
     """
@@ -228,14 +222,12 @@ class Jumps(_Preprocess):
 
     Example config dictionary::
 
-        {
-            name: "jumps"
-            signal: "hwpss_remove"
-            calc:
-                function: "twopi_jumps"
-            save:
-                jumps_name: "jumps_2pi"
-        }
+      - name: "jumps"
+        signal: "hwpss_remove"
+        calc:
+          function: "twopi_jumps"
+        save:
+          jumps_name: "jumps_2pi"
 
     .. autofunction:: sotodlib.tod_ops.jumps.find_jumps
     """
@@ -287,19 +279,19 @@ class Jumps(_Preprocess):
 
 class PSDCalc(_Preprocess):
     """ Calculate the PSD of the data and add it to the AxisManager under the
-    "psd" field. Example config dictionary::
+    "psd" field.
 
-        {
-            "name : "psd"
-            "signal: "signal" # optional
-            "wrap": "psd" # optional
-            "process": 
-                "psd_cfgs": # optional, kwargs to scipy.welch
-                    "nperseg": 1024 
-                "wrap_name": "psd" # optional
-            "calc": True
-            "save": True
-        }
+    Example config dictionary::
+
+      - "name : "psd"
+        "signal: "signal" # optional
+        "wrap": "psd" # optional
+        "process":
+          "psd_cfgs": # optional, kwargs to scipy.welch
+            "nperseg": 1024
+          "wrap_name": "psd" # optional
+        "calc": True
+        "save": True
 
     .. autofunction:: sotodlib.tod_ops.fft_ops.calc_psd
     """
@@ -421,15 +413,14 @@ class EstimateHWPSS(_Preprocess):
     """
     Builds a HWPSS Template. Calc configs go to ``hwpss_model``.
     Results of fitting saved if field specified by calc["name"].
+
     Example config dictionary::
 
-        {
-            "name : "estimate_hwpss"
-            "signal: "signal" # optional
-            "calc":
-                "hwpss_stats_name": "hwpss_stats"
-            "save": True
-        }
+      - "name : "estimate_hwpss"
+        "signal: "signal" # optional
+        "calc":
+          "hwpss_stats_name": "hwpss_stats"
+        "save": True
 
     .. autofunction:: sotodlib.hwp.hwp.get_hwpss
     """
@@ -517,16 +508,14 @@ class GlitchFill(_Preprocess):
 
     Example configuration dictionary::
 
-        {
-            name: "glitchfill"
-            signal: "hwpss_remove"
-            flag_aman: "jumps_2pi"
-            flag: "jump_flag"
-            process:
-                nbuf: 10
-                use_pca: False
-                modes: 1
-        }
+      - name: "glitchfill"
+        signal: "hwpss_remove"
+        flag_aman: "jumps_2pi"
+        flag: "jump_flag"
+        process:
+          nbuf: 10
+          use_pca: False
+          modes: 1
 
     .. autofunction:: sotodlib.tod_ops.gapfill.fill_glitches
     """


### PR DESCRIPTION
Title basically says it all. The yaml will be more useful for users writing a preprocess config file.

I added missing classes to the `preprocess.rst` file when I found missing ones with example config blocks in their docstrings.

I also indented the yaml with two spaces, as that seemed like convention in the head of the preprocess configs I've been working with.