### PR TITLE
logger fix and shorter logger name

### DIFF
--- a/sotodlib/site_pipeline/make_hwp_solutions.py
+++ b/sotodlib/site_pipeline/make_hwp_solutions.py
@@ -13,7 +13,8 @@ from typing import Optional
 from sotodlib import core
 from sotodlib.hwp.g3thwp import G3tHWP
 from sotodlib.site_pipeline import util
-logger = util.init_logger(__name__, 'make-hwp-solutions: ')
+
+logger = util.init_logger('make_hwp_solutions', 'make-hwp-solutions: ')
 
 def get_parser(parser=None):
     if parser is None:

--- a/sotodlib/site_pipeline/update_obsdb.py
+++ b/sotodlib/site_pipeline/update_obsdb.py
@@ -42,7 +42,7 @@ import logging
 from sotodlib.site_pipeline import util
 from typing import Optional
 
-logger = util.init_logger(__name__, 'update-obsdb: ')
+logger = util.init_logger('update_obsdb', 'update-obsdb: ')
 
 def check_meta_type(bookpath: str):
     metapath = os.path.join(bookpath, "M_index.yaml")

--- a/sotodlib/site_pipeline/util.py
+++ b/sotodlib/site_pipeline/util.py
@@ -254,20 +254,20 @@ def init_logger(name, announce=''):
 
     # add handler only if it doesn't exist
     if len(logger.handlers) == 0:
-      ch = logging.StreamHandler(sys.stdout)
-      formatter = _ReltimeFormatter('%(asctime)s: %(message)s (%(levelname)s)')
+        ch = logging.StreamHandler(sys.stdout)
+        formatter = _ReltimeFormatter('%(asctime)s: %(message)s (%(levelname)s)')
 
-      ch.setLevel(logging.INFO)
-      ch.setFormatter(formatter)
-      logger.addHandler(ch)
+        ch.setLevel(logging.INFO)
+        ch.setFormatter(formatter)
+        logger.addHandler(ch)
+        i, r = formatter.start_time // 1, formatter.start_time % 1
+        text = (time.strftime('%Y-%m-%d %H:%M:%S', time.gmtime(i))
+              + (',%03d' % (r*1000)))
+        logger.info(f'{announce}Log timestamps are relative to {text}')
 
     logger.propagate = False
     logger.setLevel(logging.DEBUG)
 
-    i, r = formatter.start_time // 1, formatter.start_time % 1
-    text = (time.strftime('%Y-%m-%d %H:%M:%S', time.gmtime(i))
-            + (',%03d' % (r*1000)))
-    logger.info(f'{announce}Log timestamps are relative to {text}')
 
     return logger
 


### PR DESCRIPTION
fixed a bug in init_logger introduced by #731 : if handler exists, formatter will be undefined. Also prefer shorter names in site-pipeline loggers.