### PR TITLE
Add meta and det_info restriction.

### DIFF
--- a/sotodlib/site_pipeline/preprocess_tod.py
+++ b/sotodlib/site_pipeline/preprocess_tod.py
@@ -149,7 +149,8 @@ def preprocess_tod(
         if len(db.inspect(db_data)) == 0:
             db.add_entry(db_data, dest_file)
 
-def load_preprocess_det_select(obs_id, configs, context=None):
+def load_preprocess_det_select(obs_id, configs, context=None,
+                               dets=None, meta=None):
     """ Loads the metadata information for the Observation and runs through any
     data selection specified by the Preprocessing Pipeline.
 
@@ -160,16 +161,22 @@ def load_preprocess_det_select(obs_id, configs, context=None):
         `context.get_obs`
     configs: string or dictionary
         config file or loaded config directory
+    dets: dict
+        dets to restrict on from info in det_info. See context.get_meta.
+    meta: AxisManager
+        Contains supporting metadata to use for loading.
+        Can be pre-restricted in any way. See context.get_meta.
     """
     configs, context = _get_preprocess_context(configs, context)
     pipe = Pipeline(configs["process_pipe"], logger=logger)
     
-    meta = context.get_meta(obs_id)
+    meta = context.get_meta(obs_id, dets=dets, meta=meta)
     logger.info(f"Cutting on the last process: {pipe[-1].name}")
     pipe[-1].select(meta)
     return meta
 
-def load_preprocess_tod(obs_id, configs="preprocess_configs.yaml", context=None ):
+def load_preprocess_tod(obs_id, configs="preprocess_configs.yaml",
+                        context=None, dets=None, meta=None):
     """ Loads the saved information from the preprocessing pipeline and runs the
     processing section of the pipeline. 
 
@@ -182,10 +189,15 @@ def load_preprocess_tod(obs_id, configs="preprocess_configs.yaml", context=None 
         `context.get_obs`
     configs: string or dictionary
         config file or loaded config directory
+    dets: dict
+        dets to restrict on from info in det_info. See context.get_meta.
+    meta: AxisManager
+        Contains supporting metadata to use for loading.
+        Can be pre-restricted in any way. See context.get_meta.
     """
 
     configs, context = _get_preprocess_context(configs, context)
-    meta = load_preprocess_det_select(obs_id, configs=configs, context=context)
+    meta = load_preprocess_det_select(obs_id, configs=configs, context=context, dets=dets, meta=meta)
 
     if meta.dets.count == 0:
         logger.info(f"No detectors left after cuts in obs {obs_id}")


### PR DESCRIPTION
This adds the ability to restrict by passing a dets dictionary or meta AxisManager as can be done in ctx.get_obs and ctx.get_meta when running `site_pipline.preprocess_tod.load_preprocess_tod`

I tested this by running it as is now (where all wafers/dets are loaded at once) and then restricting after by 

```
aman.restrict('dets', aman.dets.vals[(aman.det_info.wafer_slot == 'ws0') & (aman.det_info.wafer.bandpass == 'f090')])
```

And confirmed that I had the same number of detectors at the end as if I ran with this new branch using:

```
aman = pt.load_preprocess_tod(oid, configs="/so/home/msilvafe/repos/site-pipeline-configs/satp1/preprocess_config_cmb.yaml",
                       dets={'wafer_slot':'ws0', 'wafer.bandpass':'f090'})
```