### PR TITLE
get iir_params from tod.iir_params[`stream_id`]

### DIFF
--- a/sotodlib/tod_ops/filters.py
+++ b/sotodlib/tod_ops/filters.py
@@ -487,6 +487,8 @@ def iir_filter(freqs, tod, b=None, a=None, fscale=1., iir_params=None,
             iir_params = 'iir_params'
         if isinstance(iir_params, str):
             iir_params = tod[iir_params]
+        if isinstance(iir_params, core.AxisManager):
+            iir_params = iir_params[list(iir_params._fields)[1]]
         try:
             a = iir_params['a']
             b = iir_params['b']

--- a/sotodlib/tod_ops/filters.py
+++ b/sotodlib/tod_ops/filters.py
@@ -494,8 +494,9 @@ def iir_filter(freqs, tod, b=None, a=None, fscale=1., iir_params=None,
             iir_params = tod[iir_params]
         if 'a' not in list(iir_params._fields.keys()):
             # Check iir_param's uniformity
-            for _field, sub_iir_params in iir_params._fields.items():
-                if isinstance(sub_iir_params, core.AxisManager) and 'a' in list(sub_iir_params._fields.keys()):
+            for _field, _sub_iir_params in iir_params._fields.items():
+                if isinstance(_sub_iir_params, core.AxisManager) and 'a' in list(_sub_iir_params._fields.keys()):
+                    sub_iir_params = _sub_iir_params
                     if i == 0:
                         _a, _b, _fscale = sub_iir_params['a'], sub_iir_params['b'], sub_iir_params['fscale']
                     else:

--- a/sotodlib/tod_ops/filters.py
+++ b/sotodlib/tod_ops/filters.py
@@ -473,7 +473,12 @@ def iir_filter(freqs, tod, b=None, a=None, fscale=1., iir_params=None,
       If the filter parameters (b, a, fscale) are not passed in
       explicitly, they will be extracted from an AxisManager based on
       the argument iir_params, which must be a dict or AxisManager
-      with keys "b", "a", and "fscale", but note that:
+      with keys "b", "a", and "fscale", or an AxisManager including 
+      the sub-iir_params of each stream_id. In the later case, if 
+      the filter parameters of each stream_id is different,
+      raises an error.
+      
+      But note that:
 
       - If iir_params is a string, tod[iir_params] is used (and must
         be an AxisManager or dict).
@@ -488,7 +493,18 @@ def iir_filter(freqs, tod, b=None, a=None, fscale=1., iir_params=None,
         if isinstance(iir_params, str):
             iir_params = tod[iir_params]
         if 'a' not in list(iir_params._fields.keys()):
-            iir_params = iir_params[list(iir_params._fields)[1]]
+            # Check iir_param's uniformity
+            for _field, sub_iir_params in iir_params._fields.items():
+                if isinstance(sub_iir_params, core.AxisManager) and 'a' in list(sub_iir_params._fields.keys()):
+                    if i == 0:
+                        _a, _b, _fscale = sub_iir_params['a'], sub_iir_params['b'], sub_iir_params['fscale']
+                    else:
+                        if np.any(np.hstack([sub_iir_params['a'] != _a,
+                                             sub_iir_params['b'] != _b,
+                                             sub_iir_params['fscale'] != _fscale,])):
+                            raise ValueError('iir parameters are not uniform.')
+                    i += 1
+            iir_params = sub_iir_params
         try:
             a = iir_params['a']
             b = iir_params['b']

--- a/sotodlib/tod_ops/filters.py
+++ b/sotodlib/tod_ops/filters.py
@@ -487,7 +487,7 @@ def iir_filter(freqs, tod, b=None, a=None, fscale=1., iir_params=None,
             iir_params = 'iir_params'
         if isinstance(iir_params, str):
             iir_params = tod[iir_params]
-        if isinstance(iir_params, core.AxisManager):
+        if 'a' not in list(iir_params._fields.keys()):
             iir_params = iir_params[list(iir_params._fields)[1]]
         try:
             a = iir_params['a']


### PR DESCRIPTION
As the level3 data has iir_params one layer deeper than level2:

```
tod.iir_params
```
is
```
AxisManager(per_stream, ufm_mv22*)
```

So I modified defaulting lines of `tod_ops.filters.iir_filter`
From:
```
    if a is None:
        # Get params from TOD?
        if iir_params is None:
            iir_params = 'iir_params'
        if isinstance(iir_params, str):
            iir_params = tod[iir_params]
        try:
            a = iir_params['a']
            b = iir_params['b']
            fscale = iir_params['fscale']
```

To:
```
    if a is None:
        # Get params from TOD?
        if iir_params is None:
            iir_params = 'iir_params'
        if isinstance(iir_params, str):
            iir_params = tod[iir_params]
        if 'a' not in list(iir_params._fields.keys())::
            iir_params = iir_params[list(iir_params._fields)[1]]
        try:
            a = iir_params['a']
            b = iir_params['b']
            fscale = iir_params['fscale']
```

Then people can apply de-phasing filter just by:
```
iir_filt = tod_ops.filters.iir_filter(invert=True)
tod.signal = tod_ops.fourier_filter(tod, iir_filt)
```