### PR TITLE
Improvements to toast context loading plus small fixes

### DIFF
--- a/sotodlib/toast/ops/load_context.py
+++ b/sotodlib/toast/ops/load_context.py
@@ -100,7 +100,9 @@ class LoadContext(Operator):
 
     bands = List(list(), help="Only load this list of band values")
 
-    dets_select = Dict(dict(), help="The full detector selection dictionary to use")
+    dets_select = Dict(
+        dict(), help="The `dets` selection dictionary to pass to get_obs()"
+    )
 
     ax_times = Unicode(
         "timestamps",
@@ -230,12 +232,17 @@ class LoadContext(Operator):
 
     def _open_context(self):
         if self.context is None:
+            # The user did not specify a context- create a temporary
+            # one from the file
             return Context(self.context_file)
         else:
+            # Just return the user-specified context.
             return self.context
 
     def _close_context(self, ctx):
         if self.context is None:
+            # We previously created a context from a file.  Close
+            # / delete that now.
             del ctx
 
     @function_timer

--- a/sotodlib/toast/ops/mlmapmaker.py
+++ b/sotodlib/toast/ops/mlmapmaker.py
@@ -22,6 +22,12 @@ from toast.instrument_coords import xieta_to_quat, quat_to_xieta
 
 import so3g
 
+# The mapmaking tools import pixell.mpi, which will try to import
+# mpi4py if it is available, even if running on a login node.
+# Check to see if MPI is enabled in toast and if not, disable here.
+if not toast.mpi.use_mpi:
+    os.environ["DISABLE_MPI"] = "true"
+
 from ... import mapmaking as mm
 from ...core import AxisManager, IndexAxis, OffsetAxis, LabelAxis
 

--- a/sotodlib/toast/scripts/so_convert.py
+++ b/sotodlib/toast/scripts/so_convert.py
@@ -99,6 +99,7 @@ def main():
     operators = list()
     wrk.setup_load_data_books(operators)
     wrk.setup_load_data_hdf5(operators)
+    wrk.setup_load_data_context(operators)
     wrk.setup_save_data_books(operators)
     wrk.setup_save_data_hdf5(operators)
 
@@ -127,6 +128,7 @@ def main():
     data = toast.Data(comm=toast_comm)
     wrk.load_data_books(job, otherargs, runargs, data)
     wrk.load_data_hdf5(job, otherargs, runargs, data)
+    wrk.load_data_context(job, otherargs, runargs, data)
 
     # Save data
     wrk.save_data_books(job, otherargs, runargs, data)

--- a/sotodlib/toast/workflows/job.py
+++ b/sotodlib/toast/workflows/job.py
@@ -120,8 +120,8 @@ def setup_job(
                 else:
                     argparse_opts.extend([optkey, str(v)])
         if config_files is not None:
-            for conf in config_files:
-                argparse_opts.extend(["--config", conf])
+            argparse_opts.append("--config")
+            argparse_opts.extend(config_files)
 
     if parser is None:
         # Create a parser


### PR DESCRIPTION
- Add support for both collective and independent reading of data from the context.

- Add support for specifying the full detector selection dictionary.

- Add ability to apply preprocessing if a preprocessing config is specified.

- Avoid loading any data when distributing observations among process groups.

- In mlmapmaker wrapper, disable MPI in pixell if it is disabled in toast.  This prevents mpi4py imports on NERSC login nodes.

- Small fix in specifying workflow configs when running interactively.