### PR TITLE
Speedup update_obsdb.py by ~5x

### DIFF
--- a/sotodlib/site_pipeline/update_obsdb.py
+++ b/sotodlib/site_pipeline/update_obsdb.py
@@ -177,7 +177,7 @@ def main(config: str,
                 #obsfiledb creation
                 checkbook(
                     bookpath, config, add=True, 
-                    overwrite=True
+                    overwrite=overwrite
                 )
             except Exception as e:
                 if config_dict["skip_bad_books"]:


### PR DESCRIPTION
check_book will now rewrite the database to drop the old obsfiledb entry only if the --overwrite argument is called. We are checking within the obsdb for duplicates already so we shouldn't need this