### PR TITLE
Fix subgroup restart and cleanup logs msgs.

### DIFF
--- a/sotodlib/preprocess/core.py
+++ b/sotodlib/preprocess/core.py
@@ -401,7 +401,7 @@ class Pipeline(list):
         
         success = 'end'
         for step, process in enumerate(self):
-            self.logger.info(f"Running {process.name}")
+            self.logger.debug(f"Running {process.name}")
             process.process(aman, proc_aman)
             if run_calc:
                 process.calc_and_save(aman, proc_aman)

--- a/sotodlib/site_pipeline/preprocess_tod.py
+++ b/sotodlib/site_pipeline/preprocess_tod.py
@@ -277,7 +277,7 @@ def main(
             if x is None or len(x) == 0:
                 run_list.append( (obs, None) )
             elif len(x) != len(groups):
-                [groups.remove(a[f'dets:{group_by}']) for a in x]
+                [groups.remove([a[f'dets:{gb}'] for gb in group_by]) for a in x]
                 run_list.append( (obs, groups) )
 
     logger.info(f"Beginning to run preprocessing on {len(run_list)} observations")

--- a/sotodlib/tod_ops/flags.py
+++ b/sotodlib/tod_ops/flags.py
@@ -275,7 +275,6 @@ def get_turnaround_flags(aman, az=None, method='scanspeed', name='turnarounds',
         elif name in aman.flags:
             aman.flags[name] = ta_flag
         else:
-            print(ta_flag)
             aman.flags.wrap(name, ta_flag)   
     if method == 'az':
         ta_exp = RangesMatrix([ta_flag for i in range(aman.dets.count)])


### PR DESCRIPTION
This cleans up the logs:
- Removes a print from turnaround flagging
- Moves running <process> to debug instead of info log level

I tested this log-level + print statement running a single obs through preprocess_tod.main() in a jupyter nb.

It also fixes a bug in PR #804 that we didn't test for where it will fail when trying to find which obs + subobs to restart at when starting the preprocess_tod script running in "update mode" on an existing db. I've tested that this works on the satp3 database which I was running last night off of master post PR #804 merge and which failed when I tried to restart it this morning.