### PR TITLE
fix: add in colon in jumpfixing that disapeared

### DIFF
--- a/sotodlib/tod_ops/jumps.py
+++ b/sotodlib/tod_ops/jumps.py
@@ -204,7 +204,7 @@ def jumpfix_subtract_heights(
             for start, end in jump_range.ranges():
                 _heights = heights[i + j, start:end]
                 height = _heights[np.argmax(np.abs(_heights))]
-                x_fixed[i + j, int((start + end) / 2)] -= height
+                x_fixed[i + j, int((start + end) / 2):] -= height
 
     x_fixed = x
     if not inplace:


### PR DESCRIPTION
I guess this disappeared at some point. Thanks to @ktcrowley for noticing.