### PR TITLE
Adds the ability to overwrite existing fields.

### DIFF
--- a/sotodlib/core/axisman.py
+++ b/sotodlib/core/axisman.py
@@ -553,7 +553,6 @@ class AxisManager:
     # Add and remove data while maintaining internal consistency.
 
     def wrap(self, name, data, axis_map=None,
-             accept_new=True, accept_merge=True,
              overwrite=False):
         """Add data into the AxisManager.
 
@@ -572,8 +571,8 @@ class AxisManager:
             index of the dimension being described, name is a string
             giving the name of an axis already described in the
             present object, and ax is an AxisInterface object.
-
-        overwrite (bool): If True then will write over existing data
+            
+          overwrite (bool): If True then will write over existing data
             in field ``name`` if present.
 
         """

--- a/sotodlib/core/axisman.py
+++ b/sotodlib/core/axisman.py
@@ -553,7 +553,8 @@ class AxisManager:
     # Add and remove data while maintaining internal consistency.
 
     def wrap(self, name, data, axis_map=None,
-             accept_new=True, accept_merge=True):
+             accept_new=True, accept_merge=True,
+             overwrite=False):
         """Add data into the AxisManager.
 
         Arguments:
@@ -572,7 +573,12 @@ class AxisManager:
             giving the name of an axis already described in the
             present object, and ax is an AxisInterface object.
 
+        overwrite (bool): If True then will write over existing data
+            in field ``name`` if present.
+
         """
+        if overwrite and (name in self._fields):
+            self.move(name, None)
         # Don't permit AxisManager reference loops!
         if isinstance(data, AxisManager):
             assert(id(self) not in data._managed_ids())

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -255,6 +255,20 @@ class TestAxisManager(unittest.TestCase):
         b.wrap('a', a)
         self.assertNotIn('a', a.b)
 
+    def test_180_overwrite(self):
+        dets = ['det0', 'det1', 'det2']
+        a1 = np.zeros((len(dets), 100))
+        a1[1, 10] = 1.
+        aman = core.AxisManager(core.LabelAxis('dets', dets),
+                                core.OffsetAxis('samps', a1.shape[1]))
+        aman.wrap('a1', a1, [(0, 'dets'), (1, 'samps')])
+        a2 = np.zeros((len(dets), 100))
+        a2[2, 11] = 1.
+        aman.wrap('a1', a2, [(0, 'dets'), (1, 'samps')],
+                  overwrite=True)
+        self.assertNotEqual(aman.a1[2,11], 0)
+        self.assertNotEqual(aman.a1[1,10], 1.)
+
     # Multi-dimensional restrictions.
 
     def test_200_multid(self):


### PR DESCRIPTION
Currently if you try to wrap a field into an axis manager which already exists it will fail, this adds an overwrite argument which will write over the existing data in that field if true.