### PR TITLE
Exploration of sqlite performance

### DIFF
--- a/sotodlib/core/context.py
+++ b/sotodlib/core/context.py
@@ -147,9 +147,7 @@ class Context(odict):
                 db_file = os.path.abspath(db_file)
                 logger.info(f'Loading {key} from {self[key]} -> {db_file}.')
                 try:
-                    db = cls.from_file(
-                        db_file, force_new_db=False, readonly=(not readwrite)
-                    )
+                    db = cls.from_file(db_file, force_new_db=False)
                 except Exception as e:
                     logger.error(f'DB failure when loading {key} from {self[key]} -> {db_file}\n')
                     raise e

--- a/sotodlib/core/context.py
+++ b/sotodlib/core/context.py
@@ -130,7 +130,7 @@ class Context(odict):
             else:
                 self[k] = v
 
-    def reload(self, load_list='all'):
+    def reload(self, load_list='all', readwrite=False):
         """Load (or reload) certain databases associated with this dataset.
         (Note we don't load any per-observation metadata here.)
 
@@ -147,7 +147,9 @@ class Context(odict):
                 db_file = os.path.abspath(db_file)
                 logger.info(f'Loading {key} from {self[key]} -> {db_file}.')
                 try:
-                    db = cls.from_file(db_file, force_new_db=False)
+                    db = cls.from_file(
+                        db_file, force_new_db=False, readonly=(not readwrite)
+                    )
                 except Exception as e:
                     logger.error(f'DB failure when loading {key} from {self[key]} -> {db_file}\n')
                     raise e

--- a/sotodlib/core/metadata/__init__.py
+++ b/sotodlib/core/metadata/__init__.py
@@ -4,6 +4,7 @@
 """
 
 from .resultset import ResultSet
+from .common import sqlite_connect
 from .detdb import DetDb
 from .obsdb import ObsDb
 from .obsfiledb import ObsFileDb

--- a/sotodlib/core/metadata/common.py
+++ b/sotodlib/core/metadata/common.py
@@ -3,7 +3,7 @@ import gzip
 import os
 
 
-def sqlite_connect(filename=None, mode="w", timeout=1000):
+def sqlite_connect(filename=None, mode="w"):
     """Utility function for connecting to an sqlite3 DB.
 
     This provides a single function for opening an sqlite connection
@@ -30,8 +30,11 @@ def sqlite_connect(filename=None, mode="w", timeout=1000):
     # This timeout is in seconds.  If multiple processes are writing, they
     # might be blocked for a while until they get their turn.  This prevents
     # them from giving up too soon if other processes have a write lock.
-    # https://www.sqlite.org/pragma.html#pragma_busy_timeout
-    busy_time = timeout
+    timeout_env = os.getenv("SOTODLIB_SQLITE_TIMEOUT")
+    if timeout_env not in (None, ""):
+        busy_time = float(timeout_env)
+    else:
+        busy_time = 60
 
     # Journaling options
 

--- a/sotodlib/core/metadata/common.py
+++ b/sotodlib/core/metadata/common.py
@@ -41,7 +41,10 @@ def sqlite_connect(filename=None, mode="w", timeout=1000):
     # DB file and is safe to delete manually if one is sure that no processes
     # are accessing the DB.
     # https://www.sqlite.org/pragma.html#pragma_journal_mode
-    journal_mode = "persist"
+    if mode == "r":
+        journal_mode = "off"
+    else:
+        journal_mode = "persist"
 
     # Max size of the journal.  Although it is being overwritten repeatedly,
     # if it gets too large we purge it and recreate.  This should not happen
@@ -54,7 +57,10 @@ def sqlite_connect(filename=None, mode="w", timeout=1000):
     # Using "normal" instead of the default "full" can avoid potentially expensive
     # (on network filesystems) sync operations.
     # https://www.sqlite.org/pragma.html#pragma_synchronous
-    sync_mode = "normal"
+    if mode == "r":
+        sync_mode = "off"
+    else:
+        sync_mode = "normal"
 
     # Memory caching
 
@@ -81,11 +87,7 @@ def sqlite_connect(filename=None, mode="w", timeout=1000):
     conn.execute(f"pragma page_size={page_size}")
     conn.execute(f"pragma cache_size={n_cache_pages}")
 
-    if mode == "r":
-        # Read-only mode, all done.
-        return conn
-
-    # In write mode, set journaling / sync options
+    # Set journaling / sync options
     conn.execute(f"pragma journal_mode={journal_mode}")
     conn.execute(f"pragma journal_size_limit={journal_size}")
     conn.execute(f"pragma synchronous={sync_mode}")
@@ -95,6 +97,9 @@ def sqlite_connect(filename=None, mode="w", timeout=1000):
     # Hold temporary tables in memory.
     # https://www.sqlite.org/pragma.html#pragma_temp_store
     conn.execute("pragma temp_store=memory")
+
+    if mode == "r":
+        conn.execute("pragma query_only=true")
 
     return conn
 

--- a/sotodlib/core/metadata/common.py
+++ b/sotodlib/core/metadata/common.py
@@ -3,6 +3,102 @@ import gzip
 import os
 
 
+def sqlite_connect(filename=None, mode="w", timeout=1000):
+    """Utility function for connecting to an sqlite3 DB.
+
+    This provides a single function for opening an sqlite connection
+    consistently across the code base.  When connecting to a file on
+    disk we try to use options which will be more performant in the
+    situation where the DB is on a networked / shared filesystem and
+    being accessed from multiple processes.
+
+    Args:
+        filename (str):  The path on disk or None if using an
+            in-memory DB.
+        mode (str):  Either "r" or "w".
+
+    Returns:
+        (sqlite3.Connection):  The database connection.
+
+    """
+    if filename is None:
+        # Memory-backed DB
+        if mode == "r":
+            raise ValueError("Cannot open memory DB in read-only mode")
+        return sqlite3.connect(":memory:")
+
+    # This timeout is in seconds.  If multiple processes are writing, they
+    # might be blocked for a while until they get their turn.  This prevents
+    # them from giving up too soon if other processes have a write lock.
+    # https://www.sqlite.org/pragma.html#pragma_busy_timeout
+    busy_time = timeout
+
+    # Journaling options
+
+    # Persistent journaling mode.  File creation / deletion can be expensive
+    # on some filesystems.  This just writes some zeros to the header and
+    # leaves the file.  This journal is a "side car" file next to the original
+    # DB file and is safe to delete manually if one is sure that no processes
+    # are accessing the DB.
+    # https://www.sqlite.org/pragma.html#pragma_journal_mode
+    journal_mode = "persist"
+
+    # Max size of the journal.  Although it is being overwritten repeatedly,
+    # if it gets too large we purge it and recreate.  This should not happen
+    # for most normal operations.
+    # https://www.sqlite.org/pragma.html#pragma_journal_size_limit
+    journal_size = f"{10 * 1024 * 1024}"
+
+    # Disk synchronization options
+
+    # Using "normal" instead of the default "full" can avoid potentially expensive
+    # (on network filesystems) sync operations.
+    # https://www.sqlite.org/pragma.html#pragma_synchronous
+    sync_mode = "normal"
+
+    # Memory caching
+
+    # The default page size in modern sqlite is 4096 bytes, and should be fine.
+    # We set this explicitly to allow easy changing in the future or keeping it
+    # fixed if the default changes.
+    # https://www.sqlite.org/pragma.html#pragma_page_size
+    page_size = 4096
+
+    # The number of pages to cache in memory.  Setting this to a few MB of RAM
+    # can have substantial performance benefits.  Total will be number of pages
+    # times page size.
+    # https://www.sqlite.org/pragma.html#pragma_cache_size
+    n_cache_pages = 4000
+
+    # Open connection
+    if mode == "r":
+        connstr = f"file:{filename}?mode=ro"
+    else:
+        connstr = f"file:{filename}?mode=rwc"
+    conn = sqlite3.connect(connstr, uri=True, timeout=busy_time)
+
+    # Set cache sizes
+    conn.execute(f"pragma page_size={page_size}")
+    conn.execute(f"pragma cache_size={n_cache_pages}")
+
+    if mode == "r":
+        # Read-only mode, all done.
+        return conn
+
+    # In write mode, set journaling / sync options
+    conn.execute(f"pragma journal_mode={journal_mode}")
+    conn.execute(f"pragma journal_size_limit={journal_size}")
+    conn.execute(f"pragma synchronous={sync_mode}")
+
+    # Other tuning options
+
+    # Hold temporary tables in memory.
+    # https://www.sqlite.org/pragma.html#pragma_temp_store
+    conn.execute("pragma temp_store=memory")
+
+    return conn
+
+
 def sqlite_to_file(db, filename, overwrite=True, fmt=None):
     """Write an sqlite db to file.  Supports several output formats.
 
@@ -26,7 +122,7 @@ def sqlite_to_file(db, filename, overwrite=True, fmt=None):
     if fmt == 'sqlite':
         if os.path.exists(filename):
             os.remove(filename)
-        new_db = sqlite3.connect(filename)
+        new_db = sqlite_connect(filename=filename, mode='w')
         script = ' '.join(db.iterdump())
         new_db.executescript(script)
         new_db.commit()
@@ -51,7 +147,7 @@ def sqlite_from_file(filename, fmt=None, force_new_db=True):
       filename (str): path to the file.
       fmt (str): format of the input; see to_file for details.
       force_new_db (bool): Used if connecting to an sqlite database. If True the
-        databas is copied into memory and if False returns a connection to the 
+        databas is copied into memory and if False returns a connection to the
         database without reading it into memory
 
     """
@@ -60,7 +156,7 @@ def sqlite_from_file(filename, fmt=None, force_new_db=True):
         if filename.endswith('.gz'):
             fmt = 'gz'
     if fmt == 'sqlite':
-        db0 = sqlite3.connect(f'file:{filename}?mode=ro', uri=True)
+        db0 = sqlite_connect(filename=filename, mode="r")
         if not force_new_db:
             return db0
         data = ' '.join(db0.iterdump())
@@ -72,7 +168,7 @@ def sqlite_from_file(filename, fmt=None, force_new_db=True):
             data = fin.read().decode('utf-8')
     else:
         raise RuntimeError(f'Unknown format "{fmt}" requested.')
-    db = sqlite3.connect(':memory:')
+    db = sqlite_connect()
     db.executescript(data)
     return db
 

--- a/sotodlib/core/metadata/common.py
+++ b/sotodlib/core/metadata/common.py
@@ -21,7 +21,7 @@ def sqlite_connect(filename=None, mode="w", timeout=1000):
         (sqlite3.Connection):  The database connection.
 
     """
-    if filename is None:
+    if filename is None or filename == ":memory:":
         # Memory-backed DB
         if mode == "r":
             raise ValueError("Cannot open memory DB in read-only mode")

--- a/sotodlib/core/metadata/detdb.py
+++ b/sotodlib/core/metadata/detdb.py
@@ -71,7 +71,7 @@ class DetDb(object):
         "`time1` integer",
     ]
 
-    def __init__(self, map_file=None, init_db=True, readonly=False):
+    def __init__(self, map_file=":memory:", init_db=True, readonly=False):
         """Instantiate a DetDb.
 
         If map_file is provided, the database will

--- a/sotodlib/core/metadata/detdb.py
+++ b/sotodlib/core/metadata/detdb.py
@@ -71,18 +71,32 @@ class DetDb(object):
         "`time1` integer",
     ]
 
-    def __init__(self, map_file=None, init_db=True):
-        """Instantiate a DetDb.  If map_file is provided, the database will
+    def __init__(self, map_file=None, init_db=True, readonly=False):
+        """Instantiate a DetDb.
+
+        If map_file is provided, the database will
         be connected to the indicated sqlite file on disk, and any
         changes made to this object be written back to the file.
 
+        Args:
+            map_file (string): sqlite database file to map.  Defaults to
+                ':memory:'.
+            init_db (bool): If True, attempt to create the database
+                tables.
+            readonly (bool): If True, the database file will be mapped
+                in read-only mode.  Not valid on dbs held in :memory:.
+
         """
+        if init_db and readonly:
+            raise ValueError("Cannot initialize a read-only DB")
+        self._readonly = readonly
         if isinstance(map_file, sqlite3.Connection):
             self.conn = map_file
         else:
-            if map_file is None:
-                map_file = ':memory:'
-            self.conn = sqlite3.connect(map_file)
+            self.conn = common.sqlite_connect(
+                filename=map_file,
+                mode=("r" if readonly else "w"),
+            )
         self.conn.row_factory = sqlite3.Row  # access columns by name
 
         if init_db:
@@ -170,6 +184,8 @@ class DetDb(object):
           ]
 
         """
+        if self._readonly:
+            raise RuntimeError("Cannot use create_table() on a read-only DB")
         c = self.conn.cursor()
         pre_cols = self.TABLE_TEMPLATE
         if raw:
@@ -195,7 +211,7 @@ class DetDb(object):
             else:
                 raise RuntimeError("Output file %s exists (overwrite=True "
                                    "to overwrite)." % map_file)
-        new_db = DetDb(map_file=map_file, init_db=False)
+        new_db = DetDb(map_file=map_file, init_db=False, readonly=False)
         script = ' '.join(self.conn.iterdump())
         new_db.conn.executescript(script)
         return new_db
@@ -220,7 +236,7 @@ class DetDb(object):
             raise RuntimeError(f'File {filename} exists; remove or pass '
                                'overwrite=True.')
         if fmt == 'sqlite':
-            self.copy(map_file=filename, overwrite=overwrite)
+            _ = self.copy(map_file=filename, overwrite=overwrite)
         elif fmt == 'dump':
             with open(filename, 'w') as fout:
                 for line in self.conn.iterdump():
@@ -237,10 +253,10 @@ class DetDb(object):
         """This method calls
             :func:`sotodlib.core.metadata.common.sqlite_from_file`
         """
-        conn = common.sqlite_from_file(filename, fmt=fmt, 
+        conn = common.sqlite_from_file(filename, fmt=fmt,
                                        force_new_db=force_new_db)
         return cls(conn, init_db=False)
-        
+
 
     def reduce(self, dets=None, time0=None, time1=None,
                inplace=False):
@@ -262,7 +278,12 @@ class DetDb(object):
         Returns the reduced data (which is self, if inplace is True).
 
         """
-        if not inplace:
+        if inplace:
+            if self._readonly:
+                raise RuntimeError(
+                    "Cannot do inplace reduce of a read-only DB."
+                )
+        else:
             return self.copy().reduce(dets, time0, time1, inplace=True)
 
         time_clause = '0'
@@ -339,6 +360,8 @@ class DetDb(object):
         into the property table.
 
         """
+        if self._readonly:
+            raise RuntimeError("Cannot add_props() on a read-only DB")
         if time_range is None:
             time_range = self.ALWAYS
         row_id = self.get_id(name_, create=True, commit=False)

--- a/sotodlib/core/metadata/detdb.py
+++ b/sotodlib/core/metadata/detdb.py
@@ -205,7 +205,11 @@ class DetDb(object):
         of writing a Db to disk to call copy(map_file=...) and then
         simply discard the returned object.
         """
-        if map_file is not None and os.path.exists(map_file):
+        if (
+            map_file is not None and 
+            map_file != ":memory:" and
+            os.path.exists(map_file)
+        ):
             if overwrite:
                 os.remove(map_file)
             else:

--- a/sotodlib/core/metadata/manifest.py
+++ b/sotodlib/core/metadata/manifest.py
@@ -333,7 +333,7 @@ class ManifestDb:
         uninitialized.
 
         """
-        if scheme and readonly:
+        if scheme is not None and readonly:
             raise ValueError("Cannot initialize the schema of a read-only DB")
         self._readonly = readonly
         if isinstance(map_file, sqlite3.Connection):
@@ -341,16 +341,9 @@ class ManifestDb:
         else:
             if map_file is None:
                 map_file = ':memory:'
-
-            connect_args = {}
-            timeout_env = os.getenv('SOTODLIB_SQLITE_TIMEOUT')
-            if timeout_env not in (None, ''):
-                connect_args['timeout'] = int(timeout_env)
-
             self.conn = common.sqlite_connect(
                 filename=map_file,
                 mode=("r" if readonly else "w"),
-                **connect_args,
             )
         self.conn.row_factory = sqlite3.Row  # access columns by name
 
@@ -394,7 +387,7 @@ class ManifestDb:
         simply discard the returned object.
         """
         if (
-            map_file is not None and 
+            map_file is not None and
             map_file != ":memory:" and
             os.path.exists(map_file)
         ):

--- a/sotodlib/core/metadata/manifest.py
+++ b/sotodlib/core/metadata/manifest.py
@@ -393,7 +393,11 @@ class ManifestDb:
         of writing a Db to disk to call copy(map_file=...) and then
         simply discard the returned object.
         """
-        if map_file is not None and os.path.exists(map_file):
+        if (
+            map_file is not None and 
+            map_file != ":memory:" and
+            os.path.exists(map_file)
+        ):
             if overwrite:
                 os.remove(map_file)
             else:

--- a/sotodlib/core/metadata/manifest.py
+++ b/sotodlib/core/metadata/manifest.py
@@ -322,7 +322,7 @@ class ManifestDb:
     filename.
     """
 
-    def __init__(self, map_file=None, scheme=None):
+    def __init__(self, map_file=None, scheme=None, readonly=False):
         """Instantiate a database.  If map_file is provided, the
         database will be connected to the indicated sqlite file on
         disk, and any changes made to this object be written back to
@@ -333,6 +333,9 @@ class ManifestDb:
         uninitialized.
 
         """
+        if scheme and readonly:
+            raise ValueError("Cannot initialize the schema of a read-only DB")
+        self._readonly = readonly
         if isinstance(map_file, sqlite3.Connection):
             self.conn = map_file
         else:
@@ -342,10 +345,13 @@ class ManifestDb:
             connect_args = {}
             timeout_env = os.getenv('SOTODLIB_SQLITE_TIMEOUT')
             if timeout_env not in (None, ''):
-                connect_args['timeout'] = float(timeout_env)
+                connect_args['timeout'] = int(timeout_env)
 
-            self.conn = sqlite3.connect(map_file, **connect_args)
-
+            self.conn = common.sqlite_connect(
+                filename=map_file,
+                mode=("r" if readonly else "w"),
+                **connect_args,
+            )
         self.conn.row_factory = sqlite3.Row  # access columns by name
 
         if scheme is None:
@@ -393,7 +399,7 @@ class ManifestDb:
             else:
                 raise RuntimeError("Output file %s exists (overwrite=True "
                                    "to overwrite)." % map_file)
-        new_db = ManifestDb(map_file=map_file, scheme=False)
+        new_db = ManifestDb(map_file=map_file, scheme=False, readonly=False)
         script = ' '.join(self.conn.iterdump())
         new_db.conn.executescript(script)
         new_db.scheme = ManifestScheme.from_database(new_db.conn)
@@ -449,7 +455,7 @@ class ManifestDb:
           ManifestDb.
 
         """
-        conn = sqlite3.connect('file:%s?mode=ro' % filename, uri=True)
+        conn = common.sqlite_connect(filename=filename, mode="r")
         return cls(conn)
 
     def _get_file_id(self, filename, create=False):
@@ -461,6 +467,8 @@ class ManifestDb:
         row_id = c.fetchone()
         if row_id is None:
             if create:
+                if self._readonly:
+                    raise RuntimeError("Cannot add file_id to table in read-only DB")
                 c.execute('insert into files (name) values (?)', (filename,))
                 row_id = c.lastrowid
                 return row_id
@@ -571,6 +579,8 @@ class ManifestDb:
           match some single timestamp, are not caught here.
 
         """
+        if self._readonly:
+            raise RuntimeError("Cannot add_entry() in read-only DB")
         # Validate the input data.
         q, p = self.scheme.get_insertion_query(params)
         file_id = self._get_file_id(filename, create=create)
@@ -602,6 +612,8 @@ class ManifestDb:
           is set.
 
         """
+        if self._readonly:
+            raise RuntimeError("Cannot update_entry() in read-only DB")
         # Validate the input data.
         q, p = self.scheme.get_update_query(params)
         _id = params.get('_id')
@@ -626,6 +638,8 @@ class ManifestDb:
         be passed directly into this function.
 
         """
+        if self._readonly:
+            raise RuntimeError("Cannot remove_entry() in read-only DB")
         if isinstance(_id, dict):
             _id = _id['_id']
         c = self.conn.cursor()

--- a/sotodlib/core/metadata/obsdb.py
+++ b/sotodlib/core/metadata/obsdb.py
@@ -29,7 +29,7 @@ class ObsDb(object):
 
     """
 
-    def __init__(self, map_file=None, init_db=True, wafer_info=None):
+    def __init__(self, map_file=None, init_db=True, wafer_info=None, readonly=False):
         """Instantiate an ObsDb.
 
         Args:
@@ -54,12 +54,16 @@ class ObsDb(object):
           this object be written back to the file.
 
         """
+        if init_db and readonly:
+            raise ValueError("Cannot initialize a read-only DB")
+        self._readonly = readonly
         if isinstance(map_file, sqlite3.Connection):
             self.conn = map_file
         else:
-            if map_file is None:
-                map_file = ':memory:'
-            self.conn = sqlite3.connect(map_file)
+            self.conn = common.sqlite_connect(
+                filename=map_file,
+                mode=("r" if readonly else "w"),
+            )
 
         self.conn.row_factory = sqlite3.Row  # access columns by name
         if init_db:
@@ -77,14 +81,14 @@ class ObsDb(object):
                                     *(f"{k} varchar(256)" for k in pkeys),
                                     f"PRIMARY KEY ({', '.join(pkeys)}, `tag`)"
                                 ]}
-            
+
             # Define indices dynamically based on primary keys
             pkeys_str = ', '.join([k.strip('`') for k in pkeys])
             self._indices = {
                 'idx_obs': f'obs({pkeys_str})',
                 'idx_tags': f'tags({pkeys_str})',
             }
-            
+
             c = self.conn.cursor()
             c.execute("SELECT type, name FROM sqlite_master "
                       "WHERE type in ('table', 'index') and name not like 'sqlite_%';")
@@ -118,7 +122,7 @@ class ObsDb(object):
                 raise ValueError(f"Primary keys do not match: {primary_keys} != {pkeys}"+
                                 f" must use `wafer_info`=={primary_keys} or create a new dB with {pkeys}")
         return primary_keys
-    
+
     def _convert_wafer_info(self, obs_id, wafer_info):
         """Helper function to allow flexibility in way obs_id and wafer_info are passed in."""
         if isinstance(wafer_info, dict):
@@ -138,7 +142,7 @@ class ObsDb(object):
         return obs_id, wafer_info
 
     def _warn_primary_keys(self, wafer_info):
-        """Warn the user if the primary keys are not specified 
+        """Warn the user if the primary keys are not specified
            and we're defaulting to using _all."""
         if len(self.primary_keys) == 1:
             return []
@@ -160,10 +164,10 @@ class ObsDb(object):
             """
             warnings.warn(warn_str, UserWarning)
         return wafer_info
-    
+
     def __len__(self):
         return self.conn.execute(f'SELECT COUNT({self.primary_keys[0]}) FROM obs').fetchone()[0]
-    
+
     def add_obs_columns(self, column_defs, ignore_duplicates=True, commit=True):
         """Add columns to the obs table.
 
@@ -196,6 +200,8 @@ class ObsDb(object):
             'timestamp float, drift str'
 
         """
+        if self._readonly:
+            raise RuntimeError("Cannot add_obs_columns() on a read-only DB")
         current_cols = self.conn.execute('pragma table_info(obs)').fetchall()
         current_cols = [r[1] for r in current_cols]
         if isinstance(column_defs, str):
@@ -241,7 +247,7 @@ class ObsDb(object):
         Example of ways to pass updates to obsdb when there are multiple primary keys.
 
         1) obs_id as str and wafer_info as tuple::
-        
+
             obsdb.update_obs('obs_2345_xyz_110', wafer_info=('ws0', 'f090'), ...)
 
         2) obs_id as str and wafer_info as dict::
@@ -255,8 +261,10 @@ class ObsDb(object):
         4) obs_id as tuple and wafer_info is None::
 
             obsdb.update_obs(('obs_2345_xyz_110', 'ws0', 'f090'), ...)
-        
+
         """
+        if self._readonly:
+            raise RuntimeError("Cannot update_obs() on a read-only DB")
         obs_id, wafer_info = self._convert_wafer_info(obs_id, wafer_info)
 
         obs_key = {'obs_id': obs_id}
@@ -270,13 +278,13 @@ class ObsDb(object):
         placeholders = ', '.join(['?'] * len(obs_key))
         c.execute(f'INSERT OR IGNORE INTO obs ({columns}) VALUES ({placeholders})',
                   tuple(obs_key.values()))
-            
+
         if len(data.keys()):
             settors = [f'{k}=?' for k in data.keys()]
             where_str = ' AND '.join([f'{k}=?' for k in obs_key.keys()])
             c.execute(f'UPDATE obs SET {", ".join(settors)} WHERE {where_str}',
                       tuple(data.values()) + tuple(obs_key.values()))
-                        
+
         for t in tags:
             if t[0] == '!':
                 # Kill this tag
@@ -307,7 +315,7 @@ class ObsDb(object):
             else:
                 raise RuntimeError("Output file %s exists (overwrite=True "
                                    "to overwrite)." % map_file)
-        new_db = ObsDb(map_file=map_file, init_db=False)
+        new_db = ObsDb(map_file=map_file, init_db=False, readonly=False)
         script = ' '.join(self.conn.iterdump())
         new_db.conn.executescript(script)
         return new_db
@@ -360,7 +368,7 @@ class ObsDb(object):
         obs_id, wafer_info = self._convert_wafer_info(obs_id, wafer_info)
         if obs_id is None:
             return self.query('1', add_prefix=add_prefix)
-        
+
         wafer_info = self._warn_primary_keys(wafer_info)
         query_text = " AND ".join([f"{key} == '{val}'" for key, val in zip(self.primary_keys, [obs_id] + wafer_info)])
 
@@ -410,13 +418,13 @@ class ObsDb(object):
 
           When filtering is activated in this way, the returned
           results must satisfy all the criteria (i.e. the individual
-          constraints are AND-ed). If your tag name contains special 
-          characters (e.g. '-'), you will need to enclose it in 
+          constraints are AND-ed). If your tag name contains special
+          characters (e.g. '-'), you will need to enclose it in
           backticks when using it in a query string, e.g.:
- 
+
             obsdb.query('`bad-tag`=1', tags=['bad-tag'])
 
-          For this reason, we generally advise against the use of 
+          For this reason, we generally advise against the use of
           non-alphanumeric characters in tags.
 
         """
@@ -455,7 +463,7 @@ class ObsDb(object):
         if add_prefix is not None:
             results.keys = [add_prefix + k for k in results.keys]
         return results
-    
+
     def query_linked_dbs(self, secondary_dbs, query_text, add_prefix='',
                          wafer_info=None):
         """
@@ -480,7 +488,7 @@ class ObsDb(object):
         # Ensure secondary_dbs is a list
         if not isinstance(secondary_dbs, list):
             secondary_dbs = [secondary_dbs]
-        
+
         # Query the primary database
         primary_results = self.query(query_text, add_prefix=add_prefix)
         if len(primary_results) == 0:

--- a/sotodlib/core/metadata/obsdb.py
+++ b/sotodlib/core/metadata/obsdb.py
@@ -309,7 +309,11 @@ class ObsDb(object):
         of writing a Db to disk to call copy(map_file=...) and then
         simply discard the returned object.
         """
-        if map_file is not None and os.path.exists(map_file):
+        if (
+            map_file is not None and 
+            map_file != ":memory:" and
+            os.path.exists(map_file)
+        ):
             if overwrite:
                 os.remove(map_file)
             else:

--- a/sotodlib/core/metadata/obsfiledb.py
+++ b/sotodlib/core/metadata/obsfiledb.py
@@ -148,7 +148,11 @@ class ObsFileDb:
         of writing a Db to disk to call copy(map_file=...).
         """
         script = ' '.join(self.conn.iterdump())
-        if map_file is not None and os.path.exists(map_file):
+        if (
+            map_file is not None and 
+            map_file != ":memory:" and
+            os.path.exists(map_file)
+        ):
             if overwrite:
                 os.remove(map_file)
             else:

--- a/sotodlib/core/metadata/obsfiledb.py
+++ b/sotodlib/core/metadata/obsfiledb.py
@@ -69,7 +69,7 @@ class ObsFileDb:
     #: starting with /).
     prefix = ''
 
-    def __init__(self, map_file=None, prefix=None, init_db=True, readonly=False):
+    def __init__(self, map_file=":memory:", prefix=None, init_db=True, readonly=False):
         """Instantiate an ObsFileDb.
 
         Arguments:

--- a/sotodlib/core/metadata/obsfiledb.py
+++ b/sotodlib/core/metadata/obsfiledb.py
@@ -82,25 +82,20 @@ class ObsFileDb:
             in read-only mode.  Not valid on dbs held in :memory:.
 
         """
+        if init_db and readonly:
+            raise ValueError("Cannot initialize a read-only DB")
+        self._readonly = readonly
         if isinstance(map_file, sqlite3.Connection):
             self.conn = map_file
         else:
-            if map_file is None:
-                map_file = ':memory:'
-            self.conn = sqlite3.connect(map_file)
-            uri = False
-            if readonly:
-                if map_file == ':memory:':
-                    raise ValueError('Cannot honor request for readonly db '
-                                     'mapped to :memory:.')
-                map_file, uri = 'file:%s?mode=ro' % map_file, True
-
-            self.conn = sqlite3.connect(map_file, uri=uri)
-
+            self.conn = common.sqlite_connect(
+                filename=map_file,
+                mode=("r" if readonly else "w"),
+            )
         self.conn.row_factory = sqlite3.Row  # access columns by name
 
         self.prefix = self._get_prefix(map_file, prefix)
-        if init_db and not readonly:
+        if init_db:
             self._create()
 
     @staticmethod
@@ -152,15 +147,14 @@ class ObsFileDb:
         connected to that sqlite file on disk.  Note that a quick way
         of writing a Db to disk to call copy(map_file=...).
         """
-        if map_file is None:
-            map_file = ':memory:'
         script = ' '.join(self.conn.iterdump())
-        if map_file != ':memory:' and os.path.exists(map_file):
-            if not overwrite:
+        if map_file is not None and os.path.exists(map_file):
+            if overwrite:
+                os.remove(map_file)
+            else:
                 raise RuntimeError("Output database '%s' exists -- remove or "
                                    "pass overwrite=True to copy." % map_file)
-            os.remove(map_file)
-        new_db = ObsFileDb(map_file, init_db=False)
+        new_db = ObsFileDb(map_file, init_db=False, readonly=False)
         new_db.conn.executescript(script)
         new_db.prefix = self.prefix
         return new_db
@@ -206,6 +200,8 @@ class ObsFileDb:
             this detset.
 
         """
+        if self._readonly:
+            raise RuntimeError("Cannot add_dataset() on a read-only DB")
         for d in detector_names:
             q = 'insert into detsets (name,det) values (?,?)'
             self.conn.execute(q, (detset_name, d))
@@ -226,6 +222,8 @@ class ObsFileDb:
           sample_stop (int): sample_start + n_samples.
 
         """
+        if self._readonly:
+            raise RuntimeError("Cannot add_obsfile() on a read-only DB")
         self.conn.execute(
             'insert into files (name,detset,obs_id,sample_start,sample_stop) '
             'values (?,?,?,?,?)',
@@ -241,7 +239,7 @@ class ObsFileDb:
         """
         c = self.conn.execute('select distinct obs_id from files')
         return [r[0] for r in c]
-    
+
     def get_obs_with_detset(self, detset):
         """Returns a list of all obs_ids that include a specified detset"""
         c = self.conn.execute(
@@ -424,6 +422,8 @@ class ObsFileDb:
         files that are no longer covered by the database (with prefix).
 
         """
+        if self._readonly:
+            raise RuntimeError("Cannot drop_obs() on a read-only DB")
         # What files does this affect?
         c = self.conn.execute('select name from files where obs_id=?',
                               (obs_id,))
@@ -443,6 +443,8 @@ class ObsFileDb:
         prefix).
 
         """
+        if self._readonly:
+            raise RuntimeError("Cannot drop_detset() on a read-only DB")
         # What files does this affect?
         c = self.conn.execute('select name from files where detset=?',
                               (detset,))
@@ -466,6 +468,8 @@ class ObsFileDb:
         longer included in the database.
 
         """
+        if self._readonly:
+            raise RuntimeError("Cannot drop_incomplete() on a read-only DB")
         affected_files = []
         scan = self.verify()
         for obs_id, info in scan['grids'].items():

--- a/sotodlib/core/metadata/obsfiledb.py
+++ b/sotodlib/core/metadata/obsfiledb.py
@@ -106,7 +106,7 @@ class ObsFileDb:
         """
         if prefix is not None:
             return prefix
-        if map_file == ':memory:':
+        if map_file is None or map_file == ':memory:':
             return ''
         return os.path.split(os.path.abspath(map_file))[0] + '/'
 


### PR DESCRIPTION
This branch has some changes to explore sqlite performance through modifying low-level DB parameters.  It currently includes some temporary timers that will be removed before review.  Some starting test scripts for [parallel read are in pwg-scripts](https://github.com/simonsobs/pwg-scripts/tree/master/pwg-duf/sqlite_profile), but I expect there will not be much noticeable change until considering the case of multiple readers plus a writer.  Or perhaps there will be other non-sqlite bottlenecks identified.