### PR TITLE
ensure pid_direction to be 1 or -1 or 0

### DIFF
--- a/sotodlib/hwp/g3thwp.py
+++ b/sotodlib/hwp/g3thwp.py
@@ -956,7 +956,11 @@ class G3tHWP():
                 data = self.load_data(start, end)
 
             if 'pid_direction' in data.keys():
-                aman['pid_direction'] = np.nanmedian(data['pid_direction'][1])*2 - 1
+                pid_direction = np.nanmedian(data['pid_direction'][1])*2 - 1
+                if pid_direction in [1, -1]:
+                    aman['pid_direction'] = pid_direction
+                else:
+                    aman['pid_direction'] = 0
 
             logger.info('Saving raw encoder data')
             self._set_raw_axes(aman, data)


### PR DESCRIPTION
Fixed issue with getting nan value for pid_direction.

This issue resulted in a ValueError when loading hwp metadata.

ValueError: The field 'pid_direction' does not share axis 'dets'; pid_direction is not identical across all items pass other_fields='drop' or 'first' or else remove this field from the targets.