### PR TITLE
Fix search on readthedocs website

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -122,7 +122,6 @@ for missing in autodoc_mock_imports:
 try:
     import sphinx_rtd_theme
     html_theme = 'sphinx_rtd_theme'
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 except ImportError:
     html_theme = 'alabaster'
 


### PR DESCRIPTION
This removes `html_theme_path` in order to fix search.

Search works locally, but not on the readthedocs website. This was suggested as a possible fix in [1].

Will test in the docs build on this PR.

[1] - https://stackoverflow.com/a/77358365