### PR TITLE
Data Packaging Updates

### DIFF
--- a/sotodlib/core/context.py
+++ b/sotodlib/core/context.py
@@ -104,28 +104,6 @@ class Context(odict):
         logger.info('Calling hook for %s: %s' % (hook_key, hook_func))
         hook_func(self, *args, **kwargs)
 
-    """
-    def _subst(self, dest, max_recursion=20):
-        # Do string substitution of all our tags into dest (in-place
-        # if dest is a dict).
-        assert(max_recursion > 0)  # Too deep this dictionary.
-        if isinstance(dest, str):
-            # Keep subbing until it doesn't change any more...
-            new = dest.format(**self['tags'])
-            while dest != new:
-                dest = new
-                new = dest.format(**self['tags'])
-            return dest
-        if isinstance(dest, list):
-            return [self._subst(x) for x in dest]
-        if isinstance(dest, tuple):
-            return (self._subst(x) for x in dest)
-        if isinstance(dest, dict):
-            for k, v in dest.items():
-                dest[k] = self._subst(v, max_recursion-1)
-            return dest
-        return dest
-    """
     def _get_warn_missing(self, k, default=None):
         if not k in self:
             logger.warning(f'Key "{k}" not present in context.')

--- a/sotodlib/core/context.py
+++ b/sotodlib/core/context.py
@@ -6,6 +6,7 @@ import logging
 import numpy as np
 
 from . import metadata
+from .util import tag_substr
 from .axisman import AxisManager, OffsetAxis, AxisInterface
 
 logger = logging.getLogger(__name__)
@@ -88,7 +89,7 @@ class Context(odict):
         self['tags'] = self._get_warn_missing('tags', {})
 
         # Perform recursive substitution on strings defined in tags.
-        self._subst(self)
+        tag_substr(self, self['tags'])
 
         # Load basic databases.
         self.reload(load_list)
@@ -103,6 +104,7 @@ class Context(odict):
         logger.info('Calling hook for %s: %s' % (hook_key, hook_func))
         hook_func(self, *args, **kwargs)
 
+    """
     def _subst(self, dest, max_recursion=20):
         # Do string substitution of all our tags into dest (in-place
         # if dest is a dict).
@@ -123,7 +125,7 @@ class Context(odict):
                 dest[k] = self._subst(v, max_recursion-1)
             return dest
         return dest
-
+    """
     def _get_warn_missing(self, k, default=None):
         if not k in self:
             logger.warning(f'Key "{k}" not present in context.')

--- a/sotodlib/core/util.py
+++ b/sotodlib/core/util.py
@@ -1,5 +1,27 @@
 import numpy as np
 
+def tag_substr(dest, tags, max_recursion=20):
+    """ Do string substitution of all our tags into dest (in-place
+    if dest is a dict). Used for context and data packaging tag replacements
+    """
+    assert(max_recursion > 0)  # Too deep this dictionary.
+    if isinstance(dest, str):
+        # Keep subbing until it doesn't change any more...
+        new = dest.format(**tags)
+        while dest != new:
+            dest = new
+            new = dest.format(**tags)
+        return dest
+    if isinstance(dest, list):
+        return [tag_substr(x,tags) for x in dest]
+    if isinstance(dest, tuple):
+        return (tag_substr(x,tags) for x in dest)
+    if isinstance(dest, dict):
+        for k, v in dest.items():
+            dest[k] = tag_substr(v,tags, max_recursion-1)
+        return dest
+    return dest
+
 def get_coindices(v0, v1, check_unique=False):
     """Given vectors v0 and v1, each of which contains no duplicate
     values, determine the elements that are found in both vectors.

--- a/sotodlib/io/bookbinder.py
+++ b/sotodlib/io/bookbinder.py
@@ -629,7 +629,18 @@ class BookBinder:
         self.max_file_size = max_file_size
         self.ignore_tags = ignore_tags
 
-        if not os.path.exists(outdir):
+        if os.path.exists(outdir):
+            if len(os.listdir(outdir)) > 1:
+                raise ValueError(
+                    f"Output directory {outdir} contains files. Delete to retry"
+                      " bookbinding"
+                )
+            elif len(os.listdir(outdir)) == 1:
+                assert (os.listdir(outdir)[0] == 'Z_bookbinder_log.txt', 
+                    f"only acceptable file in new book path {outdir} is "
+                    " Z_bookbinder_log.txt"
+                )
+        else:
             os.makedirs(outdir)
 
         logfile = os.path.join(outdir, 'Z_bookbinder_log.txt')

--- a/sotodlib/io/datapkg_utils.py
+++ b/sotodlib/io/datapkg_utils.py
@@ -1,0 +1,52 @@
+import os
+import yaml
+
+from ..core.util import tag_substr
+
+def load_configs(cfg_file, env_file=None, env_var="DATAPKG_ENV"):
+    """ load a yaml config file and replace string paths tags
+    
+    Example config file with a tag::
+
+        my_path : /complete/path
+        other_path: {tag}/path
+    
+    matches with an environment file which would contain::
+
+        tag: /other/relevant/thing
+
+    so that the returned config dictionary contains::
+
+        'other_path' : '/other/relevant/thing/path'
+    
+    Arguments
+    ----------
+    cfg_file: str
+        path to a .yaml configuration file
+    env_file: str (optional)
+        path to a .yaml file where each entry is a possible tag.
+    env_var: str (optional)
+        
+
+    Returns
+    --------
+    configs: dict
+        loaded configuration dictionary where all strings with tags have been
+        replaced with the values loaded from the environment file
+    """
+    if env_file is None:
+        env_file = os.environ.get(env_var)
+    if env_file is None:
+        tags = {}
+    else:
+        tags = yaml.safe_load( open(env_file, "r") )
+
+    configs = yaml.safe_load( open(cfg_file, "r"))
+    try:
+        configs = tag_substr(configs, tags)
+    except KeyError as e:
+        raise ValueError(
+            f"Config file {cfg_file} expects tag {e.args[0]} but this tag is "
+            f"not found in environment file '{env_file}'"
+        )
+    return configs

--- a/sotodlib/io/g3thk_db.py
+++ b/sotodlib/io/g3thk_db.py
@@ -10,8 +10,8 @@ import numpy as np
 from tqdm import tqdm
 from so3g import hk
 
-
 import logging
+from .datapkg_utils import load_configs
 
 logger = logging.getLogger(__name__)
 
@@ -543,9 +543,12 @@ class G3tHk:
         configs - dictionary containing `data_prefix` and `g3thk_db` keys
         """
         if type(configs) == str:
-            configs = yaml.safe_load(open(configs, "r"))
+            configs = load_configs(configs)
 
-        return cls(os.path.join(configs["data_prefix"], "hk"), configs["g3thk_db"])
+        return cls(
+            os.path.join(configs["data_prefix"], "hk"), 
+            configs["g3thk_db"]
+        )
 
     def delete_file(self, hkfile, dry_run=False, my_logger=None):
         """WARNING: Removes actual files from file system.

--- a/sotodlib/io/imprinter.py
+++ b/sotodlib/io/imprinter.py
@@ -27,6 +27,7 @@ from .load_smurf import (
     SupRsyncType,
     Files,
 )
+from .datapkg_utils import load_configs
 from .check_book import BookScanner
 from .g3thk_db import G3tHk, HKFiles
 from ..site_pipeline.util import init_logger
@@ -218,8 +219,7 @@ class Imprinter:
         """
 
         # load config file and parameters
-        with open(im_config, "r") as f:
-            self.config = yaml.safe_load(f)
+        self.config = load_configs(im_config)
 
         self.db_path = self.config.get("db_path")
         self.daq_node = self.config.get("daq_node")
@@ -425,8 +425,7 @@ class Imprinter:
         if not self.build_hk:
             return
         
-        with open(self.g3tsmurf_config, "r") as f:
-            g3tsmurf_cfg = yaml.safe_load(f)
+        g3tsmurf_cfg = load_configs(self.g3tsmurf_config)
         lvl2_data_root = g3tsmurf_cfg["data_prefix"]
 
         if min_ctime is None:
@@ -578,8 +577,7 @@ class Imprinter:
                 session.commit()
 
     def get_book_path(self, book):
-        with open(self.g3tsmurf_config, "r") as f:
-            g3tsmurf_cfg = yaml.safe_load(f)
+        g3tsmurf_cfg = load_configs(self.g3tsmurf_config)
         lvl2_data_root = g3tsmurf_cfg["data_prefix"]
 
         if book.type in ["obs", "oper"]:
@@ -611,8 +609,7 @@ class Imprinter:
         ancil_drop_duplicates=False,
     ):
         """get the appropriate bookbinder for the book based on its type"""
-        with open(self.g3tsmurf_config, "r") as f:
-            g3tsmurf_cfg = yaml.safe_load(f)
+        g3tsmurf_cfg = load_configs(self.g3tsmurf_config)
         lvl2_data_root = g3tsmurf_cfg["data_prefix"]
 
         if book.type in ["obs", "oper"]:
@@ -1749,8 +1746,7 @@ def create_g3tsmurf_session(config):
 
     """
     # create database connection
-    with open(config, "r") as f:
-        config = yaml.safe_load(f)
+    config = load_configs(config)
     config["db_args"] = {"connect_args": {"check_same_thread": False}}
     SMURF = G3tSmurf.from_configs(config)
     session = SMURF.Session()

--- a/sotodlib/io/imprinter.py
+++ b/sotodlib/io/imprinter.py
@@ -1204,7 +1204,7 @@ class Imprinter:
                 raise ValueError(
                     f"Found {q_incomplete.count()} incomplete observations. "
                     f"New max ctime would be {new_ctime}. More than "
-                    f"{incomplete_timeouts[1]} in the past."
+                    f"{incomplete_timeouts[1]} hours in the past."
                 )
             elif max_ctime - new_ctime > 3600*incomplete_timeouts[0]:
                 level = self.logger.warning

--- a/sotodlib/io/imprinter.py
+++ b/sotodlib/io/imprinter.py
@@ -54,7 +54,6 @@ class BookExistsError(Exception):
 
     pass
 
-
 class BookBoundError(Exception):
     """Exception raised when a book is already bound"""
 
@@ -63,7 +62,6 @@ class BookBoundError(Exception):
 
 class NoFilesError(Exception):
     """Exception raised when no files are found in the book"""
-
     pass
 
 
@@ -754,7 +752,6 @@ class Imprinter:
                 ancil_drop_duplicates=ancil_drop_duplicates,
             )
             book.path = op.abspath(binder.outdir)
-
             binder.bind(pbar=pbar)
 
             # write M_book file
@@ -779,6 +776,7 @@ class Imprinter:
                 tc = self.tube_configs[book.tel_tube]
             else:
                 tc = {}
+            
             mfile = os.path.join(binder.outdir, "M_index.yaml")
             with open(mfile, "w") as f:
                 yaml.dump(

--- a/sotodlib/io/imprinter.py
+++ b/sotodlib/io/imprinter.py
@@ -456,6 +456,7 @@ class Imprinter:
                 stop=dt.datetime.utcfromtimestamp((int(ctime) + 1) * 1e5),
                 tel_tube=self.daq_node,  
             )
+            book.path = self.get_book_path(book)
             session.add(book)
             session.commit()
 
@@ -538,6 +539,7 @@ class Imprinter:
                     start=book_start,
                     stop=book_stop,
                 )
+                smurf_book.path = self.get_book_path(smurf_book)
                 session.add(smurf_book)
                 session.commit()
 
@@ -572,6 +574,7 @@ class Imprinter:
                 start=book_start,
                 stop=book_stop,
             )
+            stray_book.path = self.get_book_path(stray_book)
             flist = self.get_files_for_book(stray_book)
             if len(flist) > 0:
                 self.logger.info(f"registering {book_id}")

--- a/sotodlib/io/imprinter_cli.py
+++ b/sotodlib/io/imprinter_cli.py
@@ -44,12 +44,21 @@ def main(
             raise ValueError(f"Output root {output_root} does not exist")
         imprint.docker_output_root = imprint.output_root
         imprint.output_root = output_root
+        print(
+            f"Imprinter output root changed from {imprint.docker_output_root}"
+            f"to {imprint.output_root}"
+        )
     else:
         imprint.docker_output_root = None
     if g3_config is not None:
         if not os.path.exists(g3_config):
             raise ValueError(f"G3tSmurf config file {g3_config} does not exist")
+        print(
+            f"Imprinter g3tsmurf config changed from {imprint.g3tsmurf_config}"
+            f"to {g3_config}"
+        )
         imprint.g3tsmurf_config = g3_config
+
 
     if action == 'failed':
         check_failed_books(imprint)

--- a/sotodlib/io/imprinter_utils.py
+++ b/sotodlib/io/imprinter_utils.py
@@ -66,7 +66,7 @@ def set_book_rebind(imprint, book):
     imprint: Imprinter instance
     book: str or Book 
     """
-    book_dir = imprint.get_book_path(book)
+    book_dir = imprint.get_book_abs_path(book)
 
     if op.exists(book_dir):
         print(f"Removing all files from {book_dir}")

--- a/sotodlib/io/imprinter_utils.py
+++ b/sotodlib/io/imprinter_utils.py
@@ -66,22 +66,14 @@ def set_book_rebind(imprint, book):
     imprint: Imprinter instance
     book: str or Book 
     """
-    try:
-        # find appropriate binder for the book type
-        binder = imprint._get_binder_for_book(
-            book, 
-            ignore_tags=False,
-        )
-    except:
-         # if binder making failed there's no files
-        binder = None
-    if binder is not None:
-        book_dir = op.abspath(binder.outdir)
-        del binder
-        time.sleep(1)
-        if op.exists(book_dir):
-            print(f"Removing all files from {book_dir}")
-            shutil.rmtree(book_dir)
+    book_dir = imprint.get_book_path(book)
+
+    if op.exists(book_dir):
+        print(f"Removing all files from {book_dir}")
+        shutil.rmtree(book_dir)
+    else: 
+        print(f"Found no files in {book_dir} to remove")
+
     book.status = UNBOUND
     imprint.get_session().commit()
 

--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -161,6 +161,7 @@ class G3tSmurf:
         db_args={},
         finalize={},
         hk_db_path=None,
+        make_db=False,
     ):
         """
         Class to manage a smurf data archive.
@@ -181,6 +182,11 @@ class G3tSmurf:
                 Additional arguments to pass to sqlalchemy.create_engine
             finalize: dict, optional
                 Arguments required for fast tracking of data file transfers
+            hk_db_path: str
+                Path the HK database for finalization tracking
+            make_db: bool
+                if True and db_path does not exist it will make a new database.
+                otherwise will throw and error if database path does not exist
         """
         if db_path is None:
             db_path = os.path.join(archive_path, "frames.db")
@@ -192,8 +198,12 @@ class G3tSmurf:
 
         if os.path.exists(self.db_path):
             new_db = False
-        else:
+        elif make_db:
             new_db = True
+        else:
+            raise ValueError(
+                f"Path {self.db_path} does not exist and make_db is False"
+            )
         
         try:
             self.engine = db.create_engine(
@@ -242,7 +252,7 @@ class G3tSmurf:
                 session.commit()
 
     @classmethod
-    def from_configs(cls, configs):
+    def from_configs(cls, configs, **kwargs):
         """
         Create a G3tSmurf instance from a configs dictionary or yaml file
         example configuration file will all relevant entries::
@@ -280,6 +290,7 @@ class G3tSmurf:
             db_args=configs.get("db_args", {}),
             finalize=configs.get("finalization", {}),
             hk_db_path=configs.get("g3thk_db"),
+            **kwargs
         )
 
     @staticmethod

--- a/sotodlib/site_pipeline/make_book.py
+++ b/sotodlib/site_pipeline/make_book.py
@@ -1,9 +1,32 @@
-from typing import Optional
+import os
 import traceback
 import argparse
-
+import datetime as dt
+from typing import Optional
 from sotodlib.io.imprinter import Imprinter
 
+def make_lock(fname):
+    if os.path.exists(fname):
+        raise ValueError(f"Tried to make lockfile {fname} which already"
+                          " exists")
+    with open(fname, 'w') as f:
+        print(f"writing lock file {fname}")
+        f.write(str(dt.datetime.now().timestamp()))
+
+def check_lock(fname, timeout):
+    if not os.path.exists(fname):
+        return True
+    with open(fname, 'r') as f:
+        t = float(f.readline())
+    if dt.datetime.now().timestamp() > t + timeout*3600:
+        raise ValueError(f"lockfile {fname} is over {timeout} hours old")
+    return False
+
+def remove_lock(fname):
+    if not os.path.exists(fname):
+        raise ValueError(f"lockfile {fname} does not exist at removal?")
+    print(f"removing lock file {fname}")
+    os.remove(fname)
 
 def main(config: str):
     """Make books based on imprinter db
@@ -13,13 +36,28 @@ def main(config: str):
     config : str
         path to imprinter configuration file
     """
-    imprinter = Imprinter(config, db_args={'connect_args': {'check_same_thread': False}})
+    imprinter = Imprinter(
+        config, 
+        db_args={'connect_args': {'check_same_thread': False}}
+    )
+    # lockname will be unique even if two imprinter configs are in 
+    # the same folder
+    b,f = os.path.split(config)
+    l = ".make_book." + f.replace(".yaml", ".lock")
+    lockname = os.path.join(b,l)
+
+    if not check_lock(lockname, 6):
+        imprinter.logger.warning("Not running make_book because of lockfile")
+        return
+    make_lock(lockname)
+
+
     # get unbound books
     unbound_books = imprinter.get_unbound_books()
     already_failed_books = imprinter.get_failed_books()
     
     print(f"Found {len(unbound_books)} unbound books and "
-          f"{len(already_failed_books)} failed books")
+        f"{len(already_failed_books)} failed books")
     for book in unbound_books:
         print(f"Binding book {book.bid}")
         try:
@@ -43,11 +81,17 @@ def main(config: str):
             # it has failed twice, ideally we want people to look at it now
             # do something here
 
+    remove_lock(lockname)
+
 
 def get_parser(parser=None):
     if parser is None:
         parser = argparse.ArgumentParser()
-    parser.add_argument('config', type=str, help="Path to imprinter configuration file")
+    parser.add_argument(
+        'config', 
+        type=str, 
+        help="Path to imprinter configuration file"
+    )
     parser.add_argument('output_root', type=str, help="Root path of the books")
     return parser
 

--- a/sotodlib/site_pipeline/update_book_plan.py
+++ b/sotodlib/site_pipeline/update_book_plan.py
@@ -69,6 +69,7 @@ def main(
         max_ctime = max_ctime.timestamp()
 
     # obs and oper books
+    logger.info("Registering obs/oper Books")
     imprinter.update_bookdb_from_g3tsmurf(
         min_ctime=min_ctime, max_ctime=max_ctime,
         ignore_singles=False,
@@ -92,16 +93,19 @@ def main(
         max_ctime_timecodes = max_ctime_timecodes.timestamp()
 
     # hk books
+    logger.info("Registering any HK Books")
     imprinter.register_hk_books(
         min_ctime=min_ctime_timecodes, 
         max_ctime=max_ctime_timecodes,
     )
     # smurf and stray books
+    logger.info("Registering any timecode Books")
     imprinter.register_timecode_books(
         min_ctime=min_ctime_timecodes, 
         max_ctime=max_ctime_timecodes,
     )
 
+    logger.info("Sending Updates to monitor")
     monitor = None
     if "monitor" in imprinter.config:
         logger.info("Will send monitor information to Influx")

--- a/sotodlib/site_pipeline/update_book_plan.py
+++ b/sotodlib/site_pipeline/update_book_plan.py
@@ -20,6 +20,7 @@ def main(
     min_ctime_timecodes: Optional[float] = None,
     max_ctime_timecodes: Optional[float] = None,
     from_scratch: bool = False,
+    use_monitor=False,
     ):
     """
     Update the book plan database with new data from the g3tsmurf database.
@@ -49,6 +50,9 @@ def main(
         The maximum ctime to include in the book planor timecode (hk, smurf, stray) books, by default None
     from_scratch : bool, optional
         If True, start to search from beginning of time, by default False
+    use_monitor : bool
+        if True, will send monitor information to influx, set to false by
+        default so we can use identical config files for development
     """
     if stream_ids is not None:
         stream_ids = stream_ids.split(",")
@@ -105,9 +109,8 @@ def main(
         max_ctime=max_ctime_timecodes,
     )
 
-    logger.info("Sending Updates to monitor")
     monitor = None
-    if "monitor" in imprinter.config:
+    if use_monitor and "monitor" in imprinter.config:
         logger.info("Will send monitor information to Influx")
         try:
             monitor = Monitor.from_configs(
@@ -118,6 +121,7 @@ def main(
             monitor = None
 
     if monitor is not None:
+        logger.info("Sending Updates to monitor")
         record_book_counts(monitor, imprinter)
     
 
@@ -200,7 +204,8 @@ def get_parser(parser=None):
               "for timecode books",
         default=7
     )
-
+    parser.add_argument('--use-monitor', help="Send updates to influx",
+                        action="store_true")
     return parser
 
 

--- a/sotodlib/site_pipeline/update_book_plan.py
+++ b/sotodlib/site_pipeline/update_book_plan.py
@@ -20,7 +20,7 @@ def main(
     min_ctime_timecodes: Optional[float] = None,
     max_ctime_timecodes: Optional[float] = None,
     from_scratch: bool = False,
-    use_monitor=False,
+    use_monitor: bool = False,
     ):
     """
     Update the book plan database with new data from the g3tsmurf database.

--- a/sotodlib/site_pipeline/update_book_plan.py
+++ b/sotodlib/site_pipeline/update_book_plan.py
@@ -60,7 +60,8 @@ def main(
     imprinter = Imprinter(
         config, 
         db_args={'connect_args': {'check_same_thread': False}},
-        logger=logger
+        logger=logger,
+        make_db=from_scratch,
     )
     
     # leaving min_ctime and max_ctime as None will go through all available 

--- a/sotodlib/site_pipeline/update_g3thk_database.py
+++ b/sotodlib/site_pipeline/update_g3thk_database.py
@@ -27,8 +27,7 @@ def main(config=None, from_scratch=False, verbosity=2):
     elif verbosity == 3:
         logger.setLevel(logging.DEBUG)
 
-    cfgs = yaml.safe_load( open(config, "r"))
-    HK = G3tHk.from_configs(cfgs)
+    HK = G3tHk.from_configs(config)
 
     if from_scratch or HK.session.query(HKFiles).count()==0:
         logger.info("Building Database from Scratch, May take awhile")

--- a/sotodlib/site_pipeline/update_g3tsmurf_db.py
+++ b/sotodlib/site_pipeline/update_g3tsmurf_db.py
@@ -52,14 +52,16 @@ def main(config: Optional[str] = None, update_delay: float = 2,
     elif verbosity == 3:
         logger.setLevel(logging.DEBUG)
 
-    cfgs = load_configs( config )
-    SMURF = G3tSmurf.from_configs(cfgs)
-
     if from_scratch:
         logger.info("Building Database from Scratch, May take awhile")
         min_time = dt.datetime.utcfromtimestamp(int(1.6e9))
+        make_db = True
     else:
         min_time = dt.datetime.now() - dt.timedelta(days=update_delay)
+        make_db = False
+
+    cfgs = load_configs( config )
+    SMURF = G3tSmurf.from_configs(cfgs, make_db=make_db)
 
     monitor = None
     if use_monitor and "monitor" in cfgs:

--- a/sotodlib/site_pipeline/update_g3tsmurf_db.py
+++ b/sotodlib/site_pipeline/update_g3tsmurf_db.py
@@ -19,7 +19,7 @@ from sotodlib.io.datapkg_utils import load_configs
 
 def main(config: Optional[str] = None, update_delay: float = 2, 
          from_scratch: bool = False, verbosity: int = 2,
-         index_via_actions: bool=False, use_monitor=False):
+         index_via_actions: bool=False, use_monitor:bool=False):
     """
     Arguments
     ---------

--- a/sotodlib/site_pipeline/update_g3tsmurf_db.py
+++ b/sotodlib/site_pipeline/update_g3tsmurf_db.py
@@ -71,18 +71,30 @@ def main(config: Optional[str] = None, update_delay: float = 2,
 
     updates_start = dt.datetime.now().timestamp()
 
-    SMURF.index_metadata(min_ctime=min_time.timestamp())
-    SMURF.index_archive(min_ctime=min_time.timestamp(), show_pb=show_pb)
+    session = SMURF.Session()
+    SMURF.index_metadata(min_ctime=min_time.timestamp(), session=session)
+    SMURF.index_archive(
+        min_ctime=min_time.timestamp(), 
+        show_pb=show_pb, 
+        session=session
+    )
     if index_via_actions:
-        SMURF.index_action_observations(min_ctime=min_time.timestamp())    
-    SMURF.index_timecodes(min_ctime=min_time.timestamp())
-    SMURF.update_finalization(update_time=updates_start)
+        SMURF.index_action_observations(
+            min_ctime=min_time.timestamp(),
+            session=session
+        )    
+    SMURF.index_timecodes(
+        min_ctime=min_time.timestamp(),
+        session=session
+    )
+    SMURF.update_finalization(update_time=updates_start, session=session)
     SMURF.last_update = updates_start
 
-    session = SMURF.Session()
-
     new_obs = session.query(Observations).filter(
-        Observations.start >= min_time
+        or_(
+            Observations.start >= min_time,
+            Observations.start == None,
+        )
     ).all()
 
     for obs in new_obs:

--- a/sotodlib/site_pipeline/update_g3tsmurf_db.py
+++ b/sotodlib/site_pipeline/update_g3tsmurf_db.py
@@ -14,6 +14,7 @@ from typing import Optional
 
 from sotodlib.site_pipeline.monitor import Monitor
 from sotodlib.io.load_smurf import G3tSmurf, Observations, logger
+from sotodlib.io.datapkg_utils import load_configs
 
 
 def main(config: Optional[str] = None, update_delay: float = 2, 
@@ -48,7 +49,7 @@ def main(config: Optional[str] = None, update_delay: float = 2,
     elif verbosity == 3:
         logger.setLevel(logging.DEBUG)
 
-    cfgs = yaml.safe_load( open(config, "r"))
+    cfgs = load_configs( config )
     SMURF = G3tSmurf.from_configs(cfgs)
 
     if from_scratch:

--- a/sotodlib/site_pipeline/update_g3tsmurf_db.py
+++ b/sotodlib/site_pipeline/update_g3tsmurf_db.py
@@ -19,7 +19,7 @@ from sotodlib.io.datapkg_utils import load_configs
 
 def main(config: Optional[str] = None, update_delay: float = 2, 
          from_scratch: bool = False, verbosity: int = 2,
-         index_via_actions: bool=False):
+         index_via_actions: bool=False, use_monitor=False):
     """
     Arguments
     ---------
@@ -37,6 +37,9 @@ def main(config: Optional[str] = None, update_delay: float = 2,
         will be necessary for data older than Oct 2022 but creates concurancy 
         issues on systems (like the site) running automatic deletion of level 2 
         data.
+    use_monitor : bool
+        if True, will send monitor information to influx, set to false by
+        default so we can use identical config files for development
     """
     show_pb = True if verbosity > 1 else False
 
@@ -59,7 +62,7 @@ def main(config: Optional[str] = None, update_delay: float = 2,
         min_time = dt.datetime.now() - dt.timedelta(days=update_delay)
 
     monitor = None
-    if "monitor" in cfgs:
+    if use_monitor and "monitor" in cfgs:
         logger.info("Will send monitor information to Influx")
         try:
             monitor = Monitor.from_configs(cfgs["monitor"]["connect_configs"])
@@ -175,6 +178,8 @@ def get_parser(parser=None):
     parser.add_argument("--verbosity", help="increase output verbosity. 0:Error, 1:Warning, 2:Info(default), 3:Debug",
                         default=2, type=int)
     parser.add_argument('--index-via-actions', help="Look through action folders to create observations",
+                        action="store_true")
+    parser.add_argument('--use-monitor', help="Send updates to influx",
                         action="store_true")
     return parser
 


### PR DESCRIPTION
Large overhaul of data packaging. Parts of this running on site.

Things implemented in this PR:
* General
    * Add a load_configs function that accepts tags from either a file name or environment variable pointing to a file. This substitutes in tags so that we can more easily work inside and outside the docker environments. We can also use this for easily switching between to test environments.
    * Made the analogous updates to the site-pipeline-configs configuration files https://github.com/simonsobs/site-pipeline-configs/pull/64 
    * Setup instructions here: https://simonsobs.atlassian.net/wiki/spaces/PRO/pages/248972873/Site+Automation+Upkeep+Data+Packaging+and+Site+Pipeline#Building-a-personal-development-environment 
*  Imprinter related
    * database has to be explicitly told to start a new one (because I kept accidentally making new ones off bad paths)
    * book path building separated so that we don't have to find readout ids to generate a book path. removes unnecessary queries to G3tSMuRF
    * add configurable incompleteness timeouts to throw errors if things get too far behind
    * book.path is now relative to `output_root`
    * TODO ONCE DEPLOYED: make book.path relative to `output_root` in existing databases
* G3tSMuRF related
    * only runs initialization functions if the database is new
    * database has to be explicitly told to start a new one (because I kept accidentally making new ones off bad paths)
    * Change session management. SQLAlchemey recommends a structure that works out to ["one session per update script"](https://docs.sqlalchemy.org/en/20/orm/session_basics.html#when-do-i-construct-a-session-when-do-i-commit-it-and-when-do-i-close-it)  so change lots of functions to accept sessions and organize g3tsmurf updater to work like that.
    *  Have g3tsmurf updater also look for observations with None start time because that was happening occasionally and this way they get caught and automatically updated.
* bookbinding / make book
    * Do not bookbind into a folder that has files in it 
    * have set up individual work queues so, once implemented, make book can only have 1 instance running at once