### PR TITLE
Hkload speedup

### DIFF
--- a/sotodlib/io/fetch_hk.py
+++ b/sotodlib/io/fetch_hk.py
@@ -48,7 +48,7 @@ def fetch_hk(start, stop, data_dir, fields=None):
                                             data = [[t.time / g3core.G3Units.s for t in v.times], v[k]]
                                             hk_data.setdefault(field, ([], []))
                                             hk_data[field] = (
-                                                np.concatenate([all_data[field][0], data[0]]),
-                                                np.concatenate([all_data[field][1], data[1]])
+                                                np.concatenate([hk_data[field][0], data[0]]),
+                                                np.concatenate([hk_data[field][1], data[1]])
                                             )
     return hk_data

--- a/sotodlib/io/fetch_hk.py
+++ b/sotodlib/io/fetch_hk.py
@@ -8,17 +8,31 @@ import logging
 hk_logger = logging.getLogger(__name__)
 hk_logger.setLevel(logging.INFO)
 
-def fetch_hk(start, stop, data_dir, fields=None):
+def fetch_hk(start, stop, data_dir, fields=None, folder_patterns=None):
     hk_data = {}
     bases = []
 
     start_ctime = start #- 3600
     stop_ctime = stop #+ 3600
+    
+    if folder_patterns is None:
+        folder_patterns = ['{folder}', 'hk_{folder}_*']
+    for folder in range( int(start_ctime/1e5), int(stop_ctime/1e5)+1):
+        bases = []
+        for pattern in folder_patterns:
+            extended_pattern = pattern.format(folder=folder)
 
-    for folder in range(int(start_ctime/1e5), int(stop_ctime/1e5)+1):
-        base = data_dir+'/'+str(folder)
-        if not os.path.exists(base):
-            hk_logger.debug(f'{base} does not exist, skipping')
+            base = glob.glob(os.path.join(data_dir, extended_pattern))
+            bases.extend(base)
+        
+        if len(bases) > 1:
+            bases.sort
+            base = bases[0]
+            hk_logger.warn(f"Multiple base folders were found for {folder}. The first one, alphabetically, is selected: {base}")
+        elif len(bases) == 1:
+            base = bases[0]
+        elif len(bases) == 0:
+            hk_logger.debug(f"No base folder found for {folder}, skipping")
             continue
 
         for file in sorted(os.listdir(base)):

--- a/sotodlib/io/fetch_hk.py
+++ b/sotodlib/io/fetch_hk.py
@@ -1,0 +1,54 @@
+import numpy as np
+import so3g
+from spt3g import core as g3core
+import glob
+import os
+import logging
+
+hk_logger = logging.getLogger(__name__)
+hk_logger.setLevel(logging.INFO)
+
+def fetch_hk(start, stop, data_dir, fields=None):
+    hk_data = {}
+    bases = []
+
+    start_ctime = start #- 3600
+    stop_ctime = stop #+ 3600
+
+    for folder in range(int(start_ctime/1e5), int(stop_ctime/1e5)+1):
+        base = data_dir+'/'+str(folder)
+        if not os.path.exists(base):
+            hk_logger.debug(f'{base} does not exist, skipping')
+            continue
+
+        for file in sorted(os.listdir(base)):
+            try:
+                t = int(file[:-3])
+                #print(t)
+            except:
+                hk_logger.debug(f'{file} does not have the right format, skipping')
+                continue
+            if t >= start_ctime and t <= stop_ctime+60:
+                reader = so3g.G3IndexedReader(base+'/'+file)
+
+                while True:
+                    frames = reader.Process(None)
+                    if not frames:
+                        break
+
+                    for frame in frames:
+                        if 'address' in frame:
+                            for v in frame['blocks']:
+                                for k in v.keys():
+                                    field = '.'.join([frame['address'], k])
+
+                                    if fields is None or field in fields:
+                                        key = field.split('.')[-1]
+                                        if k == key:
+                                            data = [[t.time / g3core.G3Units.s for t in v.times], v[k]]
+                                            hk_data.setdefault(field, ([], []))
+                                            hk_data[field] = (
+                                                np.concatenate([all_data[field][0], data[0]]),
+                                                np.concatenate([all_data[field][1], data[1]])
+                                            )
+    return hk_data


### PR DESCRIPTION
This is a working version for speeding up hk loading using .g3 frames. 

Not yet complete but in a steady state to be handed off to other contributors. 

Current Features:
1. it's got similar arguments as `load_range` with start, stop, fields, and data_dir. Current code addresses 2 options: a list of fields or if `fields` is `None`, outputs HK data for all fields. Rather than thinking about a full `load_range` replacement, I focused more on what the `g3thk` database needs in `load_data` 
2. addresses .g3 files and HK books using a `folder_patterns` arg just like in `load_range`

What it still needs to address:
1. docstrings
2. more robust checks for `data_dir` like in `load_range`
3. `alias` argument
4. `config` argument


How it's been used and tested:
1. I tested it on site data the most---literally, the site level2 data the most (radiometer, weather agent, UPS etc) with both options mentioned in point 1 in Current Features. I also tested both options on satp1 and satp3 data from early November 2023. Did not yet integrate this into `load_data` in `g3thk_db` but as it stands, the arguments used in `load_data` are already implemented in `fetch_data`
2. tested HK books ability with satp1 data but not a full test: so far only, tested the case of `folder_pattern=None`, `data_dir=/so/data/satp1/hk`, and `fields=None` over a start and stop that span 20 minutes and got data for 1082 fields

