### PR TITLE
Updates to preprocess_obs and SSOFootprint

### DIFF
--- a/docs/preprocess.rst
+++ b/docs/preprocess.rst
@@ -162,6 +162,8 @@ A configuration file for the processing pipeline would look like::
     process_pipe:
         - name: "sso_footprint"
           calc:
+            # If you want to search for nearby sources, exclude source_list
+            source_list: ['jupiter']
             distance: 20
             nstep: 100
           save: True

--- a/sotodlib/preprocess/core.py
+++ b/sotodlib/preprocess/core.py
@@ -219,6 +219,8 @@ def _expand(new, full, wrap_valid=True):
             new.dets, 
             return_slices=True
         )
+    else:
+        fs_dets = range(full.dets.count)
     if 'samps' in new._axes:
         _, fs_samps, ns_samps = full.samps.intersection(
             new.samps, 

--- a/sotodlib/site_pipeline/preprocess_obs.py
+++ b/sotodlib/site_pipeline/preprocess_obs.py
@@ -166,7 +166,7 @@ def get_parser(parser=None):
     )
     parser.add_argument(
         '--tags',
-        help="Observation tags. Ex: --tags='jupiter=1'",
+        help="Observation tags. Ex: --tags 'jupiter' 'setting'",
         nargs='*',
         type=str
     )

--- a/sotodlib/site_pipeline/preprocess_obs.py
+++ b/sotodlib/site_pipeline/preprocess_obs.py
@@ -1,7 +1,10 @@
 import os
 import yaml
+import time
 import numpy as np
 import argparse
+import traceback
+from typing import Optional
 
 from sotodlib import core
 import sotodlib.site_pipeline.util as sp_util
@@ -154,21 +157,35 @@ def get_parser(parser=None):
         '--max-ctime',
         help="Maximum timestamp for the beginning of an observation list",
     )
+    parser.add_argument(
+        '--update-delay',
+        help="Number of days (unit is days) in the past to start observation list.",
+        type=int
+    )
+    parser.add_argument(
+        '--tags',
+        help="Observation tags. Ex: --tags='jupiter=1'",
+        nargs='+',
+        type=str
+    )
     return parser
 
 def main(
-    configs, 
-    query=None, 
-    obs_id=None, 
-    overwrite=False,
-    min_ctime=None,
-    max_ctime=None,
-    logger=None,
+    configs: str,
+    query: Optional[str] = None, 
+    obs_id: Optional[str] = None, 
+    overwrite: bool = False,
+    min_ctime: Optional[int] = None,
+    max_ctime: Optional[int] = None,
+    update_delay: Optional[int] = None,
+    tags: Optional[str] = None,
  ):
     configs, context = _get_preprocess_context(configs)
-    if logger is None: 
-        logger = sp_util.init_logger("preprocess")
-    globals()['logger'] = logger
+    logger = sp_util.init_logger("preprocess")
+    if (min_ctime is None) and (update_delay is not None):
+        # If min_ctime is provided it will use that..
+        # Otherwise it will use update_delay to set min_ctime.
+        min_ctime = int(time.time()) + update_delay
 
     if obs_id is not None:
         tot_query = f"obs_id=='{obs_id}'"
@@ -184,7 +201,7 @@ def main(
         if tot_query=="":
             tot_query="1"
     
-    obs_list = context.obsdb.query(tot_query)
+    obs_list = context.obsdb.query(tot_query, tags=tags)
     if len(obs_list)==0:
         logger.warning(f"No observations returned from query: {query}")
     run_list = []
@@ -202,7 +219,13 @@ def main(
     logger.info(f"Beginning to run preprocessing on {len(run_list)} observations")
     for obs in run_list:
         logger.info(f"Processing obs_id: {obs_id}")
-        preprocess_obs(obs["obs_id"], configs, overwrite=overwrite, logger=logger)
+        try:
+            preprocess_obs(obs["obs_id"], configs, overwrite=overwrite, logger=logger)
+        except Exception as e:
+            logger.info(f"{type(e)}: {e}")
+            logger.info(''.join(traceback.format_tb(e.__traceback__)))
+            logger.info(f'Skiping obs:{obs["obs_id"]} and moving to the next')
+            continue
             
 
 if __name__ == '__main__':

--- a/sotodlib/site_pipeline/preprocess_obs.py
+++ b/sotodlib/site_pipeline/preprocess_obs.py
@@ -167,7 +167,7 @@ def get_parser(parser=None):
     parser.add_argument(
         '--tags',
         help="Observation tags. Ex: --tags='jupiter=1'",
-        nargs='+',
+        nargs='*',
         type=str
     )
     return parser
@@ -203,6 +203,11 @@ def main(
         if tot_query=="":
             tot_query="1"
     
+    for i, tag in enumerate(tags):
+        tags[i] = tags[i].lower()
+        if '=' not in tags[i]:
+            tags[i] += '=1'
+
     obs_list = context.obsdb.query(tot_query, tags=tags)
     if len(obs_list)==0:
         logger.warning(f"No observations returned from query: {query}")

--- a/sotodlib/site_pipeline/preprocess_obs.py
+++ b/sotodlib/site_pipeline/preprocess_obs.py
@@ -91,7 +91,9 @@ def preprocess_obs(
     logger.info(f"Beginning run for {obs_id}")
 
     aman = context.get_obs(obs_id, no_signal=True)
-    proc_aman = pipe.run(aman)
+    proc_aman, success = pipe.run(aman)
+    if success != 'end':
+        return
 
     policy = sp_util.ArchivePolicy.from_params(configs['archive']['policy'])
     dest_file, dest_dataset = policy.get_dest(obs_id)


### PR DESCRIPTION
- Fixed `update_full_aman` (and `_expand`) in preprocess core to work with aman with no signal (no dets broke the function)
- Updates to `preprocess_obs` to add Prefect capability that was added to `preprocess_tod`
- Added `tags` argument to allow querying planet scans
- Updated SSOFootprint to allow provided source list in config file (as opposed to finding nearby sources)

@guanyilun after I test run this on multiple obs and after this gets merged, I'll PR to site-pipeline-configs to get this running on Prefect.