### PR TITLE
Prepare `Calibrate` for preprocess integration

### DIFF
--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -409,10 +409,15 @@ class Calibrate(_Preprocess):
     2. to be expanded
     """
     name = "calibrate"
-    
+
+    def __init__(self, step_cfgs):
+        self.signal = step_cfgs.get('signal', 'signal')
+
+        super().__init__(step_cfgs)
+
     def process(self, aman, proc_aman):
         if self.process_cfgs["kind"] == "single_value":
-            aman.signal *=  self.process_cfgs["val"]
+            aman[self.signal] *= self.process_cfgs["val"]
         else:
             raise ValueError(f"Entry '{self.process_cfgs['kind']}'"
                               " not understood")


### PR DESCRIPTION
This PR implements two things in the `Calibrate` operation:
1. Passing the `signal` arg to `Calibrate`
2. Passing an array to `Calibrate`, which provides a calibration factor per detector

The signal arg was tested with a script like:
```python
import yaml
import numpy as np
from sotodlib import core, preprocess

# Load pipeline config
configs="/so/home/koopman/hackathon/ppc_cal_pw_cmb_240301.yaml"
configs = yaml.safe_load(open(configs, "r"))

# Load context
ctx = core.Context('/so/home/koopman/hackathon/satp1_scr3_context_20240125.yaml')
aman = ctx.get_obs('obs_1704770693_satp1_1111111', dets={'wafer_slot':'ws0'})

# Restrict to 10 detectors
aman.restrict('dets', aman.dets.vals[:10])

# Create alternative signal
shape = (aman.dets.count, aman.samps.count)
x = np.random.rand(*shape)
aman.wrap('test', x, [(0, 'dets'), (1, 'samps')])

# Run pipeline
pipe = preprocess.Pipeline(configs["process_pipe"])
proc_aman = pipe.run(aman)
```

The output was inspected to verify that the 'single_value' calibration factor was applied to the 'test' signal and not `aman.signal`.

The same script can be used to test the array calibration. In testing I used the config:
```
    - name: "calibrate"
      signal: "test"
      process:
        kind: "array"
        cal_array: "det_cal.phase_to_pW"
```