### PR TITLE
Add ability to run on multiple subgroups

### DIFF
--- a/sotodlib/site_pipeline/preprocess_tod.py
+++ b/sotodlib/site_pipeline/preprocess_tod.py
@@ -134,7 +134,8 @@ def preprocess_tod(
         for gb, g in zip(group_by, group):
             if gb == 'detset':
                 dest_dataset += "_" + g
-            dest_dataset += "_" + gb + "_" + str(g)
+            else:
+                dest_dataset += "_" + gb + "_" + str(g)
         logger.info(f"Saving data to {dest_file}:{dest_dataset}")
         proc_aman.save(dest_file, dest_dataset, overwrite=overwrite)
 


### PR DESCRIPTION
This update allows us to run `site_pipeline.preprocess_tod` on multiple sub groups for example a config file that specifies:

```
subobs:
  use: ['wafer_slot','wafer.bandpass']
```

Will process the data in len(wafer_slot) x len(wafer.bandpass) subsets of detectors at a time. The logs for a single subset look like this:

```
108.230: Beginning run for obs_1704770693_satp1_1111111:['ws0', 'f090'] (INFO)
 117.809: Running flag_turnarounds (INFO)
Ranges(n=479864:rngs=28)
 119.300: Saving data to /so/home/msilvafe/shared_files/preprocess/satp1_test/preprocess_archive.h5:obs_1704770693_satp1_1111111_wafer_slot_ws0_wafer.bandpass_f090 (INFO)
 119.335: Saving to database under {'obs:obs_id': 'obs_1704770693_satp1_1111111', 'dataset': 'obs_1704770693_satp1_1111111_wafer_slot_ws0_wafer.bandpass_f090', 'dets:wafer_slot': 'ws0', 'dets:wafer.bandpass': 'f090'} (INFO)
```

And the manifestdb entry returned from `core.metadata.ManifestDb(archive).inspect()` for a single entry looks like:

```
{'_id': 2, 'filename': '/so/home/msilvafe/shared_files/preprocess/satp1_test/preprocess_archive.h5', 'obs:obs_id': 'obs_1704770693_satp1_1111111', 'dets:wafer_slot': 'ws0', 'dets:wafer.bandpass': 'f090', 'dataset': 'obs_1704770693_satp1_1111111_wafer_slot_ws0_wafer.bandpass_f090'}
```