### PR TITLE
Level-3 HK database and loading framework

### DIFF
--- a/docs/hkdb.rst
+++ b/docs/hkdb.rst
@@ -1,0 +1,102 @@
+
+==============================
+Loading L3 Houskeeping Data
+==============================
+
+The ``sotodlib.io.hkdb`` module provides methods for indexing, and quickly
+loading housekeeping data from an archive.
+The databases implemented store the following information:
+
+- List of all housekeeping files, with start and stop times
+- List of every frame in the file, with the start and stop times of each frame,
+  agent instance-id, and the byte-offset of the frame in the file.
+
+To index and load housekeeping information, you will need to create a
+``HkConfig`` object, documented in the API section below. For example, the following yaml file can
+be loaded in directly ``HkConfig.from_yaml``:
+
+.. code-block:: yaml
+
+    hk_root: /so/data/satp1/hk
+    hk_db: satp1_hk.db
+    aliases:
+        fp_temp: cryo-ls372-lsa21yc.temperatures.Channel_02_T
+
+In addition to the hk-root and database paths, an "alias" dictionary can
+be defined here, to provide a mapping from a human-readable name to the
+field-id of the housekeeping data, where field-ids are always
+of the form ``<agent-instance>.<feed>.<field>``.
+Aliases defined here can be used to more easily load and access these fields.
+
+Loading Data
+---------------
+To load data from the hk archive, you can pass a ``LoadSpec`` object to the
+``load_hk`` function, which defines the time range and fields to load.
+
+For example, the code below will load the focal-plane temp for the last week:
+
+.. code-block:: python
+
+    from sotodlib.io import hkdb
+    cfg = hkdb.HkConfig.from_yaml('satp1_hk.yaml')
+    t1 = time.time()
+    t0 = t1 - 24 * 3600 * 7
+    lspec = hkdb.LoadSpec(
+        cfg=cfg, start=t0, end=t1,
+        fields=['fp_temp'],
+    )   
+    result = hkdb.load_hk(lspec, show_pb=True)
+
+The result object will be an HkResult object, where ``result.data`` contains
+the mapping from field-id to tuple where the first element is t, 
+where the first entry are the timestamps, and the second entry are the data
+values.  If any of the requested fields have an alias defined in the ``cfg``
+object, that alias will be set as an attribute in the HkResult object:
+
+.. code-block:: python
+
+    >> print(result.data['cryo-ls372-lsa21yc.temperatures.Channel_02_T'].shape)
+    (2, 4160195)
+    >> print(result.fp_temp)  # same exact thing as above
+    (2, 4160195)
+    >> plt.plot(*result.fp_temp)  # plots focal-plane temp
+
+The ``fields`` argument to ``LoadSpec`` is a list of field-specifications, which
+can either be:
+
+- An alias in the HkConfig
+- A field-id of the form ``<agent-instance>.<feed>.<field>``
+
+Field-ids specifications will also allow wildcards as the feed or field, to
+allow one to easily load all the fields of an agent or a feed.
+For example, you can run:
+
+.. code-block:: python
+
+    from sotodlib.io import hkdb
+    cfg = hkdb.HkConfig.from_yaml('satp1_hk.yaml')
+    t1 = time.time()
+    t0 = t1 - 24 * 3600 * 7
+    lspec = hkdb.LoadSpec(
+        cfg=cfg, start=t0, end=t1,
+        fields=['cryo-ls372-lsa21yc.*.*'],
+    )   
+    result = hkdb.load_hk(lspec, show_pb=True)
+    print(result.data.keys())
+
+    >> dict_keys(['cryo-ls372-lsa21yc.temperatures.Channel_02_R', 
+                  'cryo-ls372-lsa21yc.temperatures.Channel_02_T', 
+                  'cryo-ls372-lsa21yc.temperatures.sample_heater_out'])
+
+    # Note that the fp_temp alias will still be found, and assigned to the
+    # correct field.
+    print(result.fp_temp.shape)
+    >> (2, 4157762)
+
+
+API
+-------
+.. automodule:: sotodlib.io.hkdb
+   :members: HkConfig, HkDb, LoadSpec, load_hk, HkResult
+   :undoc-members:
+   :show-inheritance:

--- a/docs/hkdb.rst
+++ b/docs/hkdb.rst
@@ -12,8 +12,8 @@ The databases implemented store the following information:
   agent instance-id, and the byte-offset of the frame in the file.
 
 To index and load housekeeping information, you will need to create a
-``HkConfig`` object, documented in the API section below. For example, the following yaml file can
-be loaded in directly ``HkConfig.from_yaml``:
+``HkConfig`` object, documented in the API section below. For example, the
+following yaml file can be loaded in directly with ``HkConfig.from_yaml``:
 
 .. code-block:: yaml
 
@@ -47,11 +47,11 @@ For example, the code below will load the focal-plane temp for the last week:
     )   
     result = hkdb.load_hk(lspec, show_pb=True)
 
-The result object will be an HkResult object, where ``result.data`` contains
-the mapping from field-id to tuple where the first element is t, 
-where the first entry are the timestamps, and the second entry are the data
-values.  If any of the requested fields have an alias defined in the ``cfg``
-object, that alias will be set as an attribute in the HkResult object:
+The result object will be an HkResult object, where ``result.data`` contains the
+mapping from field-id to a numpy array of shape (2, nsamp), where the first
+entry are the timestamps, and the second entry are the data values.  If any of
+the requested fields have an alias defined in the ``cfg`` object, that alias
+will be set as an attribute in the HkResult object:
 
 .. code-block:: python
 

--- a/docs/hkdb.rst
+++ b/docs/hkdb.rst
@@ -18,9 +18,41 @@ following yaml file can be loaded in directly with ``HkConfig.from_yaml``:
 .. code-block:: yaml
 
     hk_root: /so/data/satp1/hk
-    hk_db: satp1_hk.db
+    db_file: satp1_hk.db
     aliases:
         fp_temp: cryo-ls372-lsa21yc.temperatures.Channel_02_T
+
+In the example above, the ``db_file`` is the path to the sqlite index database.
+It is possible to use a general database engine instead of sqlite by using the
+``db_url`` parameter instead of ``db_file``, which should be a valid sqlalchemy
+database URL as is described `here
+<https://docs.sqlalchemy.org/en/20/core/engines.html#database-urls>`_. For
+example, if the index is saved in a postgres database, you can use the following
+config:
+
+.. code-block:: yaml
+
+    hk_root: /so/data/satp1/hk
+    db_url: postgresql://<user>:${psql_password}@storage1/hkdb_satp1
+    aliases:
+        fp_temp: cryo-ls372-lsa21yc.temperatures.Channel_02_T
+
+where ``psql_password`` will be expanded with the value of the environment
+variable. Similarly, the ``db_url`` can also be set as a dictionary with fields
+matching the URL fields from the sqlalchemy docs, for example:
+
+.. code-block:: yaml
+
+    hk_root: /so/data/satp1/hk
+    db_url:
+        drivername: postgresql
+        username: <user>
+        password: ${psql_password}
+        host: storage1
+        database: hkdb_satp1
+    aliases:
+        fp_temp: cryo-ls372-lsa21yc.temperatures.Channel_02_T
+
 
 In addition to the hk-root and database paths, an "alias" dictionary can
 be defined here, to provide a mapping from a human-readable name to the

--- a/docs/hkdb.rst
+++ b/docs/hkdb.rst
@@ -25,8 +25,11 @@ following yaml file can be loaded in directly with ``HkConfig.from_yaml``:
 In addition to the hk-root and database paths, an "alias" dictionary can
 be defined here, to provide a mapping from a human-readable name to the
 field-id of the housekeeping data, where field-ids are always
-of the form ``<agent-instance>.<feed>.<field>``.
-Aliases defined here can be used to more easily load and access these fields.
+of the form ``<agent-instance>.<feed>.<field>``.  These aliases are only used
+for data loading, do not effect how the index data is stored in the database.
+This means aliases can also be added or modified, either in the config file or
+programmatically to the HkConfig object, to assist with data loading after that
+hk data has already been indexed.
 
 Loading Data
 ---------------
@@ -44,7 +47,7 @@ For example, the code below will load the focal-plane temp for the last week:
     lspec = hkdb.LoadSpec(
         cfg=cfg, start=t0, end=t1,
         fields=['fp_temp'],
-    )   
+    )
     result = hkdb.load_hk(lspec, show_pb=True)
 
 The result object will be an HkResult object, where ``result.data`` contains the
@@ -80,12 +83,12 @@ For example, you can run:
     lspec = hkdb.LoadSpec(
         cfg=cfg, start=t0, end=t1,
         fields=['cryo-ls372-lsa21yc.*.*'],
-    )   
+    )
     result = hkdb.load_hk(lspec, show_pb=True)
     print(result.data.keys())
 
-    >> dict_keys(['cryo-ls372-lsa21yc.temperatures.Channel_02_R', 
-                  'cryo-ls372-lsa21yc.temperatures.Channel_02_T', 
+    >> dict_keys(['cryo-ls372-lsa21yc.temperatures.Channel_02_R',
+                  'cryo-ls372-lsa21yc.temperatures.Channel_02_T',
                   'cryo-ls372-lsa21yc.temperatures.sample_heater_out'])
 
     # Note that the fp_temp alias will still be found, and assigned to the

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,6 +17,7 @@ Welcome to SOTODLib's documentation!
    context.rst
    g3tsmurf.rst
    hwp.rst
+   hkdb.rst
    tod_ops.rst
    coords.rst
    toast.rst

--- a/docs/site_pipeline.rst
+++ b/docs/site_pipeline.rst
@@ -295,6 +295,17 @@ Below is the full docs of the configuration class.
 
 .. autoclass:: sotodlib.site_pipeline.update_det_match.UpdateDetMatchesConfig
 
+update-hkdb
+----------------
+
+The update_hkdb site-pipeline script is used to scan through housekeeping files,
+and update the index database. Configuration for this script must be passed in
+through a config file, with fields that map to the HkConfig dataclass, described
+below:
+
+.. autoclass:: sotodlib.io.hkdb.HkConfig
+  :no-index:
+
 analyze-bright-ptsrc
 --------------------
 

--- a/sotodlib/io/hkdb.py
+++ b/sotodlib/io/hkdb.py
@@ -412,6 +412,9 @@ def load_hk(load_spec: LoadSpec, show_pb=False):
             pb.update()
     pb.close()
     for k, d in result.items():
-        result[k] = np.array([np.hstack(d[0]), np.hstack(d[1])])
+        if len(d[0]) == 0:
+            result[k] = np.array([])
+        else:
+            result[k] = np.array([np.hstack(d[0]), np.hstack(d[1])])
 
     return HkResult(result, aliases=load_spec.cfg.aliases)

--- a/sotodlib/io/hkdb.py
+++ b/sotodlib/io/hkdb.py
@@ -75,8 +75,13 @@ class HkConfig:
         with open(path, 'r') as f:
             data = yaml.safe_load(f)
             if isinstance(data.get('db_url'), dict):
-                data['db_url'] = db.URL(**data['db_url'])
-            return cls(**yaml.safe_load(f))
+                url_dict = data['db_url']
+                for k, v in url_dict.items():
+                    url_dict[k] = os.path.expandvars(v)
+                data['db_url'] = db.URL.create(**url_dict)
+            elif isinstance(str):
+                data['db_url'] = os.path.expandvars(data['db_url'])
+            return cls(**data)
 
 
 class HkFile(Base):

--- a/sotodlib/io/hkdb.py
+++ b/sotodlib/io/hkdb.py
@@ -384,5 +384,6 @@ def load_hk(load_spec: LoadSpec, show_pb=False):
     for k in result:
         result[k][0] = np.hstack(result[k][0])
         result[k][1] = np.hstack(result[k][1])
+        result[k] = np.array(result[k])
 
     return HkResult(result, aliases=load_spec.cfg.aliases)

--- a/sotodlib/io/hkdb.py
+++ b/sotodlib/io/hkdb.py
@@ -25,39 +25,43 @@ log = init_logger('hkdb')
 class HkConfig:
     """
     Configuration object for indexing and loading from an HK archive.
+
+    Attributes
+    ------------
+    hk_root: str
+        Root directory for the HK archive
+    db_file: Optional[str]
+        Path to the hk index database if the database is an sqlite file. Either
+        this or db_url must be set
+    db_url: Optional[Union[str, db.URL]]
+        URL used for db engine. Either this or db_file must be set
+    echo_db: bool
+        Whether database operations should be echoed
+    file_idx_lookback_time: Optional[float]
+        Time [sec] to look back when scanning for new files to index
+    show_index_pb: bool
+        If true, shows progress bar when indexing
+    aliases: Dict[str, str]
+        Aliases for hk fields. In this dict, the key is the alias name, and the
+        value is the field descriptor, in the format of ``agent.feed.field``.
+        For example::
+
+            {
+                'fp_temp': 'cryo-ls372-lsa21yc.temperatures.Channel_02_T',
+            }
+
+        These aliases are only used on load, and do not effect how data is stored in the hkdb.
+        Aliases should be valid python identifiers, since they will be set as attributes in
+        the HkResult object.
     """
     hk_root: str
-    "Root directory for the HK archive"
-
     db_file: Optional[str] = None
-    "Path to the hk index database if the database is an sqlite file. Either this or db_url must be set"
-
-    echo_db: bool = False
-    "Whether database operations should be echoed"
-
     db_url: Optional[Union[str, db.URL]] = None
-    "URL used for db engine. Either this or db_file must be set"
-
+    echo_db: bool = False
     file_idx_lookback_time: Optional[float] = None
-    "Time [sec] to look back when scanning for new files to index"
-
     show_index_pb: bool = True
-    "If true, shows progress bar when indexing"
-
     aliases: Dict[str, str] = field(default_factory=dict)
-    """
-    Aliases for hk fields. In this dict, the key is the alias name, and the
-    value is the field descriptor, in the format of ``agent.feed.field``.
-    For example::
 
-        {
-            'fp_temp': 'cryo-ls372-lsa21yc.temperatures.Channel_02_T',
-        }
-
-    These aliases are only used on load, and do not effect how data is stored in the hkdb.
-    Aliases should be valid python identifiers, since they will be set as attributes in
-    the HkResult object.
-    """
     def __post_init__(self):
         if self.db_file is None and self.db_url is None:
             raise ValueError("Either db_file or db_url must be set")
@@ -316,27 +320,29 @@ class Field:
 class LoadSpec:
     """
     HK loading specification
+
+    Args
+    -----
+    cfg: HkConfig
+        Configuration object
+    fields: List[str]
+        List of field specifications to load. This can either be a field
+        descriptor, of the format ``agent.feed.field``, or an alias defined in
+        the config. Field descriptors can contain wildcards, for instance
+        ``agent.*.*`` will load all fields belonging to the specified agent.
+        ``agent.feed.*`` and ``agent.*.field`` will also work as expected.
+    start: float
+        Start time to load
+    end: float
+        End time to load
+    downsample_factor: int
+        Downsample factor for data
     """
     cfg: HkConfig
-
     fields: List[str]
-    """
-    List of field specifications to load. This can either be a field
-    descriptor, of the format ``agent.feed.field``, or an alias defined in
-    the config. Field descriptors can contain wildcards, for instance
-    ``agent.*.*`` will load all fields belonging to the specified agent.
-    ``agent.feed.*`` and ``agent.*.field`` will also work as expected.
-    """
-
     start: float
-    "Start time to load"
-
     end: float
-    "End time to load"
-
     downsample_factor: int = 1
-    "Downsample factor for data"
-
 
     def __post_init__(self):
         fs = []

--- a/sotodlib/io/hkdb.py
+++ b/sotodlib/io/hkdb.py
@@ -376,9 +376,7 @@ def load_hk(load_spec: LoadSpec, show_pb=False):
                     field[1].append(np.array(data))
             pb.update()
     pb.close()
-    for k in result:
-        result[k][0] = np.hstack(result[k][0])
-        result[k][1] = np.hstack(result[k][1])
-        result[k] = np.array(result[k])
+    for k, d in result.items():
+        result[k] = np.array([np.hstack(d[0]), np.hstack(d[1])])
 
     return HkResult(result, aliases=load_spec.cfg.aliases)

--- a/sotodlib/io/hkdb.py
+++ b/sotodlib/io/hkdb.py
@@ -21,29 +21,27 @@ Session = sessionmaker()
 @dataclass
 class HkConfig:
     """
-    Configuration object for loading and indexing HK.
-
-    Args
-    -----
-    hk_root : str
-        Root directory of hk files
-    hk_db : str
-        Path to hk index database
-    echo_db : bool
-        Whether to echo database operations
-    aliases : Dict[str, str]
-        Aliases for hk fields. In this dict, the key is the alias name, and the
-        value is the field descriptor, in the format of ``agent.feed.field``.
-        For example::
-
-            {
-                'fp_temp': 'cryo-ls372-lsa21yc.temperatures.Channel_02_T',
-            }
+    Configuration object for indexing and loading from an HK archive.
     """
     hk_root: str
+    "Root directory for the HK archive"
+
     hk_db: str
+    "Path to the hk index database"
+
     echo_db: bool = False
+    "Whether database operations should be echoed"
+
     aliases: Dict[str, str] = field(default_factory=dict)
+    """
+    Aliases for hk fields. In this dict, the key is the alias name, and the
+    value is the field descriptor, in the format of ``agent.feed.field``.
+    For example::
+
+        {
+            'fp_temp': 'cryo-ls372-lsa21yc.temperatures.Channel_02_T',
+        }
+    """
 
     @classmethod
     def from_yaml(cls, path):
@@ -273,26 +271,23 @@ class Field:
 class LoadSpec:
     """
     HK loading specification
-
-    Args
-    -----
-    cfg : HkConfig
-        HkConfig object
-    fields : List[str]
-        List of field specifications to load. This can either be a field
-        descriptor, of the format ``agent.feed.field``, or an alias defined in
-        the config. Field descriptors can contain wildcards, for instance
-        ``agent.*.*`` will load all fields belonging to the specified agent.
-        ``agent.feed.*`` and ``agent.*.field`` will also work as expected.
-    start : float 
-        Starting time of data to load
-    end : float
-        Ending time of data to load
     """
     cfg: HkConfig
+
     fields: List[str]
+    """
+    List of field specifications to load. This can either be a field
+    descriptor, of the format ``agent.feed.field``, or an alias defined in
+    the config. Field descriptors can contain wildcards, for instance
+    ``agent.*.*`` will load all fields belonging to the specified agent.
+    ``agent.feed.*`` and ``agent.*.field`` will also work as expected.
+    """
+
     start: float
+    "Start time to load"
+
     end: float
+    "End time to load"
 
     def __post_init__(self):
         fs = []

--- a/sotodlib/io/hkdb.py
+++ b/sotodlib/io/hkdb.py
@@ -45,6 +45,11 @@ class HkConfig:
     echo_db: bool = False
     aliases: Dict[str, str] = field(default_factory=dict)
 
+    @classmethod
+    def from_yaml(cls, path):
+        with open(path, 'r') as f:
+            return cls(**yaml.safe_load(f))
+
 
 class HkFile(Base):
     """
@@ -151,10 +156,9 @@ class HkDb:
     cfg : Union[HKConfig, str]
         Configuration object or path to configuration file
     """
-    def __init__(self, cfg: Union[HKConfig, str]):
+    def __init__(self, cfg: Union[HkConfig, str]):
         if isinstance(cfg, str):
-            with open(cfg, 'r') as f:
-                cfg = HkConfig(**yaml.safe_load(f))
+            cfg = HkConfig.from_yaml(cfg)
         self.cfg = cfg
 
         self.engine = db.create_engine(f"sqlite:///{cfg.hk_db}", echo=cfg.echo_db)
@@ -360,4 +364,3 @@ def load_hk(load_spec: LoadSpec, show_pb=False):
         result[k][1] = np.hstack(result[k][1])
 
     return HkResult(result, aliases=load_spec.cfg.aliases)
-    

--- a/sotodlib/io/hkdb.py
+++ b/sotodlib/io/hkdb.py
@@ -1,0 +1,363 @@
+"""
+Module for loading L3 housekeeping data.
+"""
+from dataclasses import dataclass, field
+import yaml
+import os
+import numpy as np
+
+import sqlalchemy as db
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker, relationship, backref
+from typing import Union, Tuple, List, Optional, Dict
+import so3g
+from spt3g import core as spt3g_core
+from tqdm.auto import tqdm, trange
+from pprint import pprint
+
+Base = declarative_base()
+Session = sessionmaker()
+
+@dataclass
+class HkConfig:
+    """
+    Configuration object for loading and indexing HK.
+
+    Args
+    -----
+    hk_root : str
+        Root directory of hk files
+    hk_db : str
+        Path to hk index database
+    echo_db : bool
+        Whether to echo database operations
+    aliases : Dict[str, str]
+        Aliases for hk fields. In this dict, the key is the alias name, and the
+        value is the field descriptor, in the format of ``agent.feed.field``.
+        For example::
+
+            {
+                'fp_temp': 'cryo-ls372-lsa21yc.temperatures.Channel_02_T',
+            }
+    """
+    hk_root: str
+    hk_db: str
+    echo_db: bool = False
+    aliases: Dict[str, str] = field(default_factory=dict)
+
+
+class HkFile(Base):
+    """
+    Database entry for a hk file.
+
+    Args
+    ------
+    path: str
+        Path to the hk file.
+    start_time: float
+        Starting ctime of the file
+    end_time: float
+        Ending ctime of the fil
+    """
+    __tablename__ = 'hk_files'
+    id = db.Column(db.Integer, primary_key=True)
+    path = db.Column(db.String, nullable=False, unique=True)
+    start_time = db.Column(db.Float)
+    end_time = db.Column(db.Float)
+
+
+class HkFrame(Base):
+    """
+    Database entry for an hk frame.
+
+    Args
+    --------
+    file_id: int
+        ID of the file containing the frame
+    agent: str
+        instance-id of the OCS agent for the frame
+    feed: str
+        Name of the OCS feed for the frame
+    byte_offset: int
+        Offset of the frame in the G3 file in bytes
+    start_time: float
+        Starting ctime of the frame
+    end_time: float
+        Ending ctime of the frame
+    """
+    __tablename__ = 'hk_frames'
+    id = db.Column(db.Integer, primary_key=True)
+    file_id = db.Column(db.Integer, db.ForeignKey('hk_files.id'))
+    file = relationship('HkFile')
+    agent = db.Column(db.String)
+    feed = db.Column(db.String)
+    byte_offset = db.Column(db.Integer)
+    start_time = db.Column(db.Float)
+    end_time = db.Column(db.Float)
+
+
+def get_items_from_file(hk_path) -> Tuple[HkFile, List[HkFrame]]:
+    """
+    Returns HkFile and HkFrame objects corresponding to a given hk file.
+
+    Returns
+    ---------
+    hk_file : HkFile
+        HkFile object corresponding to the file
+    frames : List[HkFrame]
+        List of all HkFrames in the file
+    """
+    hkfile = HkFile(path=hk_path)
+    frames = []
+    reader = so3g.G3IndexedReader(hk_path)
+
+    file_start, file_end = 1<<32, 0
+    while True:
+        byte_offset = reader.Tell()
+        frame = reader.Process(None)
+        if not frame:
+            break
+        else:
+            frame = frame[0]
+        
+        if frame['hkagg_type'] != so3g.HKFrameType.data:
+            continue
+
+        # Process frame
+        addr = frame['address']
+        _, agent, _, feed = addr.split('.')
+        start_time, stop_time = 1<<32, 0
+        for block in frame['blocks']:
+            ts = np.array(block.times) / spt3g_core.G3Units.s
+            start_time = min(start_time, ts[0])
+            stop_time = max(stop_time, ts[-1])
+        file_start = min(file_start, start_time)
+        file_end = max(file_end, stop_time)
+        frames.append(HkFrame(
+            agent=agent, feed=feed, byte_offset=byte_offset,
+            start_time=start_time, end_time=stop_time, file=hkfile
+        ))
+
+    hkfile.start_time = file_start
+    hkfile.end_time = file_end
+    return hkfile, frames
+
+class HkDb:
+    """
+    Helper class for createing database sessions
+
+    Args
+    ------
+    cfg : Union[HKConfig, str]
+        Configuration object or path to configuration file
+    """
+    def __init__(self, cfg: Union[HKConfig, str]):
+        if isinstance(cfg, str):
+            with open(cfg, 'r') as f:
+                cfg = HkConfig(**yaml.safe_load(f))
+        self.cfg = cfg
+
+        self.engine = db.create_engine(f"sqlite:///{cfg.hk_db}", echo=cfg.echo_db)
+        Session.configure(bind=self.engine)
+        self.Session = sessionmaker(bind=self.engine)
+        Base.metadata.create_all(self.engine)
+
+
+def index_files(paths, db: HkDb):
+    """
+    Indexes a group of files, adding items to the database.
+
+    Args
+    -----
+    paths : Union[str, List[str]]
+        Path or paths to files to index
+    db : HkDb
+        Database object to use
+    """
+    paths = np.atleast_1d(paths)
+    items =[]
+    for p in paths:
+        hk_file, hk_frames = get_items_from_file(p)
+        items.append(hk_file)
+        items.extend(hk_frames)
+
+    with db.Session.begin() as sess:
+        sess.add_all(items)
+
+
+def get_all_hk_files(cfg: HkConfig):
+    """
+    Gets list of all hk files in specified root directory
+    """
+    hk_files = []
+    for root, _, files in os.walk(cfg.hk_root):
+        for file in files:
+            if file.endswith('.g3'):
+                hk_files.append(os.path.join(root, file))
+    return hk_files
+
+
+def index_all(cfg: Union[HkConfig, str], show_pb=True, files_per_batch=1):
+    """
+    Indexes all files in the specified root directory.
+    """
+    hkdb = HkDb(cfg)
+    all_files = get_all_hk_files()
+
+    with hkdb.Session.begin() as sess:
+        archived_paths = [path for path, in sess.query(HkFile.path).all()]
+        remaining_files = sorted(list(set(all_files) - set(archived_paths)))
+    
+    for i in trange(0, len(remaining_files), files_per_batch, disable=(not show_pb)):
+        index_files(remaining_files[i:i+files_per_batch], hkdb)
+
+
+#####################
+# HK Loading stuff
+#####################
+
+@dataclass
+class Field:
+    agent: str
+    feed: str
+    field: str
+
+    def __str__(self):
+        return f"{self.agent}.{self.feed}.{self.field}"
+    
+    def matches(self, other):
+        if self.agent != other.agent:
+            return False
+        if self.feed != other.feed and self.feed != '*' and other.feed != '*':
+            return False
+        if self.field != other.field and self.field != '*' and other.field != '*':
+            return False
+        return True
+    
+    @classmethod
+    def from_str(cls, s):
+        try:
+            agent, feed, field = s.split('.')
+        except Exception:
+            raise ValueError(f"Could not parse field: {s}")
+
+        return cls(agent, feed, field)
+
+@dataclass
+class LoadSpec:
+    """
+    HK loading specification
+
+    Args
+    -----
+    cfg : HkConfig
+        HkConfig object
+    fields : List[str]
+        List of field specifications to load. This can either be a field
+        descriptor, of the format ``agent.feed.field``, or an alias defined in
+        the config. Field descriptors can contain wildcards, for instance
+        ``agent.*.*`` will load all fields belonging to the specified agent.
+        ``agent.feed.*`` and ``agent.*.field`` will also work as expected.
+    start : float 
+        Starting time of data to load
+    end : float
+        Ending time of data to load
+    """
+    cfg: HkConfig
+    fields: List[str]
+    start: float
+    end: float
+
+    def __post_init__(self):
+        fs = []
+        for f in self.fields:
+            if f in self.cfg.aliases:
+                fs.append(Field.from_str(self.cfg.aliases[f]))
+            else:
+                fs.append(Field.from_str(f))
+        self.fields = fs
+
+
+class HkResult:
+    """
+    Helper class for storing results of LoadHk. If aliases are set for any
+    of the keys, they will be set as attributes of the object.
+
+    Attributes
+    ------------
+    data: dict
+        Dict where the key is the field descriptor, and the value is a list
+        where val[0] are timestamps, and val[1] is data.
+    """
+    def __init__(self, data, aliases=None):
+        if aliases is None:
+            aliases = {}
+        self._aliases = aliases
+        self.data = data
+        for alias, key in aliases.items():
+            if key in self.data:
+                setattr(self, alias, self.data[key])
+
+
+def load_hk(load_spec: LoadSpec, show_pb=False):
+    """
+    Loads hk data
+
+    Args
+    ------
+    load_spec: LoadSpec
+        Load specification. See docstrings of the LoadSpec class.
+    show_pb: bool
+        If true, will show a progressbar :)
+    """
+    hkdb = HkDb(load_spec.cfg)
+    agent_set = list(set(f.agent for f in load_spec.fields))
+
+    file_spec = {}  # {path: [offsets]}
+    with hkdb.Session.begin() as sess:
+        query = sess.query(HkFrame).filter(
+            HkFrame.start_time <= load_spec.end,
+            HkFrame.end_time >= load_spec.start,
+            HkFrame.agent.in_(agent_set)
+        )
+        for frame in query:
+            if frame.file.path not in file_spec:
+                file_spec[frame.file.path] = []
+            file_spec[frame.file.path].append(frame.byte_offset)
+        
+    result = {}  # {field: [timestamps, data]}
+    def get_result_field(agent, feed, field_name):
+        f = Field(agent, feed, field_name)
+        key = str(f)
+        if key in result:
+            return result[key]
+        for field in load_spec.fields:
+            if field.matches(f):
+                result[key] = [[], []]
+        return None
+
+    nframes = np.sum([len(offsets) for offsets in file_spec.values()])
+    pb = tqdm(total=nframes, disable=(not show_pb))
+    for path, offsets in file_spec.items():
+        reader = so3g.G3IndexedReader(path)
+        for offset in sorted(offsets):
+            reader.Seek(offset)
+            frame = reader.Process(None)[0]
+            addr = frame['address']
+            _, agent, _, feed = addr.split('.')
+            for block in frame['blocks']:
+                ts = np.array(block.times) / spt3g_core.G3Units.s
+                for field_name, data in block.items():
+                    field = get_result_field(agent, feed, field_name)
+                    if field is None:
+                        continue
+                    field[0].append(ts)
+                    field[1].append(np.array(data))
+            pb.update()
+    pb.close()
+    for k in result:
+        result[k][0] = np.hstack(result[k][0])
+        result[k][1] = np.hstack(result[k][1])
+
+    return HkResult(result, aliases=load_spec.cfg.aliases)
+    

--- a/sotodlib/io/hkdb.py
+++ b/sotodlib/io/hkdb.py
@@ -26,7 +26,7 @@ class HkConfig:
     """
     Configuration object for indexing and loading from an HK archive.
 
-    Attributes
+    Args
     ------------
     hk_root: str
         Root directory for the HK archive

--- a/sotodlib/io/hkdb.py
+++ b/sotodlib/io/hkdb.py
@@ -413,7 +413,7 @@ def load_hk(load_spec: Union[LoadSpec, dict], show_pb=False):
             HkFrame.start_time <= load_spec.end,
             HkFrame.end_time >= load_spec.start,
             HkFrame.agent.in_(agent_set)
-        )
+        ).order_by(HkFrame.start_time)
         for frame in query:
             if frame.file.path not in file_spec:
                 file_spec[frame.file.path] = []

--- a/sotodlib/site_pipeline/update_hkdb.py
+++ b/sotodlib/site_pipeline/update_hkdb.py
@@ -1,7 +1,7 @@
 """
 Script for calling hkdb update function with a configuration file
 """
-from sotodlib.io import hkdb 
+from sotodlib.io import hkdb
 
 def main(cfg_file: str):
     """Updates hkdb index databases"""

--- a/sotodlib/site_pipeline/update_hkdb.py
+++ b/sotodlib/site_pipeline/update_hkdb.py
@@ -1,0 +1,12 @@
+"""
+Script for calling hkdb update function with a configuration file
+"""
+from sotodlib.io import hkdb 
+
+def main(cfg_file: str):
+    """Updates hkdb index databases"""
+    hkdb.update_index_all(cfg_file)
+
+if __name__ == "__main__":
+    import sys
+    main(sys.argv[1])


### PR DESCRIPTION
This is a draft PR with an initial level-3 housekeeping indexing and loading framework.

Docs will come shortly, but this can currently be used and tested on satp1 data, since I have a satp1 index that should be up to date as of 03/28.

First create a hk.yaml file to use as configuration, such as:
```
hk_root: /so/data/satp1/hk
hk_db: /so/home/jlashner/work/daily/2024-03-28/l3-hk/satp1_hk.db
aliases:
    fp_temp: cryo-ls372-lsa21yc.temperatures.Channel_02_T
```
Then in python, you can load data the last week's worth of focal-plane temps as follows
```
t1 = time.time()
t0 = t1 - 7*24*3600
cfg = hkdb.HkConfig.from_yaml('hk.yaml')
ls = hkdb.LoadSpec(
    cfg=cfg,
    fields=['cryo-ls372-lsa21yc.*.*'],
    start=t0, end=t1,
)
res = hkdb.load_hk(ls, show_pb=True)
plt.plot(*res.fp_temp)

# The above is the same as below, attributes in the result are set based on aliases.
# plt.plot(*res.data['cryo-ls372-lsa21yc.temperatures.Channel_02_T'])
```