### PR TITLE
Deal with overlapping observations

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup_opts["entry_points"] = {
         "so_hardware_info = sotodlib.scripts.hardware_info:main",
         "so-metadata = sotodlib.core.metadata.cli:main",
         "so-site-pipeline = sotodlib.site_pipeline.cli:main",
+        "so-data-package = sotodlib.io.imprinter_cli:main",
         "toast_so_sim = sotodlib.toast.scripts.so_sim:cli",
         "toast_so_map = sotodlib.toast.scripts.so_map:cli",
         "toast_so_sat_transfer = sotodlib.toast.scripts.so_sat_transfer:cli",

--- a/sotodlib/io/bookbinder.py
+++ b/sotodlib/io/bookbinder.py
@@ -1024,14 +1024,20 @@ def get_hk_files(hkdir, start, stop, tbuff=10*60):
         files.extend([os.path.join(subpath, f) for f in os.listdir(subpath)])
 
     files = np.array(sorted(files))
-    file_times = np.array([int(os.path.basename(f).split('.')[0]) for f in files])
+    file_times = np.array(
+        [int(os.path.basename(f).split('.')[0]) for f in files]
+    )
 
     m = (start-tbuff <= file_times) & (file_times < stop+tbuff)
     if not np.any(m):
-        return []
-
+        check = np.where( file_times <= start )
+        if len(check) < 1:
+            raise ValueError("Cannot find HK files we need")
+        fidxs = [check[0][-1]]
+    else:
+        fidxs = np.where(m)[0]
     # Add files before and after for good measure
-    fidxs = np.where(m)[0]
+    
     i0, i1 = fidxs[0], fidxs[-1]
     if i0 > 0:
         m[i0 - 1] = 1

--- a/sotodlib/io/bookbinder.py
+++ b/sotodlib/io/bookbinder.py
@@ -23,6 +23,10 @@ class TimingSystemOff(Exception):
     """Exception raised when we try to bind books where the timing system is found to be off and the books have imprecise timing counters"""
     pass
 
+class NoScanFrames(Exception):
+    """Exception raised when we try and bind a book but the SMuRF file contains not Scan frames (so no detector data)"""
+    pass
+
 def setup_logger(logfile=None):
     """
     This setups up a logger for bookbinder. If a logfile is passed, it will
@@ -372,6 +376,8 @@ class SmurfStreamProcessor:
             self.nframes += 1
             frame_idx += 1
 
+        if len(ts) == 0:
+            raise NoScanFrames(f"{self.obs_id} has no detector data")
         self.times = np.hstack(ts)
         self.smurf_frame_counters = np.hstack(smurf_frame_counters)
         self.frame_idxs = np.hstack(frame_idxs)

--- a/sotodlib/io/datapkg_utils.py
+++ b/sotodlib/io/datapkg_utils.py
@@ -3,6 +3,15 @@ import yaml
 
 from ..core.util import tag_substr
 
+def get_tags(env_file=None, env_var="DATAPKG_ENV"):
+    if env_file is None:
+        env_file = os.environ.get(env_var)
+    if env_file is None:
+        tags = {}
+    else:
+        tags = yaml.safe_load( open(env_file, "r") )
+    return tags
+
 def load_configs(cfg_file, env_file=None, env_var="DATAPKG_ENV"):
     """ load a yaml config file and replace string paths tags
     
@@ -34,12 +43,7 @@ def load_configs(cfg_file, env_file=None, env_var="DATAPKG_ENV"):
         loaded configuration dictionary where all strings with tags have been
         replaced with the values loaded from the environment file
     """
-    if env_file is None:
-        env_file = os.environ.get(env_var)
-    if env_file is None:
-        tags = {}
-    else:
-        tags = yaml.safe_load( open(env_file, "r") )
+    tags = get_tags(env_file=env_file, env_var=env_var)
 
     configs = yaml.safe_load( open(cfg_file, "r"))
     try:
@@ -50,3 +54,12 @@ def load_configs(cfg_file, env_file=None, env_var="DATAPKG_ENV"):
             f"not found in environment file '{env_file}'"
         )
     return configs
+
+
+def get_imprinter_config( platform, env_file=None, env_var="DATAPKG_ENV"):
+    tags = get_tags(env_file=env_file, env_var=env_var)
+
+    if 'configs' not in tags:
+        raise ValueError(f"configs not found in tags {tags}")
+
+    return os.path.join( tags['configs'], platform, 'imprinter.yaml')

--- a/sotodlib/io/imprinter.py
+++ b/sotodlib/io/imprinter.py
@@ -621,9 +621,9 @@ class Imprinter:
 
     def _get_binder_for_book(self, 
         book, 
-        pbar=False, 
         ignore_tags=False,
         ancil_drop_duplicates=False,
+        allow_bad_timing=False
     ):
         """get the appropriate bookbinder for the book based on its type"""
         g3tsmurf_cfg = load_configs(self.g3tsmurf_config)
@@ -644,6 +644,7 @@ class Imprinter:
                 book, obsdb, filedb, lvl2_data_root, readout_ids, book_path,
                 ignore_tags=ignore_tags,
                 ancil_drop_duplicates=ancil_drop_duplicates,
+                allow_bad_timing=allow_bad_timing,
             )
             return bookbinder
 
@@ -743,6 +744,7 @@ class Imprinter:
         pbar=False,
         ignore_tags=False,
         ancil_drop_duplicates=False,
+        allow_bad_timing=False,
         check_configs={}
     ):
         """Bind book using bookbinder
@@ -764,6 +766,8 @@ class Imprinter:
         ancil_drop_duplicates: if true, will drop duplicate data from ancilary  
             files. added to deal with an ocs aggregator error. Only ever 
             expected to be turned on by hand.
+        allow_bad_timing: if true, will bind books even if the timing is low 
+            precision
         check_configs: dict
             additional non-default configurations to send to check book
         """
@@ -791,6 +795,7 @@ class Imprinter:
                 book, 
                 ignore_tags=ignore_tags,
                 ancil_drop_duplicates=ancil_drop_duplicates,
+                allow_bad_timing=allow_bad_timing,
             )
             binder.bind(pbar=pbar)
 

--- a/sotodlib/io/imprinter.py
+++ b/sotodlib/io/imprinter.py
@@ -62,6 +62,11 @@ class NoFilesError(Exception):
     """Exception raised when no files are found in the book"""
     pass
 
+class OverlapObsError(Exception):
+    """Exception raised when we find observations that could be registered to
+    multiple books"""
+    pass
+
 ###################
 # database schema #
 ###################
@@ -1335,6 +1340,16 @@ class Imprinter:
         # into the same book.
         if return_obsset:
             return output
+
+        # look for repeat obs_ids
+        obs_ids = []
+        [obs_ids.extend( o.obs_ids) for o in output]
+        if np.any([obs_ids.count(o) != 1 for o in obs_ids]):
+            repeats = np.where( [obs_ids.count(o) != 1 for o in obs_ids])[0]
+            raise OverlapObsError(f"Found repeated level 2 obs_ids in book "
+                    f"list. {np.unique([obs_ids[x] for x in repeats])} overlap "
+                    "multiple observations. Need to choose which books to put " 
+                    "them in.")
 
         # register books in the book database (bdb)
         for oset in output:

--- a/sotodlib/io/imprinter.py
+++ b/sotodlib/io/imprinter.py
@@ -1570,7 +1570,7 @@ class Imprinter:
         )
         return {o.obs_id: o for o in obs}
 
-    def upload_book_to_librarian(self, book, session=None):
+    def upload_book_to_librarian(self, book, session=None, raise_on_error=True):
         """Upload bound book to the librarian
 
         Parameters
@@ -1578,6 +1578,8 @@ class Imprinter:
         book: Book object
         session: imprinter sqlalchemy session
             session that made book
+        raise_on_error: bool
+            raise an error if the librarian throws an error on the upload
         """
 
         if session is None:
@@ -1593,6 +1595,7 @@ class Imprinter:
             self.librarian = LibrarianClient.from_info(conn)
         
         assert book.status == BOUND, "cannot upload unbound books"
+
         self.logger.info(f"Uploading book {book.bid} to librarian")
         try:     
             self.librarian.upload(
@@ -1605,7 +1608,12 @@ class Imprinter:
             self.logger.error(
                 f"Failed to upload book {book.bid}."
             )
-            raise e
+            if raise_on_error:
+                raise e
+            else:
+                return False, e
+        return True, None
+            
 
     def delete_level2_files(self, book, dry_run=True):
         """Delete level 2 data from already bound books

--- a/sotodlib/io/imprinter.py
+++ b/sotodlib/io/imprinter.py
@@ -1242,7 +1242,7 @@ class Imprinter:
             stream_filt,
             G3tObservations.stop < max_stop,
             not_(G3tObservations.stop == None),
-            G3tObservations.obs_id.notin_(already_registered),
+            G3tObservations.obs_id.not_in(already_registered),
         )
         self.logger.debug(
             f"Found {obs_q.count()} level 2 observations to consider"

--- a/sotodlib/io/imprinter_cli.py
+++ b/sotodlib/io/imprinter_cli.py
@@ -1,5 +1,7 @@
 """ Command-line interface for helping to clear out or clean up failed books. 
 
+Make sure you have the DATAPKG_ENV environment variable set to fill in the tags present in the site-pipeline-configs config files
+
 --action=failed: the script will cycle through failed books and
 give the option to retry binding (useful if software changes mean we expect the
 books to now be successfully bound), to skip binding those files (push
@@ -7,20 +9,8 @@ timestreams into the stray books), or do nothing.
 
 --action=timecodes: not implemented yet
 
-Additional Arguments for working with system running in a docker image (note
-that if we implement an environment variable prefix for the data-packaging
-system then this setup will be unnecessary):
-
---g3-config: point directly to the g3tsmurf configuration file. The site setup
-mounts the site-pipeline-configs folder into /config, when running this script
-outside of the docker container you have to override this imprinter configuration.
-
---output-root: the output root for the books when running outside the docker
-image. The docker container mounts /so/staged into /staged. Means when running
-outside the docker container you have to override this imprinter configuration
-AND fix the path in the imprinter database to match books made inside the docker
-container. 
 """
+
 import os
 import argparse
 from typing import Optional
@@ -28,41 +18,19 @@ from typing import Optional
 from sotodlib.io.imprinter import Imprinter, Books
 import sotodlib.io.imprinter_utils as utils
 
-def main(
-        imprint_config:str, 
-        action:str, 
-        g3_config:Optional[str]=None,
-        output_root:Optional[str]=None
-    ):
+def main():
+
+    parser = get_parser(parser=None)
+    args = parser.parse_args()
+
     print("You must be running this from an account with write permissions to"
          " the database and the book write directory.")
     
-    imprint = Imprinter(imprint_config)
-    ## overrides that often happen because running inside and outside dockers
-    if output_root is not None:
-        if not os.path.exists(output_root):
-            raise ValueError(f"Output root {output_root} does not exist")
-        imprint.docker_output_root = imprint.output_root
-        imprint.output_root = output_root
-        print(
-            f"Imprinter output root changed from {imprint.docker_output_root}"
-            f"to {imprint.output_root}"
-        )
-    else:
-        imprint.docker_output_root = None
-    if g3_config is not None:
-        if not os.path.exists(g3_config):
-            raise ValueError(f"G3tSmurf config file {g3_config} does not exist")
-        print(
-            f"Imprinter g3tsmurf config changed from {imprint.g3tsmurf_config}"
-            f"to {g3_config}"
-        )
-        imprint.g3tsmurf_config = g3_config
+    imprint = Imprinter.for_platform(args.platform)
 
-
-    if action == 'failed':
+    if args.action == 'failed':
         check_failed_books(imprint)
-    elif action == 'timecodes':
+    elif args.action == 'timecodes':
         raise NotImplementedError
     else:
         raise ValueError("Chosen action must be 'failed' or 'timecodes'")
@@ -102,16 +70,12 @@ def check_failed_books(imprint:Imprinter):
             ignore_tags = resp.lower() == 'y'
             resp = input("Drop Ancillary Duplicates? (y/n)")
             ancil_drop_duplicates = resp.lower() == 'y'
+            resp = input("Allow Low Precision Timing? (y/n)")
+            allow_bad_timing = resp.lower() == 'y'
             imprint.bind_book(
-                book, ignore_tags=ignore_tags, ancil_drop_duplicates=ancil_drop_duplicates
+                book, ignore_tags=ignore_tags, ancil_drop_duplicates=ancil_drop_duplicates,
+                allow_bad_timing=allow_bad_timing,
             )
-            if imprint.docker_output_root is not None:
-                book.path = book.path.replace(
-                    imprint.output_root, 
-                    imprint.docker_output_root
-                )
-                imprint.get_session().commit()
-                print(f"Updated book path to {book.path}")
         elif resp == 3:
             utils.set_book_wont_bind(imprint, book)
         elif resp == 4:
@@ -121,18 +85,20 @@ def check_failed_books(imprint:Imprinter):
 
 def get_parser(parser=None):
     if parser is None:
-        parser = argparse.ArgumentParser()
-    parser.add_argument("--imprint-config", help="Imprinter config file",
-        type=str, required=True)
-    parser.add_argument("--action", help=" 'failed' or 'timecodes' ",
-        type=str, required=True)
-    parser.add_argument("--g3-config", help="G3tSmurf config file",
-        type=str)
-    parser.add_argument("--output-root", help="Overide imprinter output root?",
-        type=str)
+        parser = argparse.ArgumentParser(
+            description="Make sure you have the DATAPKG_ENV environment "
+            "variable set to fill in the tags present in the "
+            "site-pipeline-configs config files. This includes the 'configs' " 
+            "tag pointing to your site-pipeline-configs directory"
+        )
+    parser.add_argument(
+        "platform", 
+        help="platform (lat, satp1, satp2, satp3)",
+        type=str
+    )
+    parser.add_argument(
+        "action", 
+        help=" 'failed' or 'timecodes' ",
+        type=str
+    )
     return parser
-
-if __name__ == '__main__':
-    parser = get_parser(parser=None)
-    args = parser.parse_args()
-    main(**vars(args))

--- a/sotodlib/io/imprinter_utils.py
+++ b/sotodlib/io/imprinter_utils.py
@@ -82,7 +82,13 @@ def find_overlaps(imprint, obs_id, min_ctime, max_ctime):
     books. Creates a list of ObsSets with that obs_id, prints info to screen and
     returns the list. imprinter then has a function
     imprinter.register_book(obsset, commit=True) that can be used to register
-    the desired observation
+    the desired observation. Example usage::
+
+        rsets = utils.find_overlaps(
+            imprint, 'obs_ufm_mv9_1714406208', <- obs id from error message
+            min_ctime, max_ctime
+        )
+        imprint.register_book( rsets[0], commit=True)
 
     obs_id: level 2 obs_id that overlaps multiple observations
     """

--- a/sotodlib/io/imprinter_utils.py
+++ b/sotodlib/io/imprinter_utils.py
@@ -107,6 +107,41 @@ def find_overlaps(imprint, obs_id, min_ctime, max_ctime):
 
     return rsets
 
+def block_fix_duplicate_timestamps(imprint):
+    """Run through and fix all the books with duplicated ancillary timestamps"""
+
+    failed_books = imprint.get_failed_books()
+    fix_list = []
+    for book in failed_books:
+        if "duplicate timestamps" in book.message:
+            fix_list.append(book)
+    imprint.logger.info(
+        f"Found {len(fix_list)} books with duplicate HK data to fix"
+    )
+
+    for book in fix_list:
+        imprint.logger.info(f"Setting book {book.bid} for rebinding")
+        set_book_rebind(imprint, book)
+        imprint.logger.info(
+            f"Binding book {book.bid} dropping duplicate HK data"
+        )
+        imprint.bind_book(book, ancil_drop_duplicates=True)
+
+def block_set_rebind(imprint):
+    """Run through and set all books with files errors to be rebound"""
+    
+    failed_books = imprint.get_failed_books()
+    
+    fix_list = []
+    for book in failed_books:
+        if "Delete to retry bookbinding" in book.message:
+            fix_list.append(book)
+    imprint.logger.info(
+        f"Found {len(fix_list)} books with files to be removed"
+    )
+    for book in fix_list:
+        imprint.logger.info(f"Setting book {book.bid} for rebinding")
+        set_book_rebind(imprint, book)    
 
 def get_timecode_final(imprint, time_code, type='all'):
     """Check if all required entries in the g3tsmurf database are present for

--- a/sotodlib/io/imprinter_utils.py
+++ b/sotodlib/io/imprinter_utils.py
@@ -82,6 +82,7 @@ def set_book_rebind(imprint, book, update_level2=False):
     if update_level2:
         g3session, SMURF = imprint.get_g3tsmurf_session(return_archive=True)
         obs_dict = imprint.get_g3tsmurf_obs_for_book(book)
+        print(f"Updating level 2 observations")
         for _, obs in obs_dict.items():
             SMURF.update_observation_files(obs, g3session, force=True)
 

--- a/sotodlib/io/imprinter_utils.py
+++ b/sotodlib/io/imprinter_utils.py
@@ -77,7 +77,31 @@ def set_book_rebind(imprint, book):
     book.status = UNBOUND
     imprint.get_session().commit()
 
-    
+def find_overlaps(imprint, obs_id, min_ctime, max_ctime):
+    """ helper function for when a level 2 observation could span multiple
+    books. Creates a list of ObsSets with that obs_id, prints info to screen and
+    returns the list. imprinter then has a function
+    imprinter.register_book(obsset, commit=True) that can be used to register
+    the desired observation
+
+    obs_id: level 2 obs_id that overlaps multiple observations
+    """
+    obsset = imprint.update_bookdb_from_g3tsmurf(
+        min_ctime=min_ctime, max_ctime=max_ctime,
+        return_obsset=True,
+    )
+    rsets = []
+    for o in obsset:
+        if obs_id in o.obs_ids:
+            rsets.append(o)
+    for i,r in enumerate(rsets):
+        print(f"-----ObsSet {i}----------")
+        for o in r:
+            print("\t", o)
+
+    return rsets
+
+
 def get_timecode_final(imprint, time_code, type='all'):
     """Check if all required entries in the g3tsmurf database are present for
     smurf or stray book regisitration.

--- a/sotodlib/site_pipeline/update_g3tsmurf_db.py
+++ b/sotodlib/site_pipeline/update_g3tsmurf_db.py
@@ -102,6 +102,7 @@ def main(config: Optional[str] = None, update_delay: float = 2,
         )
     ).all()
 
+    raise_list = []
     for obs in new_obs:
         if obs.stop is None or len(obs.tunesets)==0:
             SMURF.update_observation_files(
@@ -109,7 +110,9 @@ def main(config: Optional[str] = None, update_delay: float = 2,
                 session, 
                 force=True,
             )
-        
+        if not obs.timing:
+            raise_list.append( obs.obs_id)
+
         if monitor is not None:
             if obs.stop is not None:
                 try:
@@ -121,6 +124,10 @@ def main(config: Optional[str] = None, update_delay: float = 2,
                     logger.error(
                         f"Monitor Update failed for {obs.obs_id} with {e}"
                     )
+    if len(raise_list) > 0:
+        raise ValueError(
+            f"Found {len(raise_list)} observations with bad timing. obs_ids " f"are {raise_list}"
+        )
 
 def _obs_tags(obs, cfgs):
     

--- a/sotodlib/site_pipeline/update_g3tsmurf_db.py
+++ b/sotodlib/site_pipeline/update_g3tsmurf_db.py
@@ -110,7 +110,7 @@ def main(config: Optional[str] = None, update_delay: float = 2,
                 session, 
                 force=True,
             )
-        if not obs.timing:
+        if (obs.stop is not None) and (not obs.timing):
             raise_list.append( obs.obs_id)
 
         if monitor is not None:

--- a/sotodlib/site_pipeline/update_librarian.py
+++ b/sotodlib/site_pipeline/update_librarian.py
@@ -3,7 +3,9 @@ import datetime as dt
 from typing import Optional
 
 from sotodlib.io.imprinter import Imprinter, BOUND, UPLOADED
+from sotodlib.site_pipeline.util import init_logger
 
+logger = init_logger(__name__, "update_librarian: ")
 
 def main(config: str):
     """
@@ -23,8 +25,22 @@ def main(config: str):
     session = imprinter.get_session()
     to_upload = imprinter.get_bound_books(session=session)
 
+    failed_list = []
     for book in to_upload:
-        imprinter.upload_book_to_librarian(book, session=session)
+        success, err = imprinter.upload_book_to_librarian(
+            book, session=session, raise_on_error=False
+        )
+        if not success:
+            failed_list.append( (book.bid, err) )
+        ## don't just continually fail
+        if len(failed_list) > 5:
+            break
+    
+    if len(failed_list) != 0:
+        # raise the first error so we know something is wrong
+        logger.error(f"Failed to upload books {[f[0] for f in failed_list]}")
+        raise failed_list[0][1]
+
 
 
 

--- a/tests/test_bookbinder.py
+++ b/tests/test_bookbinder.py
@@ -78,14 +78,16 @@ class BookbinderTest(unittest.TestCase):
 
         in_ts, in_data = load_data(l2_files, data_name='data')
 
-        ts, mask = bb.fill_time_gaps(in_ts)
+        ts, mask = bb.fill_time_gaps(in_ts, allow_bad_timing=True)
         frame_idxs = np.zeros_like(ts, dtype=np.int32)
         file_idxs = np.zeros_like(np.unique(frame_idxs), dtype=np.int32)
 
         obsid = 'obsid'
         bookid = 'bookid'
         readout_ids = [str(i) for i in range(len(in_data))]
-        ssp = bb.SmurfStreamProcessor(obsid, l2_files, bookid, readout_ids)
+        ssp = bb.SmurfStreamProcessor(
+            obsid, l2_files, bookid, readout_ids, allow_bad_timing=False
+        )
         ssp.preprocess()
         ssp.bind(self.l3_dir, ts, frame_idxs, file_idxs)
 

--- a/tests/test_bookbinder.py
+++ b/tests/test_bookbinder.py
@@ -86,7 +86,7 @@ class BookbinderTest(unittest.TestCase):
         bookid = 'bookid'
         readout_ids = [str(i) for i in range(len(in_data))]
         ssp = bb.SmurfStreamProcessor(
-            obsid, l2_files, bookid, readout_ids, allow_bad_timing=False
+            obsid, l2_files, bookid, readout_ids, allow_bad_timing=True,
         )
         ssp.preprocess()
         ssp.bind(self.l3_dir, ts, frame_idxs, file_idxs)

--- a/tests/test_bookbinder.py
+++ b/tests/test_bookbinder.py
@@ -78,7 +78,7 @@ class BookbinderTest(unittest.TestCase):
 
         in_ts, in_data = load_data(l2_files, data_name='data')
 
-        ts, mask = bb.fill_time_gaps(in_ts, allow_bad_timing=True)
+        ts, mask = bb.fill_time_gaps(in_ts)
         frame_idxs = np.zeros_like(ts, dtype=np.int32)
         file_idxs = np.zeros_like(np.unique(frame_idxs), dtype=np.int32)
 


### PR DESCRIPTION
We ran into an issue today where one UFM streamed for ~3 hours while all the others were being turned off and on. This was an exact issue we'd said we "wouldn't deal with" but we need the drone data and the update functions were going to keep throwing errors about it. We can't automate a fix but this set of code makes it easier to manually fix these events. 

(1) the error is now a useful printout instead of just a uniqueness database constraint error
(2) we have a helper function to isolate the offending time range and make it easy to choose which book the overlapped observation goes in to. 
```
rsets = utils.find_overlaps(imprint, 'obs_ufm_mv9_1714406208', min_ctime, max_ctime)
imprint.register_book( rsets[0], commit=True)
```
(3) the update function now removes already registered level 2 observations from the search for new books to register (something I'd been thinking we should to for awhile and I'm pleasantly surprised at how easy it actually was to implement) 

------------------------
This PR now also includes a bunch of fixes for dealing with the timing system dropping out and improvements to the Imprinter CLI. For the timing system issues, books made with Low Precision timing should not be used for science analysis and so we want to clear them out but make sure they don't accidentally end up in obsdb queries that are expected to be useful. To achieve this we have the following changes:

* timing checks at level 2 now checks both counters are incrementing instead of just reading the "do you have counters" field.
* if a level 2 observation has low precision timing the tags are changed from `obs,cmb,things` to `obs,bad,bad_cmb,things,timing_issues`. Tags propagate all the way to the obsdb so that prevents the the books from being automatically categorized as cmb or cal. Similar things are done with operations
* update g3tsmurf throws errors if it finds low precision timing in complete observations
* books don't get bound automatically if low precision timing is there. they have to get flagged by hand. The by-hand time stamps are just using the linearized frame times

------------------------

Imprinter CLI is now much easier to use. Once installed on a system and with the correct environment variables set, we can just to `so-data-package platform failed` to cycle through and fix/catagorized failed book. Now we need to expand out the operations it can do beyond just fixing failed books

------------------------

Also added half the fix for ACU data missing in the drone calibration books. The bookbinder will now always expect to find HK data.