### PR TITLE
More preprocess metrics

### DIFF
--- a/sotodlib/preprocess/core.py
+++ b/sotodlib/preprocess/core.py
@@ -418,3 +418,103 @@ class Pipeline(list):
         
         return full, success
         
+
+class _FracFlaggedMixIn(object):
+
+    @classmethod
+    def gen_metric(
+        cls,
+        meta,
+        proc_aman,
+        flags_key=None,
+        percentiles=[0, 50, 75, 90, 95, 100],
+        tags=[],
+    ):
+        """ Generate a QA metric from the output of this process.
+
+        Arguments
+        ---------
+        meta : AxisManager
+            The full metadata container.
+        proc_aman : AxisManager
+            The metadata containing just the output of this process.
+        flags_key : str or tuple
+            The keys to access the flag dataset. e.g. 'glitches.glitch_flags'.
+            If a single term is passed, the first item will be inferred to be the
+            process name.
+        percentiles : list
+            Percentiles to compute across detectors
+        tags : list
+            Keys into `metadata.det_info` to record as tags with the Influx line.
+            Added to the default list ["wafer_slot", "tel_tube", "wafer.bandpass"].
+
+        Returns
+        -------
+        line : dict
+            InfluxDB line entry elements to be fed to
+            `site_pipeline.monitor.Monitor.record`
+        """
+        # parse key for flags dataset
+        if flags_key is None:
+            raise ValueError("The flags_key parameter must be specified in the config.")
+        else:
+            keys = flags_key.split(".")
+            if len(keys) == 1:
+                key1, key2 = cls.name, keys[0]
+            elif len(keys) == 2:
+                key1, key2 = keys
+            else:
+                raise ValueError(f"Could not parse flags_key {flags_key}")
+
+        # add specified tags
+        tag_keys = ["wafer_slot", "tel_tube", "wafer.bandpass"]
+        tag_keys += [t for t in tags if t not in tag_keys]
+
+        tags = []
+        vals = []
+        from ..qa.metrics import _get_tag, _has_tag
+        # record one metric per wafer slot, per bandpass
+        for bp in np.unique(meta.det_info.wafer.bandpass):
+            for ws in np.unique(meta.det_info.wafer_slot):
+                subset = np.where(
+                    (meta.det_info.wafer_slot == ws) & (meta.det_info.wafer.bandpass == bp)
+                )[0]
+
+                # Compute the number of samples that were flagged
+                frac_flagged = np.array([
+                    np.dot(r.ranges(), [-1, 1]).sum() for r in proc_aman[key1][key2][subset]
+                ], dtype=float)
+                num_valid = np.array([
+                    np.dot(r.ranges(), [-1, 1]).sum() for r in proc_aman[key1].valid[subset]
+                ])
+                with np.errstate(divide="ignore"):
+                    frac_flagged *= np.where(num_valid > 0, 1 / num_valid, 0)
+
+                # record percentiles over detectors and fraction of samples flagged
+                perc = np.percentile(frac_flagged, percentiles)
+                mean = frac_flagged.mean()
+
+                # get the tags for this wafer (all detectors in this subset share these)
+                tags_base = {
+                    k: _get_tag(meta.det_info, k, subset[0]) for k in tag_keys if _has_tag(meta.det_info, k)
+                }
+                tags_base["telescope"] = meta.obs_info.telescope
+
+                # add tags and values to respective lists in order
+                tags_perc = [tags_base.copy() for i in range(perc.size)]
+                for i, t in enumerate(tags_perc):
+                    t["det_stat"] = f"percentile_{percentiles[i]}"
+                vals += list(perc)
+                tags += tags_perc
+                tags_mean = tags_base.copy()
+                tags_mean["det_stat"] = "mean"
+                vals.append(mean)
+                tags.append(tags_mean)
+
+        obs_time = [meta.obs_info.timestamp] * len(vals)
+        return {
+            "field": cls._influx_field,
+            "values": vals,
+            "timestamps": obs_time,
+            "tags": tags,
+        }

--- a/sotodlib/qa/metrics.py
+++ b/sotodlib/qa/metrics.py
@@ -102,8 +102,6 @@ class QAMetric(object):
             raise Exception(f"Metadata does not correspond to obs_id {obs_id}.")
         line = self._process(meta)
         log_tags = {"observation": obs_id}  # used to identify this entry
-        for t in line["tags"]:  # make sure this is also recorded in metric itself
-            t.update(log_tags)
         self.monitor.record(**line, log=self._influx_log, measurement=self._influx_meas, log_tags=log_tags)
         self.monitor.write()
 

--- a/sotodlib/qa/metrics.py
+++ b/sotodlib/qa/metrics.py
@@ -4,6 +4,22 @@ import numpy as np
 from ..core import metadata
 
 
+def _has_tag(root, keys):
+    keys = keys.split(".")
+    for key in keys:
+        if key in root:
+            root = root[key]
+        else:
+            return False
+    return True
+
+def _get_tag(root, keys, i):
+    keys = keys.split(".")
+    for key in keys:
+        root = root[key]
+    return root[i]
+
+
 class QAMetric(object):
     """ Base class for quality assurance metrics to be recorded in Influx,
     derived from processed metadata files.
@@ -113,12 +129,14 @@ class PreprocessQA(QAMetric):
     """
 
     _influx_meas = "preprocesstod"
+    _process_args = {}
 
-    def __init__(self, context, monitor, process_name, **kwargs):
+    def __init__(self, context, monitor, process_name, process_args={}, **kwargs):
         """ In addition to the context and monitor, pass the name of the
         preprocess process to record. It should have a `gen_metric` method
         implemented and `_influx_field` attribute.
         """
+        self._process_args = process_args
         super().__init__(context, monitor, **kwargs)
 
         from sotodlib.preprocess import Pipeline
@@ -131,7 +149,7 @@ class PreprocessQA(QAMetric):
         self._influx_field = self._pipe_proc._influx_field
 
     def _process(self, meta):
-        return self._pipe_proc.gen_metric(meta, meta.preprocess)
+        return self._pipe_proc.gen_metric(meta, meta.preprocess, **self._process_args)
 
     def _get_available_obs(self):
         # find preprocess manifest file

--- a/sotodlib/site_pipeline/record_qa.py
+++ b/sotodlib/site_pipeline/record_qa.py
@@ -46,9 +46,20 @@ def main(config):
         logger.info(f"Recording metrics for obs_id {oid} ({i}/{n})...")
         # load metadata once
         meta = context.get_meta(oid, ignore_missing=True)
+        # check that obsdb info is available
+        if len(meta.obs_info.keys()) < 2:
+            logger.warning("This observation is missing obs_info. Skipping.")
+            i += 1
+            continue
         for m, m_obs in zip(metrics, obs_id):
             if oid in m_obs:
-                m.process_and_record(oid, meta)
+                try:
+                    m.process_and_record(oid, meta)
+                except Exception:
+                    logger.error(
+                        f"Processing metric {m._influx_meas}.{m._influx_field} failed.",
+                        exc_info=True
+                    )
         i += 1
 
 


### PR DESCRIPTION
I've added some more metrics for the current `preprocesstod` output.

I was also thinking a bit about the volume of data this will be feeding to InfluxDB, and whether it will remain a sustainable rate. A very rough estimate could be that an Influx line is up to 1 kB (1000 char, no compression), and here I am saving one line per detector per obs_id. If there are order tens of thousands of detectors for the full observatory, that would come to tens of MB per obs_id. Is that sensible?