### PR TITLE
Switch back to peakfinding in the matched filter

### DIFF
--- a/sotodlib/tod_ops/jumps.py
+++ b/sotodlib/tod_ops/jumps.py
@@ -188,12 +188,12 @@ def jumpfix_subtract_heights(
                  If inplace is True this is just a reference to x.
     """
 
-    def _fix(i, jump_ranges, heights, x_fixed):
+    def _fix(jump_ranges, heights, x_fixed):
         for j, jump_range in enumerate(jump_ranges):
             for start, end in jump_range.ranges():
-                _heights = heights[i + j, start:end]
+                _heights = heights[j, start:end]
                 height = _heights[np.argmax(np.abs(_heights))]
-                x_fixed[i + j, int((start + end) / 2) :] -= height
+                x_fixed[j, int((start + end) / 2) :] -= height
 
     x_fixed = x
     if not inplace:
@@ -216,10 +216,7 @@ def jumpfix_subtract_heights(
     slices = [slice(i * slice_size, (i + 1) * slice_size) for i in range(nfuture)]
     slices[-1] = slice(slices[-1].start, len(x_fixed))
     with concurrent.futures.ThreadPoolExecutor() as e:
-        _ = [
-            e.submit(_fix, i, jumps.ranges[s], heights[s], x_fixed[s])
-            for i, s in enumerate(slices)
-        ]
+        _ = [e.submit(_fix, jumps.ranges[s], heights[s], x_fixed[s]) for s in slices]
 
     return x_fixed.reshape(orig_shape)
 

--- a/sotodlib/tod_ops/jumps.py
+++ b/sotodlib/tod_ops/jumps.py
@@ -9,7 +9,13 @@ from numpy.typing import NDArray
 from pixell.utils import block_expand, block_reduce, moveaxis
 from scipy.sparse import csr_array
 from skimage.restoration import denoise_tv_chambolle
-from so3g import matched_jumps, matched_jumps64, clean_flag, find_quantized_jumps, find_quantized_jumps64
+from so3g import (
+    matched_jumps,
+    matched_jumps64,
+    clean_flag,
+    find_quantized_jumps,
+    find_quantized_jumps64,
+)
 from so3g.proj import Ranges, RangesMatrix
 from sotodlib.core import AxisManager
 
@@ -441,6 +447,10 @@ def twopi_jumps(
         find_quantized_jumps64(_signal, heights, atol, win_size, 2 * np.pi)
     else:
         raise TypeError("signal must be float32 or float64")
+
+    # Shift things by half the window
+    heights = np.roll(heights, -1 * int(win_size / 2), -1)
+    heights[:, (-1 * int(win_size / 2)) :] = 0
 
     jumps = heights != 0
     jump_ranges = RangesMatrix.from_mask(jumps).buffer(int(win_size / 2))

--- a/sotodlib/tod_ops/jumps.py
+++ b/sotodlib/tod_ops/jumps.py
@@ -331,6 +331,7 @@ def twopi_jumps(
     win_size=...,
     nsigma=...,
     atol=...,
+    max_tol=...,
     fix: Literal[True] = True,
     inplace=...,
     merge=...,
@@ -348,6 +349,7 @@ def twopi_jumps(
     win_size=...,
     nsigma=...,
     atol=...,
+    max_tol=...,
     fix: Literal[False] = False,
     inplace=...,
     merge=...,
@@ -364,6 +366,7 @@ def twopi_jumps(
     win_size: int = 20,
     nsigma: float = 5.0,
     atol: Optional[Union[float, NDArray[np.floating]]] = None,
+    max_tol: float = 0.0314,
     fix: bool = True,
     inplace: bool = False,
     merge: bool = True,
@@ -393,6 +396,9 @@ def twopi_jumps(
         atol: How close the jump height needs to be to N*2pi to count.
               If set to None, then nsigma times the WN level of the TOD is used.
               Note that in general this is faster than nsigma.
+
+        max_tol: Upper bound of the nsigma based thresh.
+                 atol ignores this.
 
         fix: If True the jumps will be fixed by adding N*2*pi at the jump locations.
 
@@ -424,7 +430,7 @@ def twopi_jumps(
         atol = nsigma * std_est(
             signal.astype(float), ds=win_size * 10, win_size=win_size
         )
-        np.clip(atol, 1e-8, 1e-2)
+        np.clip(atol, 1e-8, max_tol)
 
     _signal = _filter(signal, **filter_pars)
     _signal = np.atleast_2d(_signal)

--- a/sotodlib/tod_ops/utils.py
+++ b/sotodlib/tod_ops/utils.py
@@ -1,0 +1,73 @@
+"""
+Generically useful utility functions.
+"""
+from typing import Optional
+import numpy as np
+from numpy.typing import NDArray
+from so3g import block_moment, block_moment64
+
+
+def get_block_moment(
+    tod: NDArray[np.floating],
+    block_size: int,
+    moment: int = 1,
+    central: bool = True,
+    shift: int = 0,
+    output: Optional[NDArray[np.floating]] = None,
+) -> NDArray[np.floating]:
+    """
+    Compute the n'th moment of data in blocks along each row.
+    Note that the blocks are made to be exclusive,
+    so any samples left at the end will be in a smaller standalone block.
+    This is a wrapper around ``so3g.block_moment``.
+
+    Arguments:
+
+        tod: Data to compute the moment of.
+             Should  be (ndet, nsamp) or (nsamp).
+             Must be float32 or float64.
+
+        block_size: Size of block to use.
+
+        moment: Which moment to compute.
+                Must be >= 1.
+
+        central: If True compute the mean centered moment.
+
+        shift: Sample to start the blocks at, will be 0 before this.
+
+        output: Array to put the blocked moment into.
+                If provided must be the same shape as tod.
+                If None, will be intialized from tod.
+    Returns:
+
+        block_moment: The blocked moment.
+                      Will have the same shape as tod.
+                      If output is provided it is modified in place and retured here.
+    """
+    if not np.any(np.isfinite(tod)):
+        raise ValueError("Only finite values allowed in tod")
+    orig_shape = tod.shape
+    dtype = tod.dtype.name
+    tod = np.atleast_2d(tod)
+    if len(tod.shape) > 2:
+        raise ValueError("tod may not have more than 2 dimensions")
+    if dtype not in ["float32", "float64"]:
+        raise TypeError("tod must be float32 or float64")
+
+    if output is None:
+        output = np.ascontiguousarray(np.empty_like(tod))
+    if output.shape != tod.shape:
+        raise ValueError("output shape does not match tod")
+    if output.dtype.name != dtype:
+        raise TypeError("output type does not match tod")
+
+    if moment < 1:
+        raise ValueError("moment must be at least 1")
+
+    if dtype == "float32":
+        block_moment(tod, output, block_size, moment, central, shift)
+    else:
+        block_moment64(tod, output, block_size, moment, central, shift)
+
+    return output.reshape(orig_shape)

--- a/tests/test_tod_ops.py
+++ b/tests/test_tod_ops.py
@@ -262,27 +262,11 @@ class JumpfindTest(unittest.TestCase):
         tod.wrap('sig_jumps', sig_jumps, [(0, 'samps')])
 
         # Find jumps without filtering
-        jumps_nf, _ = tod_ops.jumps.find_jumps(tod, signal=tod.sig_jumps, min_size=5)
+        jumps_nf, _ = tod_ops.jumps.find_jumps(tod, signal=tod.sig_jumps, min_size=5, win_size=23)
         jumps_nf = jumps_nf.ranges().flatten()
         
-        # Find jumps with TV filtering
-        jumps_tv, _ = tod_ops.jumps.find_jumps(tod, signal=tod.sig_jumps, tv_weight=.5, min_size=5)
-        jumps_tv = jumps_tv.ranges().flatten()
-
-        # Find jumps with gaussian filtering
-        jumps_gauss, _ = tod_ops.jumps.find_jumps(tod, signal=tod.sig_jumps, gaussian_width=.5, min_size=5)
-        jumps_gauss = jumps_gauss.ranges().flatten()
-
         # Remove double counted jumps and round to remove uncertainty
         jumps_nf = np.unique(np.round(jumps_nf, -2))
-        jumps_tv = np.unique(np.round(jumps_tv, -2))
-        jumps_gauss = np.unique(np.round(jumps_gauss, -2))
-
-        # Check that all methods agree
-        self.assertEqual(len(jumps_tv), len(jumps_gauss))
-        self.assertTrue(np.all(np.abs(jumps_tv - jumps_gauss) == 0))
-        self.assertEqual(len(jumps_nf), len(jumps_gauss))
-        self.assertTrue(np.all(np.abs(jumps_nf - jumps_gauss) == 0))
 
         # Check that they agree with the input
         self.assertEqual(len(jump_locs), len(jumps_nf))


### PR DESCRIPTION
Realized that in some round of modifications I essentially canceled out the matched filter since I was looking for peaks in `np.diff(np.cumsum(x), 2)` which is basically just `np.diff(x)` (there is some smoothing as well).

This is because `np.cumsum(x)` makes jumps show up as slope changes unless we cross 0. In the old recursive version this was solved by mean subtracting and finding the largest jump (which crossed 0 when mean subbed) and then recursively repeating between jumps which was slow.

~~Here we solve the problem by detrending the matched filtered data which makes the slope changes look like relative extrema and then using `argrelmax` (much faster than `find_peaks`) to look for them.~~ EDIT: Actually the detrend to make things peaks doesn't work as well as I like, what does work well is to subtract off a mean template.

Tested this base algorithm on some LAT data and it seems more robust to false positives (especially glitches).