### PR TITLE
Add sample-diff white noise estimates to workflow tools

### DIFF
--- a/docs/toast.rst
+++ b/docs/toast.rst
@@ -189,6 +189,9 @@ Here is a list of the supported high-level operations:
 .. autofunction:: sotodlib.toast.workflows.setup_flag_noise_outliers
 .. autofunction:: sotodlib.toast.workflows.flag_noise_outliers
 
+.. autofunction:: sotodlib.toast.workflows.setup_flag_diff_noise_outliers
+.. autofunction:: sotodlib.toast.workflows.flag_diff_noise_outliers
+
 .. autofunction:: sotodlib.toast.workflows.setup_mapmaker_filterbin
 .. autofunction:: sotodlib.toast.workflows.mapmaker_filterbin
 
@@ -203,6 +206,9 @@ Here is a list of the supported high-level operations:
 
 .. autofunction:: sotodlib.toast.workflows.setup_noise_estimation
 .. autofunction:: sotodlib.toast.workflows.noise_estimation
+
+.. autofunction:: sotodlib.toast.workflows.setup_diff_noise_estimation
+.. autofunction:: sotodlib.toast.workflows.diff_noise_estimation
 
 .. autofunction:: sotodlib.toast.workflows.setup_raw_statistics
 .. autofunction:: sotodlib.toast.workflows.raw_statistics

--- a/sotodlib/toast/workflows/__init__.py
+++ b/sotodlib/toast/workflows/__init__.py
@@ -39,6 +39,8 @@ from .proc_filters import (
 from .proc_flagging import (
     setup_flag_sso,
     flag_sso,
+    setup_flag_diff_noise_outliers,
+    flag_diff_noise_outliers,
     setup_flag_noise_outliers,
     flag_noise_outliers,
     setup_processing_mask,
@@ -49,7 +51,12 @@ from .proc_mapmaker_filterbin import setup_mapmaker_filterbin, mapmaker_filterbi
 from .proc_mapmaker_madam import setup_mapmaker_madam, mapmaker_madam
 from .proc_mapmaker_ml import setup_mapmaker_ml, mapmaker_ml
 from .proc_mapmaker import setup_mapmaker, mapmaker
-from .proc_noise_est import setup_noise_estimation, noise_estimation
+from .proc_noise_est import (
+    setup_diff_noise_estimation,
+    diff_noise_estimation,
+    setup_noise_estimation,
+    noise_estimation,
+)
 from .proc_characterize import (
     setup_raw_statistics,
     raw_statistics,

--- a/sotodlib/toast/workflows/proc_flagging.py
+++ b/sotodlib/toast/workflows/proc_flagging.py
@@ -156,6 +156,88 @@ def flag_noise_outliers(job, otherargs, runargs, data):
     ).apply(data)
 
 
+def setup_flag_diff_noise_outliers(operators):
+    """Add commandline args and operators for flagging white noise outliers.
+
+    Args:
+        operators (list):  The list of operators to extend.
+
+    Returns:
+        None
+
+    """
+    operators.append(
+        toast.ops.SignalDiffNoiseModel(
+            name="diff_noise_cut",
+            noise_model="diff_noise_cut",
+            enabled=False,
+        )
+    )
+    operators.append(
+        toast.ops.FlagNoiseFit(
+            name="diff_noise_cut_flag",
+            sigma_NET=5.0,
+            enabled=True,
+        )
+    )
+
+
+@workflow_timer
+def flag_diff_noise_outliers(job, otherargs, runargs, data):
+    """Flag detectors with outlier white noise properties.
+
+    Args:
+        job (namespace):  The configured operators and templates for this job.
+        otherargs (namespace):  Other commandline arguments.
+        runargs (namespace):  Job related runtime parameters.
+        data (Data):  The data container.
+
+    Returns:
+        None
+
+    """
+    log = toast.utils.Logger.get()
+    timer = toast.timing.Timer()
+    timer.start()
+
+    # Configured operators for this job
+    job_ops = job.operators
+
+    # If any operators are disabled, just return
+    all_enabled = job_ops.diff_noise_cut.enabled and job_ops.diff_noise_cut_flag.enabled
+    if not all_enabled:
+        log.info_rank(
+            "Noise-based cut of detectors disabled", comm=data.comm.comm_world
+        )
+        return
+
+    # Estimate noise.
+    log.info_rank(
+        "  Running noise estimation on raw data...", comm=data.comm.comm_world
+    )
+    job_ops.diff_noise_cut.apply(data)
+    log.info_rank(
+        "  Estimated raw data noise in", comm=data.comm.comm_world, timer=timer
+    )
+
+    # Flag detector outliers
+    job_ops.diff_noise_cut_flag.noise_model = job_ops.diff_noise_cut.noise_model
+    log.info_rank(
+        "  Running flagging of noise model outliers...", comm=data.comm.comm_world
+    )
+    job_ops.diff_noise_cut_flag.apply(data)
+    log.info_rank(
+        "  Flag raw noise model outliers in", comm=data.comm.comm_world, timer=timer
+    )
+
+    # Delete these temporary models
+    toast.ops.Delete(
+        meta=[
+            job_ops.diff_noise_cut.noise_model,
+        ]
+    ).apply(data)
+
+
 def setup_processing_mask(operators):
     """Add commandline args and operators for processing mask flagging.
 
@@ -168,7 +250,9 @@ def setup_processing_mask(operators):
     """
     operators.append(
         toast.ops.PixelsHealpix(
-            name="processing_mask_pixels", pixels="pixels_processing_mask", enabled=False
+            name="processing_mask_pixels",
+            pixels="pixels_processing_mask",
+            enabled=False,
         )
     )
     operators.append(toast.ops.ScanHealpixMask(name="processing_mask", enabled=False))
@@ -194,7 +278,9 @@ def processing_mask(job, otherargs, runargs, data):
     if job_ops.processing_mask.enabled:
         if job_ops.processing_mask_pixels.enabled:
             # We are using a custom pointing matrix
-            job_ops.processing_mask_pixels.detector_pointing = job_ops.det_pointing_radec
+            job_ops.processing_mask_pixels.detector_pointing = (
+                job_ops.det_pointing_radec
+            )
             job_ops.processing_mask.pixel_dist = "processing_mask_pixel_dist"
             job_ops.processing_mask.pixel_pointing = job_ops.processing_mask_pixels
         else:

--- a/sotodlib/toast/workflows/proc_noise_est.py
+++ b/sotodlib/toast/workflows/proc_noise_est.py
@@ -66,9 +66,7 @@ def noise_estimation(job, otherargs, runargs, data):
 
     if job_ops.noise_estim.enabled:
         # Estimate noise.
-        log.info_rank(
-            "  Building noise estimate...", comm=data.comm.comm_world
-        )
+        log.info_rank("  Building noise estimate...", comm=data.comm.comm_world)
         job_ops.noise_estim.apply(data)
         log.info_rank(
             "  Finished noise estimate in",
@@ -95,3 +93,45 @@ def noise_estimation(job, otherargs, runargs, data):
                 comm=data.comm.comm_world,
                 timer=timer,
             )
+
+
+def setup_diff_noise_estimation(operators):
+    """Add commandline args and operators for signal difference noise estimation.
+
+    Args:
+        operators (list):  The list of operators to extend.
+
+    Returns:
+        None
+
+    """
+    operators.append(
+        toast.ops.SignalDiffNoiseModel(
+            name="diff_noise_estim",
+            noise_model="diff_noise_estim",
+            enabled=False,
+        )
+    )
+
+
+@workflow_timer
+def diff_noise_estimation(job, otherargs, runargs, data):
+    """Estimate a simple white noise model for every detector.
+
+    This uses sample differences to estimate the white noise properties.
+
+    Args:
+        job (namespace):  The configured operators and templates for this job.
+        otherargs (namespace):  Other commandline arguments.
+        runargs (namespace):  Job related runtime parameters.
+        data (Data):  The data container.
+
+    Returns:
+        None
+
+    """
+    # Configured operators for this job
+    job_ops = job.operators
+
+    if job_ops.diff_noise_estim.enabled:
+        job_ops.diff_noise_estim.apply(data)


### PR DESCRIPTION
There are two instances of this operator:  one for flagging outliers prior to any processing, and one for quick noise estimation prior to mapmaking.