### PR TITLE
Make copy of slices because slices are pointers

### DIFF
--- a/sotodlib/core/axisman.py
+++ b/sotodlib/core/axisman.py
@@ -759,14 +759,22 @@ class AxisManager:
             if isinstance(v, AxisManager):
                 dest._fields[k] = v.copy()
                 if axis_name in v._axes:
-                    dest._fields[k].restrict(axis_name, selector)
+                    dest._fields[k].restrict(
+                        axis_name, 
+                        selector, 
+                        ## copies of axes made above
+                        in_place=True 
+                    )
             elif np.isscalar(v) or v is None:
                 dest._fields[k] = v
             else:
                 sslice = [sl if n == axis_name else slice(None)
                           for n in dest._assignments[k]]
                 sslice = dest._broadcast_selector(sslice)
-                dest._fields[k] = v[sslice]
+                if in_place:
+                    dest._fields[k] = v[sslice]
+                else:
+                    dest._fields[k] = v[sslice].copy()
         dest._axes[axis_name] = new_ax
         return dest
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -339,6 +339,19 @@ class TestAxisManager(unittest.TestCase):
             self.assertIn('rebel_child', aout, msg=msg)
             self.assertEqual(aout['rebel_child'].shape, (3,), msg=msg)
 
+    def test_403_restrict_slices(self):
+        # Test in_place is false for slices of arrays
+        dets = ['det0', 'det1', 'det2']
+        n, ofs = 1000, 0
+        aman = core.AxisManager(
+                core.LabelAxis('dets', dets),
+                core.OffsetAxis('samps', n, ofs)
+        )
+        aman.wrap_new('test', ('dets','samps'))
+        rman = aman.restrict('samps', (0,500), in_place=False)
+        rman.test += 5
+        self.assertNotEqual( aman.test[0,0], rman.test[0,0])
+
     def test_410_merge(self):
         dets = ['det0', 'det1', 'det2']
         n, ofs = 1000, 0


### PR DESCRIPTION
Slices need to be copied when restricting with `in_place=False`. Also added a test to catch this error and a comment to remind us not to change the nested in_places. 

Closes https://github.com/simonsobs/sotodlib/issues/636 