### PR TITLE
Preprocess Full

### DIFF
--- a/sotodlib/core/axisman.py
+++ b/sotodlib/core/axisman.py
@@ -28,6 +28,9 @@ class AxisInterface:
 
     def copy(self):
         raise NotImplementedError
+    
+    def rename(self, name):
+        self.name = name
 
     def resolve(self, src, axis_index=None):
         """Perform a check or promote-and-check of this Axis against a data
@@ -344,6 +347,10 @@ class AxisManager:
             self._fields[new_name] = self._fields.pop(name)
             self._assignments[new_name] = self._assignments.pop(name)
         return self
+    
+    def add_axis(self, a):
+        assert isinstance( a, AxisInterface)
+        self._axes[a.name] = a.copy()
 
     def __contains__(self, name):
         return name in self._fields or name in self._axes

--- a/sotodlib/hwp/hwp.py
+++ b/sotodlib/hwp/hwp.py
@@ -7,7 +7,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def get_hwpss(aman, signal=None, hwp_angle=None, bin_signal=True, bins=360,
+def get_hwpss(aman, signal_name=None, hwp_angle=None, bin_signal=True, bins=360,
               lin_reg=True, modes=[1, 2, 3, 4, 6, 8], apply_prefilt=True,
               prefilt_cfg=None, prefilt_detrend='linear', flags=None,
               merge_stats=True, hwpss_stats_name='hwpss_stats',
@@ -23,8 +23,9 @@ def get_hwpss(aman, signal=None, hwp_angle=None, bin_signal=True, bins=360,
     ----------
     aman : AxisManager object
         The TOD to extract HWPSS from.
-    signal : array-like, optional
-        The TOD signal to use. If not provided, `aman.signal` will be used.
+    signal_name : str
+        The field name in the axis manager to use for the TOD signal.
+        If not provided, ``signal`` will be used.
     hwp_angle : array-like, optional
         The HWP angle for each sample in `aman`. If not provided, `aman.hwp_angle` will be used.
     bin_signal : bool, optional
@@ -81,23 +82,23 @@ def get_hwpss(aman, signal=None, hwp_angle=None, bin_signal=True, bins=360,
 
             - **sigma_tod** (n_dets) : estimate of the standard deviation of the signal using function ``estimate_sigma_tod``
     """
+    if prefilt_cfg is None:
+        prefilt_cfg = {'type': 'sine2', 'cutoff': 1.0, 'trans_width': 1.0}
 
-    if signal is None:
+    prefilt = filters.get_hpf(prefilt_cfg)
+
+    if signal_name is None:
         if apply_prefilt:
-            if prefilt_cfg is None:
-                prefilt_cfg = {'type': 'sine2', 'cutoff': 1.0, 'trans_width': 1.0}
-            prefilt = filters.get_hpf(prefilt_cfg)
             signal = np.array(tod_ops.fourier_filter(
                 aman, prefilt, detrend=prefilt_detrend, signal_name='signal'))
         else:
             signal = aman.signal
     else:
         if apply_prefilt:
-            raise ValueError('filters module does not support'+
-                    ' passing an axis other than aman.signal, you must'+
-                    ' run with apply_prefilt=False, signal=<your signal>'+
-                    ' apply_prefilt=True, signal=None, or apply_prefilt'+
-                    '=False, signal=None.')
+            signal = np.array(tod_ops.fourier_filter(
+                aman, prefilt, detrend=prefilt_detrend, signal_name=signal_name))
+        else:
+            signal = aman[signal_name]
 
     if hwp_angle is None:
         hwp_angle = aman.hwp_angle

--- a/sotodlib/preprocess/core.py
+++ b/sotodlib/preprocess/core.py
@@ -218,6 +218,11 @@ class Pipeline(list):
         """
         if proc_aman is None:
             proc_aman = core.AxisManager( aman.dets, aman.samps)
+            fman = core.AxisManager(core.LabelAxis(name='fdets', vals=aman.dets.vals), 
+                                    core.OffsetAxis('fsamps', count=aman.samps.count,
+                                                    offset=aman.samps.offset, 
+                                                    origin_tag=aman.samps.origin_tag))
+            proc_aman.merge(fman)
             run_calc = True
         else:
             if aman.dets.count != proc_aman.dets.count or not np.all(aman.dets.vals == proc_aman.dets.vals):

--- a/sotodlib/preprocess/core.py
+++ b/sotodlib/preprocess/core.py
@@ -184,8 +184,8 @@ def expand_proc_aman(calc_aman, proc_aman, flag_fill_val=False,
             if isinstance(calc_aman[fld][0], bool):
                 fill_value = flag_fill_val
         else:
-            raise ValueError('Data type in axis manager not supported '+
-                            'in expand_proc_aman')
+            raise ValueError(f"Data type {type(calc_aman[fld])} in axis manager"
+                            " not supported in expand_proc_aman")
 
         if np.any(np.isin(axes, ['dets', 'samps'])):
             out_aman.wrap_new('f'+fld, faxes, cls=np.full, fill_value=fill_value)

--- a/sotodlib/preprocess/core.py
+++ b/sotodlib/preprocess/core.py
@@ -374,7 +374,7 @@ class Pipeline(list):
             if run_calc:
                 process.calc_and_save(aman, proc_aman)
                 update_full_aman( proc_aman, full, self.wrap_valid)
-            
+                
             if select:
                 process.select(aman, proc_aman)
                 proc_aman.restrict('dets', aman.dets.vals)
@@ -383,6 +383,6 @@ class Pipeline(list):
             if aman.dets.count == 0:
                 success = process.name
                 break
-            
+        
         return full, success
         

--- a/sotodlib/preprocess/core.py
+++ b/sotodlib/preprocess/core.py
@@ -157,8 +157,10 @@ def expand_proc_aman(calc_aman, proc_aman, flag_fill_val=False,
         and samps in calc_aman padded to fdets, fsamps shape.
     """
     assn = calc_aman._assignments
-    out_aman = core.AxisManager(*[proc_aman['f'+x] if x in ['dets','samps'] \
-                                  else calc_aman[x] for x in calc_aman._axes])
+    oaxes = [proc_aman['f'+x] if x in ['dets','samps'] \
+                                  else calc_aman[x] for x in calc_aman._axes]
+    oaxes += [proc_aman[x] for x in calc_aman._axes if x in ['dets','samps']]
+    out_aman = core.AxisManager(*oaxes)
     
     _, _, fmdets = np.intersect1d(proc_aman.dets.vals,
                                     proc_aman.fdets.vals,
@@ -189,9 +191,9 @@ def expand_proc_aman(calc_aman, proc_aman, flag_fill_val=False,
         out_aman.wrap(fld, calc_aman[fld], list(enumerate(axes)))
         d = {'dets': fmdets, 'samps': fmsamps}
         slices = [d.get(a, slice(None)) for a in axes]
-        if isinstance(calc_aman[fld], RangesMatrix)
+        if isinstance(calc_aman[fld], RangesMatrix):
             out_aman['f'+fld][tuple(slices)]=calc_aman[fld].mask()
-            out_aman['f'+fld] = RangesMatrix.from_mask(out_aman[fld])
+            out_aman['f'+fld] = RangesMatrix.from_mask(out_aman['f'+fld])
         else:
             out_aman['f'+fld][tuple(slices)]=calc_aman[fld]
     return out_aman
@@ -225,7 +227,7 @@ def collape_proc_aman(proc_aman):
         if np.any(np.isin(axes, ['dets', 'samps'])):
             continue
         naxes = [a.strip('f') if a in ['fdets', 'fsamps'] else a for a in axes]
-        out_aman.wrap(fld, proc_aman[fld], list(enumerate(naxes)))
+        out_aman.wrap(fld[1:], proc_aman[fld], list(enumerate(naxes)))
     return out_aman
 
 class Pipeline(list):

--- a/sotodlib/preprocess/core.py
+++ b/sotodlib/preprocess/core.py
@@ -202,7 +202,11 @@ def _expand(new, full, wrap_valid=True):
     else:
         fs_samps = slice(None)
 
-    out = full.copy(axes_only=True)
+    out = core.AxisManager()
+    for k, v in full._axes.items():
+        if k in list(new._axes.keys())+['dets','samps']:
+            out._axes[k] = v 
+
     for a in new._axes:
         if a not in out:
             out.add_axis( new[a] )

--- a/sotodlib/preprocess/core.py
+++ b/sotodlib/preprocess/core.py
@@ -2,6 +2,7 @@
 import logging
 import numpy as np
 from .. import core
+from so3g.proj import RangesMatrix
 
 class _Preprocess(object):
     """The base class for Preprocessing modules which defines the required
@@ -127,7 +128,79 @@ class _Preprocess(object):
                 f"Preprocess Module of name {name} is already Registered"
             )
 
+def expand_proc_aman(calc_aman, proc_aman, flag_fill_val=False,
+                     flt_fill_val=np.nan, int_fill_val=2**32-1):
+    """
+    Helper function to expand the size of calculated products to match the 
+    precut dets and samps shape.
+    Arguments:
+    ----------
+    calc_aman: AxisManager
+        AxisManager returned from calc step.
+    proc_aman: AxisManager
+        AxisManager passed between processes.
+    fill_value:
+        Value to fill missing indices with.
+    """
+    if (proc_aman.dets.count < proc_aman.fdets.count) or \
+       (proc_aman.samps.count < proc_aman.fsamps.count):
+        _, mdets, fmdets = np.intersect1d(proc_aman.dets.vals,
+                                          proc_aman.fdets.vals,
+                                          return_indices=True)
+        fmsamps = slice(proc_aman.samps.offset,
+                        proc_aman.samps.offset+proc_aman.samps.count)
+    
+    out_aman = core.AxisManager(proc_aman.fdets, proc_aman.fsamps)
+    for fld in calc_aman._fields:
+        dat = calc_aman[fld]
+        dax, sax = None, None
+        axes = calc_aman.shape_str(fld).split(',')
+        maxes = np.isin(axes, ['dets', 'samps'])
+        axismap = [(i, a) for i, a in enumerate(axes)]
+        faxismap = [(i, 'f'+a) if m else (i, a) for i, [a, m] in enumerate(list(zip(axes, maxes)))]
+        if np.all(~maxes):
+            out_aman.wrap(fld, dat, axismap)
+        else:
+            if np.isin(type(np.hstack(dat)[0]), [so3g.RangesInt32, bool]):
+                fill_value = flag_fill_val
+                if isinstance(dat, RangesMatrix):
+                    dat = dat.mask()
+            if np.isin(type(np.hstack(dat)[0]), [np.int64, np.int32, int]):
+                fill_value = int_fill_val
+            if np.isin(type(np.hstack(dat)[0]), [np.float64, np.float32, float]):
+                fill_value = flt_fill_val
 
+            shape = tuple([proc_aman[am].count if m else calc_aman[fld].count for am, m in zip(axismap, maxes)])
+            fdat = np.full(shape, fill_value)
+
+            if ('dets' in axes) and not('samps' in axes):
+                dax = np.where(axes == 'dets')[0]
+                dat = np.moveaxis(dat, dax, 0)
+                fdat = np.moveaxis(fdat, dax, 0) 
+                fdat[fmdets] = dat
+                dat = np.moveaxis(dat, 0, dax)
+                fdat = np.moveaxis(fdat, 0, dax)
+            elif ('samps' in axes) and not('dets' in axes):
+                sax = np.where(axes == 'samps')[0]
+                dat = np.moveaxis(dat, sax, 0)
+                fdat = np.moveaxis(fdat, sax, 0)
+                fdat[fmsamps] = dat
+                dat = np.moveaxis(dat, 0, sax)
+                fdat = np.moveaxis(fdat, 0, sax)
+            else:
+                dax = np.where(axes == 'dets')[0]
+                sax = np.where(axes == 'samps')[0]
+                dat = np.moveaxis(dat, (dax, sax), (0,1))
+                fdat = np.moveaxis(fdat, (dax, sax), (0,1))
+                fdat[fmdets, fmsamps] = dat
+                dat = np.moveaxis(dat, (0,1), dax, sax)
+                fdat = np.moveaxis(fdat, (0,1), (dax, sax))
+            
+            if isinstance(fill_value, bool):
+                fdat = RangesMatrix.from_mask(fdat)
+                dat = RangesMatrix.from_mask(dat)
+            out_aman.wrap(fld, dat, axismap)
+            out_aman.wrap(fld, fdat, faxismap)
 
 class Pipeline(list):
     """This class is designed to create and run pipelines out of a series of

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -49,8 +49,8 @@ class DetBiasFlags(_Preprocess):
     def calc_and_save(self, aman, proc_aman):
         m = tod_ops.flags.get_det_bias_flags(aman, merge=False,
                                                **self.calc_cfgs)
-        calc_aman = core.AxisManager(proc_aman.fdets, proc_aman.fsamps)
-        calc_aman.wrap('det_bias_flags', msk, [(0, 'dets'), (1, 'samps')])
+        calc_aman = core.AxisManager(proc_aman.dets, proc_aman.samps)
+        calc_aman.wrap('det_bias_flags', m, [(0, 'dets'), (1, 'samps')])
         dbc_aman = expand_proc_aman(calc_aman, proc_aman)
         del calc_aman
         self.save(proc_aman, dbc_aman)
@@ -427,8 +427,8 @@ class EstimateHWPSS(_Preprocess):
     Example config block::
 
       - "name : "estimate_hwpss"
-        "signal: "signal" # optional
         "calc":
+          "signal_name": "signal" # optional
           "hwpss_stats_name": "hwpss_stats"
         "save": True
 
@@ -436,20 +436,8 @@ class EstimateHWPSS(_Preprocess):
     """
     name = "estimate_hwpss"
 
-    def __init__(self, step_cfgs):
-        self.signal = step_cfgs.get('signal', 'signal')
-
-        super().__init__(step_cfgs)
-
     def calc_and_save(self, aman, proc_aman):
-        _prefilt = (self.signal == 'signal')
-        if not _prefilt:
-            print("WARNING: apply_prefilt defaulting to False because " +
-                  f"{self.signal} != 'signal'.")
-        calc_aman = hwp.get_hwpss(aman,
-                                    signal=aman[self.signal],
-                                    apply_prefilt=_prefilt,
-                                    **self.calc_cfgs)
+        calc_aman = hwp.get_hwpss(aman, **self.calc_cfgs)
         hwpss_stats = expand_proc_aman(calc_aman, proc_aman)
         self.save(proc_aman, hwpss_stats)
 

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -518,12 +518,21 @@ class SubtractHWPSS(_Preprocess):
     """
     name = "subtract_hwpss"
 
+    def __init__(self, step_cfgs):
+        self.hwpss_stats = step_cfgs.get('hwpss_stats', 'hwpss_stats')
+
+        super().__init__(step_cfgs)
+
     def process(self, aman, proc_aman):
-        hwp.subtract_hwpss(
-            aman,
-            hwpss_template = aman[self.process_cfgs["hwpss_extract"]],
-            subtract_name = self.process_cfgs["subtract_name"]
-        )
+        if not(proc_aman[self.hwpss_stats] is None):
+            modes = [int(m[1:]) for m in proc_aman[self.hwpss_stats].modes.vals[::2]]
+            template = hwp.harms_func(aman.hwp_angle, modes,
+                                  proc_aman[self.hwpss_stats].coeffs)
+            hwp.subtract_hwpss(
+                aman,
+                hwpss_template = template,
+                subtract_name = self.process_cfgs["subtract_name"]
+                )
 
 class Apodize(_Preprocess):
     """Apodize the edges of a signal. All process configs go to `apodize_cosine`

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -521,7 +521,6 @@ class GlitchFill(_Preprocess):
             glitch_flags=proc_aman[self.flag_aman][self.flag],
             **self.process_cfgs)
 
-
 class FlagTurnarounds(_Preprocess):
     """From the Azimuth encoder data, flag turnarounds, left-going, and right-going.
         All process configs go to ``get_turnaround_flags``. If the ``method`` key

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -11,6 +11,60 @@ from sotodlib.core.flagman import (has_any_cuts, has_all_cut,
 
 from .core import _Preprocess
 
+def expand_proc_aman(calc_aman, proc_aman, flag_fill_val=False,
+                     flt_fill_val=np.nan, int_fill_val=2**32-1):
+    """
+    Helper function to expand the size of calculated products to match the 
+    precut dets and samps shape.
+    Arguments:
+    ----------
+    calc_aman: AxisManager
+        AxisManager returned from calc step.
+    proc_aman: AxisManager
+        AxisManager passed between processes.
+    fill_value:
+        Value to fill missing indices with.
+    """
+    if (proc_aman.dets.count < proc_aman.fdets.count) or \
+       (proc_aman.samps.count < proc_aman.fsamps.count):
+        _, mdets, fmdets = np.intersect1d(proc_aman.dets.vals,
+                                          proc_aman.fdets.vals,
+                                          return_indices=True)
+        msamps = slice(proc_aman.samps.offset,
+                       proc_aman.samps.offset+proc_aman.samps.count)
+    
+    out_aman = core.AxisManager(proc_aman.fdets, proc_aman.fsamps)
+    for fld in calc_aman._fields:
+        dat = calc_aman[fld]
+        axes = calc_aman.shape_str(fld).split(',')
+        maxes = np.isin(axes, ['dets', 'samps'])
+        axismap = [(i, a) for i, a in enumerate(axes)]
+        faxismap = [(i, 'f'+a) if m else (i, a) for i, [a, m] in enumerate(list(zip(axes, maxes)))]
+        if np.all(~maxes):
+            out_aman.wrap(fld, dat, axismap)
+        else:
+            if np.isin(type(np.hstack(dat)[0]), [so3g.RangesInt32, bool]):
+                fill_value = flag_fill_val
+                dat = dat.mask()
+            if np.isin(type(np.hstack(dat)[0]), [np.int64, np.int32, int]):
+                fill_value = int_fill_val
+            if np.isin(type(np.hstack(dat)[0]), [np.float64, np.float32, float]):
+                fill_value = flt_fill_val
+            shape = tuple([proc_aman[am].count if m else calc_aman[fld].count for am, m in zip(axismap, maxes)])
+            fdat = np.full(shape, fill_value)
+
+            # Need to figure out how to do this slicing.
+            # I think I need to enforce axis ordering to be dets_axis x samps_axis x any other axis
+            # Then this should be reasonably straightforward.
+            fdat[fmdets,msamps] = dat[mdets]
+
+            if isinstance(fill_value, bool):
+                fdat = RangesMatrix.from_mask(fdat)
+                dat = RangesMatrix.from_mask(dat)
+            out_aman.wrap(fld, dat, axismap)
+            out_aman.wrap(fld, fdat, faxismap)
+
+    return
 
 class FFTTrim(_Preprocess):
     """Trim the AxisManager to optimize for faster FFTs later in the pipeline.
@@ -58,7 +112,7 @@ class DetBiasFlags(_Preprocess):
                                        return_indices=True)
             msk[d2,proc_aman.samps.offset:proc_aman.samps.offset+proc_aman.samps.count] = \
                 m.mask()[d1]
-            msk = RangesMatrix(msk)
+            msk = RangesMatrix.from_mask(msk)
         else:
             msk = m
         dbc_aman.wrap('det_bias_flags', m, [(0, 'dets'), (1, 'samps')])
@@ -114,6 +168,9 @@ class Trends(_Preprocess):
         _, trend_aman = tod_ops.flags.get_trending_flags(
             aman, merge=False, full_output=True,
             signal=aman[self.signal], **self.calc_cfgs)
+        taman = core.AxisManager(proc_aman.fdets, proc_aman.fsamps,
+                                 trend_aman.trend_bins)
+        
         aman.wrap("trends", trend_aman)
         self.save(proc_aman, trend_aman)
     

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -137,8 +137,8 @@ class GlitchDetection(_Preprocess):
     Example configuration block::
         
       - name: "glitches"
-        signal: "hwpss_remove"
         calc:
+          signal_name: "hwpss_remove"
           t_glitch: 0.00001
           buffer: 10
           hp_fc: 1
@@ -146,20 +146,15 @@ class GlitchDetection(_Preprocess):
         save: True
         select:
           max_n_glitch: 10
+          sig_glitch: 10
 
     .. autofunction:: sotodlib.tod_ops.flags.get_glitch_flags
     """
     name = "glitches"
 
-    def __init__(self, step_cfgs):
-        self.signal = step_cfgs.get('signal', 'signal')
-
-        super().__init__(step_cfgs)
-    
     def calc_and_save(self, aman, proc_aman):
-        _, glitch_aman = tod_ops.flags.get_glitch_flags(
-            aman[self.signal], merge=False, full_output=True,
-            **self.calc_cfgs
+        _, glitch_aman = tod_ops.flags.get_glitch_flags(aman,
+            merge=False, full_output=True, **self.calc_cfgs
         ) 
         aman.wrap("glitches", glitch_aman)
         self.save(proc_aman, glitch_aman)

--- a/sotodlib/site_pipeline/preprocess_tod.py
+++ b/sotodlib/site_pipeline/preprocess_tod.py
@@ -153,13 +153,11 @@ def load_preprocess_det_select(obs_id, configs, context=None):
         config file or loaded config directory
     """
     configs, context = _get_preprocess_context(configs, context)
+    pipe = Pipeline(configs["process_pipe"], logger=logger)
     
     meta = context.get_meta(obs_id)
-    proc_aman = meta["preprocess"]
-    assn = [a for a in proc_aman._assignments][-1]
-    logger.info(f"Cutting on the last process: {assn}")
-    keep = core.flagman.has_all_cut(proc_aman[assn].valid)
-    meta.restrict('dets', meta.dets.vals[keep])
+    logger.info(f"Cutting on the last process: {pipe[-1].name}")
+    pipe[-1].select(meta)
     return meta
 
 def load_preprocess_tod(obs_id, configs="preprocess_configs.yaml", context=None ):

--- a/sotodlib/tod_ops/fft_ops.py
+++ b/sotodlib/tod_ops/fft_ops.py
@@ -248,14 +248,14 @@ def calc_psd(
         **kwargs
     )
     if merge:
-        aman.merge( core.AxisManager(core.OffsetAxis("fsamps", len(freqs))))
+        aman.merge( core.AxisManager(core.OffsetAxis("nusamps", len(freqs))))
         if overwrite:
             if "freqs" in aman._fields:
                 aman.move("freqs", None)
             if "Pxx" in aman._fields:
                 aman.move("Pxx", None)
-        aman.wrap("freqs", freqs, [(0,"fsamps")])
-        aman.wrap("Pxx", Pxx, [(0,"dets"),(1,"fsamps")])
+        aman.wrap("freqs", freqs, [(0,"nusamps")])
+        aman.wrap("Pxx", Pxx, [(0,"dets"),(1,"nusamps")])
     return freqs, Pxx
 
 def calc_wn(aman, pxx=None, freqs=None, low_f=5, high_f=10):

--- a/sotodlib/tod_ops/flags.py
+++ b/sotodlib/tod_ops/flags.py
@@ -265,7 +265,7 @@ def get_glitch_flags(aman,
                      n_sig=10,
                      buffer=200,
                      detrend=None,
-                     signal=None,
+                     signal_name=None,
                      merge=True,
                      overwrite=False,
                      name="glitches",
@@ -288,7 +288,7 @@ def get_glitch_flags(aman,
         Amount to buffer flags around found location
     detrend : str
         Detrend method to pass to fourier_filter
-    signal : str
+    signal_name : str
         Field name in aman to detect glitches on if None, defaults to ``signal``
     merge : bool)
         If true, add to ``aman.flags``
@@ -308,12 +308,12 @@ def get_glitch_flags(aman,
         RangesMatrix object containing glitch mask.
     """
 
-    if signal is None:
-        signal = "signal"
+    if signal_name is None:
+        signal_name = "signal"
     # f-space filtering
     filt = filters.high_pass_sine2(cutoff=hp_fc) * filters.gaussian_filter(t_sigma=t_glitch)
     fvec = fourier_filter(
-        aman, filt, detrend=detrend, signal_name=signal, resize="zero_pad"
+        aman, filt, detrend=detrend, signal_name=signal_name, resize="zero_pad"
     )
     # get the threshods based on n_sig x nlev = n_sig x iqu x 0.741
     fvec = np.abs(fvec)

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -72,7 +72,8 @@ class TestExpand(unittest.TestCase):
         aman.restrict( 'samps', (300,None))
         proc_aman.restrict( 'samps', (300,None))
         out = _expand( proc_aman, full)
-        assert_array_equal( out.flag1[3].ranges()[0] , [0,500] )
+        assert_array_equal( proc_aman.flag1[0].ranges()[0] , [0,500] )
+        assert_array_equal( out.flag1[3].ranges()[0] , [300,800] )
 
         ## test with a wrapped axis manager
         dummy = core.AxisManager(
@@ -85,7 +86,7 @@ class TestExpand(unittest.TestCase):
         
         ## check value mask
         self.assertTrue( len(out.valid[0].ranges()) == 0 )
-        assert_array_equal( out.valid[3].ranges(), [300,1000] )
+        assert_array_equal( out.valid[3].ranges()[0], [300,1000] )
 
         ## test with extra axis
         pain = core.AxisManager(
@@ -93,6 +94,10 @@ class TestExpand(unittest.TestCase):
         )
         pain.wrap_new('wammy', ('ouch', 'dets', 'samps'))
         proc_aman.wrap('pain', pain)
+        out = _expand( proc_aman, full)
+
+        ## test with no detectors
+        proc_aman.restrict('dets', [])
         out = _expand( proc_aman, full)
 
 

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -1,0 +1,101 @@
+# Copyright (c) 2021 Simons Observatory.
+# Full license can be found in the top level "LICENSE" file.
+
+"""Check tod_ops routines.
+
+"""
+
+import unittest
+import numpy as np
+import pylab as pl
+import scipy.signal
+
+from sotodlib import core, tod_ops
+from sotodlib.preprocess.core import _expand
+
+from numpy.testing import assert_array_equal
+
+
+from ._helpers import mpi_multi
+from .test_tod_ops import get_tod
+
+from so3g.proj import Ranges, RangesMatrix
+from scipy.sparse import csr_array
+
+class TestExpand(unittest.TestCase):
+
+    def test_100_expand(self):
+        aman = get_tod(sig_type='trendy',ndets=5, nsamps=1000)
+        full = core.AxisManager( aman.dets, aman.samps)
+        proc_aman = core.AxisManager( aman.dets, aman.samps)
+        
+        # wrap a dets array with floats
+        proc_aman.wrap('arr1', np.mean( aman.signal, axis=1), [(0,'dets')],) 
+        # wrap a dets array with ints
+        proc_aman.wrap(
+            'arr2', np.round( np.min(aman.signal, axis=1)).astype('int32'),
+            [(0,'dets')],
+        ) 
+        # wrap a dets,samps array to make sure it works 
+        proc_aman.wrap('arr3', aman.signal*23, [(0,'dets'), (1,'samps')],) 
+
+        # wrap a RangesMatrix
+        proc_aman.wrap(
+            'flag1', RangesMatrix.zeros( (aman.dets.count, aman.samps.count)),
+            [(0,'dets'), (1,'samps')],
+        ) 
+        proc_aman.flag1[0].add_interval( 100,700 )
+        proc_aman.flag1[3].add_interval( 110,800 )
+        proc_aman.flag1[4].add_interval( 0,200 )
+
+        # wrap a Ranges
+        proc_aman.wrap('flag2', Ranges( aman.samps.count ),[(0,'samps')],) 
+        proc_aman.flag2.add_interval( 450,700 )
+
+        # wrap a csr_array
+        proc_aman.wrap('csr_thing', 
+            csr_array( (aman.dets.count,aman.samps.count), dtype=float),
+            [(0,'dets'), (1,'samps')],
+        )
+
+        ## test same size expansion
+        out = _expand( proc_aman, full)
+        assert_array_equal( out.flag1[0].ranges()[0] , [100,700] )
+
+        ## test with detectors cut
+        aman.restrict( 'dets', aman.dets.vals[3:5])
+        proc_aman.restrict( 'dets', aman.dets.vals)
+        out = _expand( proc_aman, full)
+        self.assertTrue( proc_aman.dets.vals[0] == out.dets.vals[3])
+        assert_array_equal( out.flag1[3].ranges()[0] , [110,800] )
+
+        aman.restrict( 'samps', (300,None))
+        proc_aman.restrict( 'samps', (300,None))
+        out = _expand( proc_aman, full)
+        assert_array_equal( out.flag1[3].ranges()[0] , [0,500] )
+
+        ## test with a wrapped axis manager
+        dummy = core.AxisManager(
+            aman.dets, 
+        )
+        dummy.wrap( 'blah', np.median( aman.signal, axis=1),
+            [(0,'dets')],)
+        proc_aman.wrap('dummy', dummy)
+        out = _expand( proc_aman, full)
+        
+        ## check value mask
+        self.assertTrue( len(out.valid[0].ranges()) == 0 )
+        assert_array_equal( out.valid[3].ranges(), [300,1000] )
+
+        ## test with extra axis
+        pain = core.AxisManager(
+            aman.dets, aman.samps, core.LabelAxis('ouch', ['x','y']),
+        )
+        pain.wrap_new('wammy', ('ouch', 'dets', 'samps'))
+        proc_aman.wrap('pain', pain)
+        out = _expand( proc_aman, full)
+
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_tod_ops.py
+++ b/tests/test_tod_ops.py
@@ -23,7 +23,7 @@ SAMPLE_FREQ_HZ = 100.
 def get_tod(sig_type='trendy', ndets=3, nsamps=1000):
     tod = core.AxisManager(
         core.LabelAxis('dets', ['det%i' % i for i in range(ndets)]),
-        core.IndexAxis('samps', nsamps)
+        core.OffsetAxis('samps', nsamps)
     )
     tod.wrap_new('signal', ('dets', 'samps'), dtype='float32')
     tod.wrap_new('timestamps', ('samps',))[:] = (

--- a/tests/test_tod_ops.py
+++ b/tests/test_tod_ops.py
@@ -20,9 +20,11 @@ from ._helpers import mpi_multi
 
 SAMPLE_FREQ_HZ = 100.
 
-def get_tod(sig_type='trendy'):
-    tod = core.AxisManager(core.LabelAxis('dets', ['a', 'b', 'c']),
-                           core.IndexAxis('samps', 1000))
+def get_tod(sig_type='trendy', ndets=3, nsamps=1000):
+    tod = core.AxisManager(
+        core.LabelAxis('dets', ['det%i' % i for i in range(ndets)]),
+        core.IndexAxis('samps', nsamps)
+    )
     tod.wrap_new('signal', ('dets', 'samps'), dtype='float32')
     tod.wrap_new('timestamps', ('samps',))[:] = (
         np.arange(tod.samps.count) / SAMPLE_FREQ_HZ)


### PR DESCRIPTION
Using to AxisManagers to solve the preprocess selection issue. Should also solve #712  but not tested yet.

This PR adds another AxisManager inside of the preprocess Pipeline that is used to track the original size of the TOD AxisManager. At every step any new fields in `proc_aman` are added to the `full` AxisManager after they are expanded in size to match the original shape of the TOD AxisManager.  This expansion assumes that each top-level entry in `proc_aman` is an AxisManager (true for all existing processes, so now just required) and it was complicated enough to start test cases to make sure it works the way we'd like. 

