### PR TITLE
pointing quickfit for time domain fitting

### DIFF
--- a/sotodlib/site_pipeline/analyze_bright_ptsrc.py
+++ b/sotodlib/site_pipeline/analyze_bright_ptsrc.py
@@ -518,13 +518,14 @@ class QuickFitResult:
     Args
     ----
     xi: float
-        fitted detector xi relative to boresight center
+        fitted detector xi [rad] relative to boresight center
     eta: float
-        fitted detector eta relative to boresight center
+        fitted detector eta [rad] relative to boresight center
     amp: float
-        Amplitude used in the fit
+        Amplitude used in the fit. This will be in the same units as
+        ``am.signal``, which is generally detector phase.
     fwhm: float
-        gaussian FHWM used in the fit.
+        gaussian FHWM [rad] used in the fit.
     fit_aman: AxisManager
         AxisManager containing xi and eta of source relative to boresight center,
         fitted signal, and model.
@@ -551,13 +552,13 @@ def pointing_quickfit(
     downsample_factor: int
         If set, the signal and model will be downsampled by this factor when fitting.
     bandpass_range: tuple[float, float]
-        Low and high cutoff frequencies for bandpass. If either are None, will not apply
+        Low and high cutoff frequencies [Hz, Hz] for bandpass. If either are None, will not apply
         the corresponding highpass/lowpass.
     fwhm: float
-        Full width half max of the beam to use for the model. This should be roughly the beam
+        Full width half max [radians] of the beam to use for the model. This should be roughly the beam
         size of the telescope.
     max_rad: float
-        Only data where the angular distance between the src and the estimated det location
+        Only data where the angular distance [radians] between the src and the estimated det location
         is less than ``max_rad`` will be used in the fit. If None, will use 5 *
         fwhm.
 


### PR DESCRIPTION
Adds some det-pointing fitting functions developed during the hack session. 

The `pointing_quickfit` function fits pointing for a bright source (such as the moon) for a detector. It has a few differences with respect to the full point source fits, including:
- downsampling signal between filtering and fitting
- only fitting xi and eta, with other beam params fixed
- Use scipy.optimize.minimize instead of curve-fit
- model is filtered at each iteration

The function takes 1-2 sec per detector, and results agree nicely with tomoki's map-based pointing (see below for ws:
![image](https://github.com/simonsobs/sotodlib/assets/4718487/f14498db-5645-4103-a944-2de671e678ea)

Some missing dets can hopefully be recovered  using jump-fixes and flags dbs.

A few additional added functions:
- `quickfit_and_save_pointing` runs the fit on specified channels in an axis-manager, and saves the fitted xi, eta to a result set
- `plot_quickfit_res` makes a plot based on the result of the fn, for example:
![image](https://github.com/simonsobs/sotodlib/assets/4718487/850f04cf-8c19-474e-bfb7-a37ae90c661c)

