### PR TITLE
Fetch hk

### DIFF
--- a/sotodlib/io/fetch_hk.py
+++ b/sotodlib/io/fetch_hk.py
@@ -1,0 +1,29 @@
+import numpy as np
+import so3g
+from spt3g import core as g3core
+
+def fetch_hk(path, fields=None):
+    hk_data = {}
+    reader = so3g.G3IndexedReader(path)
+
+    while True:
+        frames = reader.Process(None)
+        if not frames:
+            break
+
+        for frame in frames:
+            if 'address' in frame:
+                for v in frame['blocks']:
+                    for k in v.keys():
+                        field = '.'.join([frame['address'], k])
+
+                        if fields is None or field in fields:
+                            key = field.split('.')[-1]
+                            if k == key:
+                                data = [[t.time / g3core.G3Units.s for t in v.times], v[k]]
+                                hk_data.setdefault(field, ([], []))
+                                hk_data[field] = (
+                                    np.concatenate([hk_data[field][0], data[0]]),
+                                    np.concatenate([hk_data[field][1], data[1]])
+                                )
+    return hk_data

--- a/sotodlib/io/fetch_hk.py
+++ b/sotodlib/io/fetch_hk.py
@@ -3,6 +3,26 @@ import so3g
 from spt3g import core as g3core
 
 def fetch_hk(path, fields=None):
+    """
+    Fetches housekeeping (HK) data from a given path.
+
+    Args:
+        path (str): Path to the HK .g3 data file.
+        fields (list, optional): List of specific fields. If None, fetches
+                                 all fields. Default is None.
+
+    Returns:
+
+        Dictionary with structure::
+
+        {
+            field[i] : (time[i], data[i])
+        }
+        
+        Same output format as `load_range`. Masked to only have data from
+        start and stop of .g3 file provided in path argument.
+
+    """
     hk_data = {}
     reader = so3g.G3IndexedReader(path)
 

--- a/sotodlib/io/fetch_hk.py
+++ b/sotodlib/io/fetch_hk.py
@@ -22,8 +22,7 @@ def fetch_hk(path, fields=None):
                             if k == key:
                                 data = [[t.time / g3core.G3Units.s for t in v.times], v[k]]
                                 hk_data.setdefault(field, ([], []))
-                                hk_data[field] = (
-                                    np.concatenate([hk_data[field][0], data[0]]),
-                                    np.concatenate([hk_data[field][1], data[1]])
-                                )
+                                hk_data[field][0].extend(data[0])
+                                hk_data[field][1].extend(data[1])
+
     return hk_data

--- a/sotodlib/io/fetch_hk.py
+++ b/sotodlib/io/fetch_hk.py
@@ -37,6 +37,9 @@ def fetch_hk(path, fields=None):
                     for k in v.keys():
                         field = '.'.join([frame['address'], k])
 
+                        if 'daq-registry' in field:
+                            continue
+
                         if fields is None or field in fields:
                             key = field.split('.')[-1]
                             if k == key:

--- a/sotodlib/io/fetch_hk.py
+++ b/sotodlib/io/fetch_hk.py
@@ -1,6 +1,6 @@
-import numpy as np
 import so3g
 from spt3g import core as g3core
+
 
 def fetch_hk(path, fields=None):
     """
@@ -18,7 +18,7 @@ def fetch_hk(path, fields=None):
         {
             field[i] : (time[i], data[i])
         }
-        
+
         Same output format as `load_range`. Masked to only have data from
         start and stop of .g3 file provided in path argument.
 


### PR DESCRIPTION
This is a working version for speeding up hk loading using .g3 frames.

Args are `path` to HK .g3 filename and a list of `fields`. If `fields` is `None`, data for all fields in that .g3 file are returned. Skips any address in .g3 frames that has `daq-registry` in it. 
