### PR TITLE
Quick map-to-tod function for SAT (for the purpose of transfer function)

### DIFF
--- a/docs/coords.rst
+++ b/docs/coords.rst
@@ -274,6 +274,12 @@ Planet Mapmaking support
 .. automodule:: sotodlib.coords.planets
    :members:
 
+Mapmaking for HWP data
+----------------------
+
+.. automodule:: sotodlib.coords.demod
+   :members:
+
 Local coordinate systems
 ------------------------
 

--- a/sotodlib/coords/demod.py
+++ b/sotodlib/coords/demod.py
@@ -142,15 +142,11 @@ def make_map(tod,
              'weight': wTQU}
     return output
 
-def from_map(tod, signal_map, P=None, wcs_kernel=None,
-             res=0.1 * coords.DEG, cuts=None, flip_gamma=True, wrap=False, pre_demod=False):
-    if P is None:
-        if wcs_kernel is None:
-            wcs_kernel = coords.get_wcs_kernel('car', 0, 0, res)
-        P = coords.P.for_tod(
-            tod=tod, wcs_kernel=wcs_kernel, cuts=cuts, comps='QU', hwp=flip_gamma)
-    
+def from_map(tod, signal_map, cuts=None, flip_gamma=True, wrap=False, pre_demod=False):
     Tmap, Qmap, Umap = signal_map
+    
+    P = coords.P.for_tod(tod=tod, geom=signal_map.geometry, cuts=cuts, 
+                         comps='QU', hwp=flip_gamma)
     dsT_sim = P.from_map(Tmap, comps='T')
     demodQ_sim = P.from_map(enmap.enmap([Qmap, Umap]), comps='QU')
     demodU_sim = P.from_map(enmap.enmap([Umap, -Qmap]), comps='QU')

--- a/sotodlib/coords/demod.py
+++ b/sotodlib/coords/demod.py
@@ -142,7 +142,24 @@ def make_map(tod,
              'weight': wTQU}
     return output
 
-def from_map(tod, signal_map, cuts=None, flip_gamma=True, wrap=False, pre_demod=False):
+def from_map(tod, signal_map, cuts=None, flip_gamma=True, wrap=False, modulated=False):
+    """
+    Generate simulated TOD with HWP from a given signal map.
+
+    Args:
+        tod : an xisManager object
+        signal_map: pixell.enmap.ndmap containing (Tmap, Qmap, Umap) representing the signal.
+        cuts (RangesMatrix, optional): Cuts to apply to the data. Default is None.
+        flip_gamma (bool, optional): Whether to flip detector coordinate. If you use the HWP, keep it `True`. Default is True.
+        wrap (bool, optional): Whether to wrap the simulated data. Default is False.
+        modulated (bool, optional): If True, return modulated signal. If False, return the demodulated signal 
+        (`dsT`, `demodQ`, and `demodU`). Default is False. 
+
+    Returns:
+        `modulate==False`: A tuple containing the TOD (np.array) of dsT, demodQ and demodU.
+        `modulate==True` : The modulated TOD (np.array)
+        
+    """
     Tmap, Qmap, Umap = signal_map
     
     P = coords.P.for_tod(tod=tod, geom=signal_map.geometry, cuts=cuts, 
@@ -151,7 +168,7 @@ def from_map(tod, signal_map, cuts=None, flip_gamma=True, wrap=False, pre_demod=
     demodQ_sim = P.from_map(enmap.enmap([Qmap, Umap]), comps='QU')
     demodU_sim = P.from_map(enmap.enmap([Umap, -Qmap]), comps='QU')
     
-    if pre_demod is False:
+    if modulated is False:
         if wrap:
             tod.wrap('dsT', dsT_sim, [(0, 'dets'), (1, 'samps')])
             tod.wrap('demodQ', demodQ_sim, [(0, 'dets'), (1, 'samps')])

--- a/sotodlib/coords/demod.py
+++ b/sotodlib/coords/demod.py
@@ -147,7 +147,7 @@ def from_map(tod, signal_map, cuts=None, flip_gamma=True, wrap=False, modulated=
     Generate simulated TOD with HWP from a given signal map.
 
     Args:
-        tod : an xisManager object
+        tod : an axisManager object
         signal_map: pixell.enmap.ndmap containing (Tmap, Qmap, Umap) representing the signal.
         cuts (RangesMatrix, optional): Cuts to apply to the data. Default is None.
         flip_gamma (bool, optional): Whether to flip detector coordinate. If you use the HWP, keep it `True`. Default is True.

--- a/sotodlib/coords/demod.py
+++ b/sotodlib/coords/demod.py
@@ -141,3 +141,26 @@ def make_map(tod,
              'weighted_map': mTQU_weighted,
              'weight': wTQU}
     return output
+
+def from_map(tod, signal_map, P=None, wcs_kernel=None,
+             res=0.1 * coords.DEG,
+            cuts=None, flip_gamma=True,
+            wrap=False):
+    if P is None:
+        if wcs_kernel is None:
+            wcs_kernel = coords.get_wcs_kernel('car', 0, 0, res)
+        P = coords.P.for_tod(
+            tod=tod, wcs_kernel=wcs_kernel, cuts=cuts, comps='QU', hwp=flip_gamma)
+    
+    Tmap, Qmap, Umap = signal_map
+    dsT_sim = P.from_map(Tmap, comps='T')
+    demodQ_sim = P.from_map(enmap.enmap([Qmap, Umap]), comps='QU')
+    demodU_sim = P.from_map(enmap.enmap([Umap, -Qmap]), comps='QU')
+    
+    if wrap:
+        tod.wrap('dsT', dsT_sim, [(0, 'dets'), (1, 'samps')])
+        tod.wrap('demodQ', demodQ_sim, [(0, 'dets'), (1, 'samps')])
+        tod.wrap('demodU', demodU_sim, [(0, 'dets'), (1, 'samps')])
+        
+    return dsT_sim, demodQ_sim, demodU_sim
+    

--- a/tests/test_demod_map.py
+++ b/tests/test_demod_map.py
@@ -1,6 +1,7 @@
 from sotodlib import core, hwp, coords
 import so3g
 import numpy as np
+from pixell import enmap
 
 import unittest
 

--- a/tests/test_demod_map.py
+++ b/tests/test_demod_map.py
@@ -130,3 +130,51 @@ class DemodMapmakingTest(unittest.TestCase):
         print(means)
         assert(abs(means[1] - Q_stream) < TOL)
         assert(abs(means[2] - U_stream) < TOL)
+        
+    def test_from_map_demodulated(self):
+        """Test the coords.demod.from_map function of demodulated signal.
+
+        """
+        tod = quick_tod(10, 10000)
+        TOL = 0.0001
+        
+        shape, wcs = enmap.fullsky_geometry(res=0.5*coords.DEG)
+        signal_map = enmap.zeros((3, *shape), wcs)
+        T_stream, Q_stream, U_stream = 1., 0.25, 0.01
+        signal_map[0] += T_stream
+        signal_map[1] += Q_stream
+        signal_map[2] += U_stream
+        _ = coords.demod.from_map(tod, signal_map, modulated=False, wrap=True)
+        
+        results = coords.demod.make_map(tod)
+        m0 = results['map']
+        s = m0[1] != 0
+        means = [m[s].mean() for m in m0]
+        assert(abs(means[1] - Q_stream) < TOL)
+        assert(abs(means[2] - U_stream) < TOL)
+        
+    def test_from_map_modulated(self):
+        """Test the coords.demod.from_map function of modulated signal.
+
+        """
+        tod = quick_tod(10, 10000)
+        tod.move('signal', None)
+        TOL = .01
+
+        shape, wcs = enmap.fullsky_geometry(res=0.5*coords.DEG)
+        signal_map = enmap.zeros((3, *shape), wcs)
+        
+        T_stream, Q_stream, U_stream = 1., 0.25, 0.01
+        signal_map[0] += T_stream
+        signal_map[1] += Q_stream
+        signal_map[2] += U_stream
+
+        _ = coords.demod.from_map(tod, signal_map, modulated=True, wrap=True)
+        hwp.demod_tod(tod)
+        results = coords.demod.make_map(tod)
+
+        m0 = results['map']
+        s = m0[1] != 0.
+        means = [m[s].mean() for m in m0]
+        assert(abs(means[1] - Q_stream) < TOL)
+        assert(abs(means[2] - U_stream) < TOL)


### PR DESCRIPTION
We need a function to generated TOD from signal only map to validate our preprocess functions and calculate transfer function.

Basic code already exists in `coords.P.from_map`.
But we should again consider the coordinates for w/ HWP configuration as [Carlos and Matthew's PR](https://github.com/simonsobs/sotodlib/pull/720).
(BTW, thank you so much Carlos and Matthew for fixing the bug!)

The new function is shown below.
It receives an axismanager with `timestamps`, `focal_plane`, and `boresight` and input T,Q,U maps. And it returns timestreams.
https://github.com/simonsobs/sotodlib/blob/be2ee3e4ba775101be40874de5f310939f5e2c81/sotodlib/coords/demod.py#L145-L182



Please see the log book
https://simonsobs.atlassian.net/wiki/spaces/PRO/pages/337772548/Transfer+Function
or
`computeXX: /so/home/tterasaki/code_dev/transfer_func/demo_transfer_func.ipynb`