### PR TITLE
Hwp metadata update

### DIFF
--- a/docs/hwp.rst
+++ b/docs/hwp.rst
@@ -67,11 +67,6 @@ Here's an annotated example of yaml config file:
   # Search range of reference slot
   ref_range: 0.1
 
-  # force to quad value
-  # 0: use measured quad value (default)
-  # 1: positive rotation direction, -1: negative rotation direction
-  force_quad: 0
-
 Data Loading
 ------------
 
@@ -159,7 +154,7 @@ There is a fucntion to output analyzed data with HDF5 metadata format.
 This is mainly used for make-hwp-solutions site pipeline element.
 ::
 
-   hwp_angle_tool.write_solution_h5(aman,h5_filename,h5_address)
+   hwp_angle_tool.make_solution(aman)
 
 .. _g3thwp-ref-section:
 
@@ -185,7 +180,11 @@ Class and function references should be auto-generated here.
     :noindex:
 
 .. autoclass:: G3tHWP
-    :members: write_solution_h5
+    :members: set_data
+    :noindex:
+
+.. autoclass:: G3tHWP
+    :members: make_solution
     :noindex:
 
 

--- a/sotodlib/hwp/g3thwp.py
+++ b/sotodlib/hwp/g3thwp.py
@@ -796,7 +796,7 @@ class G3tHWP():
         result = (interp > 0.999)
         return result
 
-    def set_data(self, tod, load_h5=True):
+    def set_data(self, tod, h5_filename=None):
         """
         Output HWP hk data as AxisManager format. The results are stored in HDF5 files.
         We save the copy of raw hwp encoder hk data into HDF5 file, to save time for
@@ -806,8 +806,8 @@ class G3tHWP():
         ----
         tod: AxisManager
 
-        load_h5:
-            If true, try to load raw encoder data from hdf5 file
+        h5_filename:
+            If this is not None, try to load raw encoder data from hdf5 file
 
         Notes
         -----
@@ -843,10 +843,11 @@ class G3tHWP():
 
         self.data = {}
         try:
-            if load_h5:
+            if h5_filename is not None:
                 logger.info('Loading raw encoder data from h5')
                 try:
-                    self.data = self._load_raw_axes(aman, output, h5_address)
+                    obs_id = tod.obs_info['obs_id']
+                    self.data = self._load_raw_axes(aman, h5_filename, obs_id)
                 except Exception as e:
                     logger.error(f"Exception '{e}' thrown while loading HWP data from h5. Attempt to load from hk.")
                     self.data = self.load_data(start, end)

--- a/sotodlib/hwp/g3thwp.py
+++ b/sotodlib/hwp/g3thwp.py
@@ -986,7 +986,7 @@ class G3tHWP():
             # version 1
             # calculate HWP angle
             try:
-                solved = solved | self.analyze(self.data, mod2pi=False, suffix=suffix)
+                solved.update(self.analyze(self.data, mod2pi=False, suffix=suffix))
             except Exception as e:
                 logger.error(
                     f"Exception '{e}' thrown while calculating HWP angle. Angle calculation failed.")

--- a/sotodlib/hwp/g3thwp.py
+++ b/sotodlib/hwp/g3thwp.py
@@ -91,17 +91,6 @@ class G3tHWP():
         self._encoder_disk_radius = self.configs.get(
             'encoder_disk_radius', 346.25)
 
-        # Method to determine the rotation direction
-        self._method_direction = self.configs.get('method_direction', 'quad')
-        assert self._method_direction in ['offcenter', 'pid', 'quad', 'scan', 'template']
-
-        # Forced direction value
-        # 0: use direction value using specified method (default)
-        # 1: positive rotation direction
-        # -1: negative rotation direction
-        self._force_direction = int(self.configs.get('force_direction', 0))
-        assert self._force_direction in [0, 1, -1], "force_direction must be 0, 1 or -1"
-
         # Output path + filename
         self._output = self.configs.get('output', None)
 
@@ -1027,24 +1016,6 @@ class G3tHWP():
             filled_flag = scipy.interpolate.interp1d(
                 solved['fast_time'+suffix], filled_flag, kind='linear', bounds_error=False)(tod.timestamps)
             aman['filled_flag'+suffix] = filled_flag.astype(bool)
-
-            if self._force_direction != 0:
-                logger.info('Correct rotation direction by force method')
-                solved['angle'+suffix] *= self._force_direction
-            else:
-                logger.info(f'Correct rotation direction by {self._method_direction} method')
-                try:
-                    method = self._method_direction + '_direction'
-                    if self._method_direction == 'quad':
-                        method += suffix
-                    if aman[method] == 0:
-                        logger.warning(f'Rotation direction by {self._method_direction} is not available. Skip.')
-                    else:
-                        solved['angle'+suffix] *= aman[method]
-                except Exception as e:
-                    logger.error(f"Exception '{e}' thrown while correcting rotation direction. Skip.")
-                    print(traceback.format_exc())
-
             aman['hwp_angle_ver1'+suffix] = np.mod(scipy.interpolate.interp1d(
                 solved['fast_time'+suffix], solved['angle'+suffix], kind='linear', bounds_error=False)(tod.timestamps), 2*np.pi)
 

--- a/sotodlib/hwp/hwp_angle_model.py
+++ b/sotodlib/hwp/hwp_angle_model.py
@@ -1,64 +1,69 @@
 import numpy as np
 
 
-def apply_hwp_angle_model(tod, hwp_solution_attr='hwp_solution', hwp_angle_model_attr='hwp_angle_model'):
+def apply_hwp_angle_model(tod, on_sign_ambiguous='fail'):
     """
-    Updates and returns the tod AxisManager after applying hwp angle model parameters.
+    Returns the tod AxisManager after applying hwp angle model parameters.
     hwp_angle_model correct the sign and offset of hwp_angle.
 
     hwp_angle_corrected = sign * hwp_angle + offset
 
     Args:
         tod: AxisManager
+        on_sign_ambiguous: Tolerance options for sign ambiguous
+            fail: raise an error if there is any sign ambiguous
+            pid: raise an error if pid sign does not exist
+            offcenter: raise an error if offcenter sign does not exist
 
     Returns:
-        tod: AxisManager containing new hwp_angle data
+        tod: AxisManager with hwp_angle attribute
     """
 
     telescope = tod.obs_info.telescope
     if "lat" in telescope:
         return tod
 
-    hwp = getattr(tod, hwp_solution_attr)
+    hwp = tod['hwp_solution']
 
-    # sign
-    # Relative sign between observations will be estimated from hwp_metadata by multiple methods
-    # sign matrix contains absolute sign correction factor for each relative sign estimation method.
-    # sign matrix will be loaded from hwp_angle_model
-    # We will be able to add "scan" and "template"
+    # sign matrix contains absolute sign correction factor for each
+    # relative sign estimators.
     sign_matrix = {
         'satp1': {'pid':  1, 'offcenter': -1, },
         'satp3': {'pid': -1, 'offcenter':  1, },
     }
 
-    # check available sign estimation methods
-    available_signs = []
-
     methods = ['pid', 'offcenter']
-    for method in methods:
-        _sign = getattr(hwp, method + '_direction')
-        if _sign != 0:
-            available_signs.append(_sign*sign_matrix[telescope][method])
+    if on_sign_ambiguous in methods:
+        sign = hwp[on_sign_ambiguous + '_direction']
+        sign *= sign_matrix[telescope][on_sign_ambiguous]
+        if sign == 0:
+            raise ValueError('hwp rotation direction is ambiguous')
+    elif on_sign_ambiguous == 'fail':
+        available_signs = []
+        for method in methods:
+            _sign = hwp[method + '_direction']
+            if _sign != 0:
+                available_signs.append(_sign*sign_matrix[telescope][method])
 
-    # check agreements of available estimation methods
-    if len(available_signs) == 0:
-        print('WARNING: relative hwp rotation direction is ambiguous')
-        sign = 1.
-    if np.all(np.array(available_signs) == available_signs[0]):
-        sign = available_signs[0]
+        # check agreements of available estimation methods
+        if len(available_signs) == 0:
+            raise ValueError('hwp rotation direction is ambiguous')
+        if np.all(np.array(available_signs) == available_signs[0]):
+            sign = available_signs[0]
+        else:
+            raise ValueError('hwp rotation direction is ambiguous')
     else:
-        print('WARNING: relative hwp rotation direction is ambiguous')
-        sign = 1.
+        raise ValueError('Invalid on_sign_ambiguous')
 
-    # offset (degree). Convert to radian when we apply correction
+    # angle offset (degree).
     # Mechanically determined offsets
     encoder_offset = -1.66
     encoder_assembly_offset = {
         'satp1': {1: -90, 2: 90},
         'satp3': {1: 90, 2: -90},
     }
-    # offset of the optical axis of the achromatic hwp
-    # this needs to be calibrated optically, this will be loaded from hwp_angle_model
+    # angle offset of the optical axis of the achromatic hwp
+    # This will be loaded from hwp_angle_model metadata
     ahwp_offset = {
         'satp1': 49.1,
         'satp3': -2.29,
@@ -69,7 +74,10 @@ def apply_hwp_angle_model(tod, hwp_solution_attr='hwp_solution', hwp_angle_model
         ahwp_offset[telescope]
 
     # apply correction
-    tod.hwp_angle = np.mod(
-        sign*tod.hwp_angle + np.deg2rad(offset), 2*np.pi)
+    hwp_angle = np.mod(sign*hwp.hwp_angle + np.deg2rad(offset), 2*np.pi)
+    if 'hwp_angle' in tod._assignments.keys():
+        tod.hwp_angle = hwp_angle
+    else:
+        tod.wrap('hwp_angle', hwp_angle, [(0, "samps")])
 
     return tod

--- a/sotodlib/hwp/hwp_angle_model.py
+++ b/sotodlib/hwp/hwp_angle_model.py
@@ -70,6 +70,6 @@ def apply_hwp_angle_model(tod, band='f090', hwp_solution_attr='hwp_solution', hw
 
     # apply correction
     tod.hwp_angle = np.mod(
-        sign*np.unwrap(tod.hwp_angle) + np.deg2rad(offset), 2*np.pi)
+        sign*tod.hwp_angle + np.deg2rad(offset), 2*np.pi)
 
     return tod

--- a/sotodlib/hwp/hwp_angle_model.py
+++ b/sotodlib/hwp/hwp_angle_model.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 
-def apply_hwp_angle_model(tod, band='f090', hwp_solution_attr='hwp_solution', hwp_angle_model_attr='hwp_angle_model'):
+def apply_hwp_angle_model(tod, hwp_solution_attr='hwp_solution', hwp_angle_model_attr='hwp_angle_model'):
     """
     Updates and returns the tod AxisManager after applying hwp angle model parameters.
     hwp_angle_model correct the sign and offset of hwp_angle.
@@ -60,13 +60,13 @@ def apply_hwp_angle_model(tod, band='f090', hwp_solution_attr='hwp_solution', hw
     # offset of the optical axis of the achromatic hwp
     # this needs to be calibrated optically, this will be loaded from hwp_angle_model
     ahwp_offset = {
-        'satp1': {'f090': 49.1, 'f150': 49.4},
-        'satp3': {'f090': -2.29, 'f150': -1.99},
+        'satp1': 49.1,
+        'satp3': -2.29,
     }
 
     offset = encoder_offset + \
         encoder_assembly_offset[telescope][hwp.primary_encoder] + \
-        ahwp_offset[telescope][band]
+        ahwp_offset[telescope]
 
     # apply correction
     tod.hwp_angle = np.mod(

--- a/sotodlib/hwp/hwp_angle_model.py
+++ b/sotodlib/hwp/hwp_angle_model.py
@@ -34,12 +34,11 @@ def apply_hwp_angle_model(tod, band='f090', hwp_solution_attr='hwp_solution', hw
     # check available sign estimation methods
     available_signs = []
 
-    _sign = getattr(hwp, 'pid_direction')
-    if _sign != 0:
-        available_signs.append(_sign*sign_matrix[telescope]['pid'])
-    _sign = np.sign(getattr(hwp, 'offcenter')[0])
-    if _sign != 0:
-        available_signs.append(_sign*sign_matrix[telescope]['offcenter'])
+    methods = ['pid', 'offcenter']
+    for method in methods:
+        _sign = getattr(hwp, method + '_direction')
+        if _sign != 0:
+            available_signs.append(_sign*sign_matrix[telescope][method])
 
     # check agreements of available estimation methods
     if len(available_signs) == 0:

--- a/sotodlib/hwp/hwp_angle_model.py
+++ b/sotodlib/hwp/hwp_angle_model.py
@@ -1,0 +1,76 @@
+import numpy as np
+
+
+def apply_hwp_angle_model(tod, band='f090', hwp_solution_attr='hwp_solution', hwp_angle_model_attr='hwp_angle_model'):
+    """
+    Updates and returns the tod AxisManager after applying hwp angle model parameters.
+    hwp_angle_model correct the sign and offset of hwp_angle.
+
+    hwp_angle_corrected = sign * hwp_angle + offset
+
+    Args:
+        tod: AxisManager
+
+    Returns:
+        tod: AxisManager containing new hwp_angle data
+    """
+
+    telescope = tod.obs_info.telescope
+    if "lat" in telescope:
+        return tod
+
+    hwp = getattr(tod, hwp_solution_attr)
+
+    # sign
+    # Relative sign between observations will be estimated from hwp_metadata by multiple methods
+    # sign matrix contains absolute sign correction factor for each relative sign estimation method.
+    # sign matrix will be loaded from hwp_angle_model
+    # We will be able to add "scan" and "template"
+    sign_matrix = {
+        'satp1': {'pid':  1, 'offcenter': -1, },
+        'satp3': {'pid': -1, 'offcenter':  1, },
+    }
+
+    # check available sign estimation methods
+    available_signs = []
+
+    _sign = getattr(hwp, 'pid_direction')
+    if _sign != 0:
+        available_signs.append(_sign*sign_matrix[telescope]['pid'])
+    _sign = np.sign(getattr(hwp, 'offcenter')[0])
+    if _sign != 0:
+        available_signs.append(_sign*sign_matrix[telescope]['offcenter'])
+
+    # check agreements of available estimation methods
+    if len(available_signs) == 0:
+        print('WARNING: relative hwp rotation direction is ambiguous')
+        sign = 1.
+    if np.all(np.array(available_signs) == available_signs[0]):
+        sign = available_signs[0]
+    else:
+        print('WARNING: relative hwp rotation direction is ambiguous')
+        sign = 1.
+
+    # offset (degree). Convert to radian when we apply correction
+    # Mechanically determined offsets
+    encoder_offset = -1.66
+    encoder_assembly_offset = {
+        'satp1': {1: -90, 2: 90},
+        'satp3': {1: 90, 2: -90},
+    }
+    # offset of the optical axis of the achromatic hwp
+    # this needs to be calibrated optically, this will be loaded from hwp_angle_model
+    ahwp_offset = {
+        'satp1': {'f090': 49.1, 'f150': 49.4},
+        'satp3': {'f090': -2.29, 'f150': -1.99},
+    }
+
+    offset = encoder_offset + \
+        encoder_assembly_offset[telescope][hwp.primary_encoder] + \
+        ahwp_offset[telescope][band]
+
+    # apply correction
+    tod.hwp_angle = np.mod(
+        sign*np.unwrap(tod.hwp_angle) + np.deg2rad(offset), 2*np.pi)
+
+    return tod

--- a/sotodlib/site_pipeline/make_hwp_solutions.py
+++ b/sotodlib/site_pipeline/make_hwp_solutions.py
@@ -186,7 +186,7 @@ def main(
         obs_id = obs["obs_id"]
         logger.info(f"Calculating Angles for {obs_id}")
         ctx = core.Context(context)
-        tod = ctx.get_obs(obs, no_signal=True)
+        tod = ctx.get_obs(obs, dets=[])
 
         # split h5 file by first 5 digits of unixtime
         unix = obs_id.split('_')[1][:5]

--- a/sotodlib/site_pipeline/make_hwp_solutions.py
+++ b/sotodlib/site_pipeline/make_hwp_solutions.py
@@ -5,6 +5,7 @@ This script will run:
 2. New versions of the metadata can be created as the analysis evolves.
 """
 import os
+import time
 import argparse
 import logging
 import yaml
@@ -200,12 +201,12 @@ def main(
             aman_encoder = g3thwp.set_data(tod, h5_filename = h5_encoder)
         else:
             aman_encoder = g3thwp.set_data(tod)
-        logger.info(f"Saving hwp_encoder")
+        logger.info("Saving hwp_encoder")
         save(aman_encoder, db_encoder, h5_encoder, obs_id, overwrite, 'gzip')
         del aman_encoder
 
         aman_solution = g3thwp.make_solution(tod)
-        logger.info(f"Saving hwp_angle")
+        logger.info("Saving hwp_angle")
         save(aman_solution, db_solution, h5_solution, obs_id, overwrite, 'gzip')
         del aman_solution
         del g3thwp

--- a/sotodlib/site_pipeline/make_hwp_solutions.py
+++ b/sotodlib/site_pipeline/make_hwp_solutions.py
@@ -188,18 +188,27 @@ def main(
         ctx = core.Context(context)
         tod = ctx.get_obs(obs, no_signal=True)
 
-        # make angle solutions
-        g3thwp = G3tHWP(HWPconfig)
-        aman_encoder = g3thwp.set_data(tod, load_h5=load_h5)
-        aman_solution = g3thwp.make_solution(tod)
-        del g3thwp
-
         # split h5 file by first 5 digits of unixtime
         unix = obs_id.split('_')[1][:5]
+        h5_encoder = os.path.join(output_dir, f'hwp_encoder_{unix}.h5')
+        h5_solution = os.path.join(output_dir, f'hwp_angle_{unix}.h5')
+
+        # make angle solutions
+        g3thwp = G3tHWP(HWPconfig)
+
+        if load_h5:
+            aman_encoder = g3thwp.set_data(tod, h5_filename = h5_encoder)
+        else:
+            aman_encoder = g3thwp.set_data(tod)
         logger.info(f"Saving hwp_encoder")
-        save(aman_encoder, db_encoder, os.path.join(output_dir, f'hwp_encoder_{unix}.h5'), obs_id, overwrite, 'gzip')
+        save(aman_encoder, db_encoder, h5_encoder, obs_id, overwrite, 'gzip')
+        del aman_encoder
+
+        aman_solution = g3thwp.make_solution(tod)
         logger.info(f"Saving hwp_angle")
-        save(aman_solution, db_solution, os.path.join(output_dir, f'hwp_angle_{unix}.h5'), obs_id, overwrite, 'gzip')
+        save(aman_solution, db_solution, h5_solution, obs_id, overwrite, 'gzip')
+        del aman_solution
+        del g3thwp
 
     return
 


### PR DESCRIPTION
This PR updates hwp_angles metadata and implement apply_hwp_angle_model

- Add draft of apply_hwp_angle_model https://github.com/simonsobs/sotodlib/discussions/735
  - We still need to implemenet hwp_angle_model metadata
  - Previously make_hwp_solution was correcting relative hwp rotation direction between observations using configured method, but removed this correction from make_hwp_solution to implement more robust correction in apply_hwp_angle_model
- Add sotodlib version to hwp_angles metadata https://github.com/simonsobs/sotodlib/issues/776
- Split hwp_angles metadata more https://simonsobs.slack.com/archives/C05K7CSFTPX/p1712183463493169
  - This is necessary for more efficient hwp metadata data transfer
  - Save fast/slow data into different HDF5 files.
  - Split HDF5 file by first 4 digits of unixtime -> 5 digits for unixtime.