### PR TITLE
pointing_model: sat_v1 begins

### DIFF
--- a/sotodlib/coords/pointing_model.py
+++ b/sotodlib/coords/pointing_model.py
@@ -1,11 +1,18 @@
+# Copyright (c) 2024 Simons Observatory.
+# Full license can be found in the top level "LICENSE" file.
+
 import numpy as np
 from .. import core
 from .helpers import _valid_arg
+from so3g.proj import quat
+
+import logging
+logger = logging.getLogger(__name__)
 
 DEG = np.pi / 180
 
 
-def apply_pointing_model(tod):
+def apply_basic_pointing_model(tod):
     """
     Updates and returns the tod.boresight AxisManager after applying pointing model parameters.
 
@@ -19,7 +26,7 @@ def apply_pointing_model(tod):
     _ancil = _valid_arg("ancil", src=tod)
     telescope = _valid_arg("obs_info", src=tod)["telescope"]
     # Start with a fresh axismanager
-    _boresight = core.AxisManager(core.OffsetAxis("samps", len(tod.timestamps)))
+    _boresight = core.AxisManager(tod.samps)
 
     if "lat" in telescope:
         # Returns in Radians
@@ -35,6 +42,167 @@ def apply_pointing_model(tod):
         _boresight.wrap("el", _ancil.el_enc * DEG, [(0, "samps")])
         _boresight.wrap("roll", -1 * _ancil.boresight_enc * DEG, [(0, "samps")])
 
-    tod.boresight = _boresight
+    if 'boresight' in tod:
+        del tod['boresight']
+
+    tod.wrap('boresight', _boresight)
 
     return _boresight
+
+
+def apply_pointing_model(tod, pointing_model=None, ancil=None,
+                         wrap=None):
+    """Applies a static pointing model to compute corrected boresight
+    position and orientation in horizon coordinates.  The encoder
+    values in tod.ancil are consumed as raw data, and the computed
+    values are stored in tod.boresight.
+
+    Args:
+      tod (AxisManager): the observation data.
+      pointing_model (AxisManager): if None, the pointing_model
+        parameters are read from tod.pointing_model.
+      ancil (AxisManager): if None, the encoders are read from
+        tod.ancil.
+      wrap (str): If specified, the name in tod where corrected
+        boresight should be stored.  If None, the default of
+        'boresight' is used.  Pass boresight=False to not store the
+        result in tod.
+
+    Returns:
+      AxisManager: the corrected boresight.
+
+    """
+    if pointing_model is None and 'pointing_model' not in tod:
+        logger.warning('No pointing_model found -- applying basic model.')
+        assert wrap in (None, 'boresight')
+        return apply_basic_pointing_model(tod)
+
+    pointing_model = _valid_arg(pointing_model, 'pointing_model',
+                                src=tod)
+    ancil = _valid_arg(ancil, 'ancil', src=tod)
+
+    # Encoder values, to radians.
+    vers = pointing_model['version']
+    tel_type = vers.split('_')[0]
+    if tel_type == 'sat':
+        boresight = apply_pointing_model_sat(vers, pointing_model, tod, ancil)
+    elif tel_type == 'lat':
+        boresight = apply_pointing_model_lat(vers, pointing_model, tod, ancil)
+    else:
+        raise ValueError(f'Unimplemented pointing model "{vers}"')
+
+    if wrap is None:
+        wrap = 'boresight'
+    if wrap is not False:
+        if wrap in tod._fields:
+            del tod[wrap]
+        tod.wrap(wrap, boresight)
+    return boresight
+
+
+def apply_pointing_model_sat(vers, params, tod, ancil):
+    az, el, roll = _get_sat_enc_radians(ancil)
+
+    if vers == 'sat_naive':
+        return _new_boresight(ancil.samps, az=az, el=el, roll=roll)
+
+    elif vers == 'sat_v1':
+        az1, el1, roll1 = model_sat_v1(params, az, el, roll)
+        return _new_boresight(ancil.samps, az=az1, el=el1, roll=roll1)
+
+    else:
+        raise ValueError(f'Unimplemented pointing model "{vers}"')
+
+
+def apply_pointing_model_lat(vers, tod, pointing_model, ancil):
+    raise ValueError(f'Unimplemented pointing model "{vers}"')
+
+
+#
+# SAT model(s)
+#
+
+# sat_v1: you can expand v1, as long as new params don't do anything
+# if their value is zero (and that should be the registered default).
+
+defaults_sat_v1 = {
+    'enc_offset_az': 0.,
+    'enc_offset_el': 0.,
+    'enc_offset_boresight': 0.,
+    'base_tilt_cos': 0.,
+    'base_tilt_sin': 0.,
+    'bs_xi0': 0.,
+    'bs_eta0': 0.,
+}
+
+def model_sat_v1(params, az, el, roll):
+    """Applies pointing model to (az, el, roll).
+
+    Args:
+      params: AxisManager (or dict) of pointing parameters.
+      az, el, roll: naive horizon coordinates, in radians, of the
+        boresight.
+
+    The implemented model parameters are:
+
+      - bs_{xi,eta}0: within the focal plane (i.e. relative to the
+        corrected boresight), the center of rotation of the boresight.
+        Radians.
+      - enc_offset_{az,el,boresight}: encoder offsets, in degrees.
+      - base_tilt_{cos,sin}: base tilt coefficients, in radians.
+
+    """
+    _p = dict(defaults_sat_v1)
+    if isinstance(params, dict):
+        _p.update(params)
+    else:
+        _p.update({k: params[k] for k in params._fields.keys()})
+    params, _p = _p, None
+
+    for k, v in params.items():
+        if k == 'version':
+            continue
+        if k not in defaults_sat_v1 and v != 0.:
+            raise ValueError(f'Handling of model param "{k}" is not implemented.')
+
+    # Construct offsetted encoders.
+    az = az + params['enc_offset_az'] * DEG
+    el = el + params['enc_offset_el'] * DEG
+    roll = roll - params['enc_offset_boresight'] * DEG
+
+    # Rotation that tilts the base (referred to vals after enc correction).
+    base_tilt = get_base_tilt_q(params['base_tilt_cos'], params['base_tilt_sin'])
+
+    # Rotation that takes a vector in array-centered focal plane coords
+    # to a vector in boresight-rotation-centered focal plane coords.
+    q_fp_bs = ~quat.rotation_xieta(params['bs_xi0'], params['bs_eta0'])
+
+    # Horizon coordinates.
+    q_hs = (base_tilt * quat.rotation_lonlat(-az, el)
+            * ~q_fp_bs * quat.euler(2, roll) * q_fp_bs)
+
+    neg_az, el, roll = quat.decompose_lonlat(q_hs)
+    return -neg_az, el, roll
+
+
+# Support functions
+
+def _new_boresight(samps, az=None, el=None, roll=None):
+    boresight = core.AxisManager(samps)
+    for k, v in zip(['az', 'el', 'roll'], [az, el, roll]):
+        boresight.wrap_new(k, shape=('samps',), dtype='float64')
+        if v is not None:
+            boresight[k][:] = v
+    return boresight
+
+def _get_sat_enc_radians(ancil):
+    return (ancil.az_enc * DEG,
+            ancil.el_enc * DEG,
+            -ancil.boresight_enc * DEG)
+
+def get_base_tilt_q(c, s):
+    # Imagine az=-phi
+    phi = np.arctan2(s, c)
+    # And that base tilt causes the el to bump upwards by amp at that position.
+    amp = (c**2 + s**2)**.5
+    return quat.euler(2, phi) * quat.euler(1, -amp) * quat.euler(2, -phi)

--- a/sotodlib/coords/pointing_model.py
+++ b/sotodlib/coords/pointing_model.py
@@ -201,8 +201,18 @@ def _get_sat_enc_radians(ancil):
             -ancil.boresight_enc * DEG)
 
 def get_base_tilt_q(c, s):
+    """Returns the quaternion rotation that applies base tilt, taking
+    vectors in the platforms horizon coordinates to vectors in the
+    site's local horizon coordinates.  The c and s parameters together
+    define a direction and amplitude of the base tilt.
+
+    In this implementation, c and s have the same meaning and sign
+    convention as TPOINT parameters AN and AW, respectively.
+
+    """
     # Imagine az=-phi
     phi = np.arctan2(s, c)
-    # And that base tilt causes the el to bump upwards by amp at that position.
+    # And that base tilt causes the true el to lie below the expected
+    # (encoder) el, at that position.
     amp = (c**2 + s**2)**.5
-    return quat.euler(2, phi) * quat.euler(1, -amp) * quat.euler(2, -phi)
+    return quat.euler(2, phi) * quat.euler(1, amp) * quat.euler(2, -phi)

--- a/sotodlib/coords/pointing_model.py
+++ b/sotodlib/coords/pointing_model.py
@@ -65,7 +65,7 @@ def apply_pointing_model(tod, pointing_model=None, ancil=None,
         tod.ancil.
       wrap (str): If specified, the name in tod where corrected
         boresight should be stored.  If None, the default of
-        'boresight' is used.  Pass boresight=False to not store the
+        'boresight' is used.  Pass wrap=False to not store the
         result in tod.
 
     Returns:
@@ -74,7 +74,8 @@ def apply_pointing_model(tod, pointing_model=None, ancil=None,
     """
     if pointing_model is None and 'pointing_model' not in tod:
         logger.warning('No pointing_model found -- applying basic model.')
-        assert wrap in (None, 'boresight')
+        assert wrap in (None, 'boresight'), \
+            'When using naive pointing model, wrap=... not supported'
         return apply_basic_pointing_model(tod)
 
     pointing_model = _valid_arg(pointing_model, 'pointing_model',

--- a/tests/test_pointing_model.py
+++ b/tests/test_pointing_model.py
@@ -1,0 +1,126 @@
+# Copyright (c) 2024 Simons Observatory.
+# Full license can be found in the top level "LICENSE" file.
+
+"""Check functionality of coords.pointing_model.
+
+"""
+
+import itertools
+import unittest
+import numpy as np
+
+from sotodlib import coords, core
+from so3g.proj import quat
+from pixell import enmap
+
+pm = coords.pointing_model
+
+DEG = np.pi/180
+
+def to_rad(*arg):
+    return [a * DEG for a in arg]
+
+def to_deg(*arg):
+    return [a / DEG for a in arg]
+
+def full_vectors(az=0., el=0., roll=0.):
+    z = 0 * az + 0*el + 0*roll
+    return z + az, z + el, z + roll
+
+
+class CoordsUtilsTest(unittest.TestCase):
+    def test_populate(self):
+        # Test that model populates tod.
+        tod = core.AxisManager(core.OffsetAxis('samps', 1000))
+        ancil = core.AxisManager(tod.samps)
+        for k, v in zip(['az', 'el', 'boresight'],
+                        full_vectors(np.linspace(0, 360, tod.samps.count), 60, 0)):
+            ancil.wrap_new(f'{k}_enc', shape=('samps',))[:] = v
+        tod.wrap('ancil', ancil)
+        tod.wrap('obs_info', core.AxisManager())
+        tod['obs_info'].wrap('telescope', 'satp1')
+
+        results = []
+        # TOD without 'pointing_model' -- should work, with warning
+        with self.assertLogs(pm.__name__, level='WARN'):
+            pm.apply_pointing_model(tod)
+        results.append(tod.boresight)
+        del tod['boresight']
+
+        tod.wrap('pointing_model', core.AxisManager())
+        tod['pointing_model'].wrap('version', 'sat_v1')
+        pm.apply_pointing_model(tod, wrap=False)
+        assert 'boresight' not in tod
+
+        pm.apply_pointing_model(tod)
+        assert 'boresight' in tod
+        assert 'az' in tod.boresight
+        results.append(tod.boresight)
+
+        pm.apply_pointing_model(tod)
+
+        # Check consistency...
+        for r in results[1:]:
+            for k in ['az', 'el', 'roll']:
+                d = (r[k] - results[0][k] + np.pi) % (2*np.pi) - np.pi
+                np.testing.assert_array_almost_equal(d, 0*d)
+
+    def test_sat_v1(self):
+        # Test model_sat_v1 general behaviors.
+        az, el, roll = full_vectors(az=np.linspace(-90, 90, 100),
+                                    el=60)
+        params = core.AxisManager()
+        params.wrap('version', 'sat_v1')
+        az1, el1, roll1 = to_deg(*pm.model_sat_v1(params, *to_rad(az, el, roll)))
+        params0 = {'version': 'sat_v1'}
+        az1, el1, roll1 = to_deg(*pm.model_sat_v1(params, *to_rad(az, el, roll)))
+
+        params = dict(params0)
+        params['enc_offset_az'] = 1.
+        az1, el1, roll1 = to_deg(*pm.model_sat_v1(params, *to_rad(az, el, roll)))
+        assert np.all((az1 - az + 180) % 360 - 180 > 0)
+
+        params = dict(params0)
+        params.update({
+            'base_tilt_cos': 0 * DEG,
+            'base_tilt_sin': 1 * DEG,  # West up.
+            })
+
+        for az0, ex in [
+                (0.,  0),
+                (90., -1),
+                (180., 0),
+                (270., +1),
+        ]:
+            az, el, roll = full_vectors(az=np.linspace(-1, 1, 5) + az0, el=30.)
+            az1, el1, roll1 = to_deg(*pm.model_sat_v1(params, *to_rad(az, el, roll)))
+            d_el = el1 - el
+            if ex == 0:
+                assert any(d_el > 0) and any(d_el < 0)
+            else:
+                assert all(d_el * ex > 0)
+
+        # Boresight center.
+        params = dict(params0)
+        params.update({
+            'bs_xi0': 0.4 * DEG,
+            'bs_eta0': 0.1 * DEG,
+        })
+        az, el, roll = full_vectors(roll=np.linspace(0., 360., 20), el=45.)
+        for xi, eta, sig in [
+                (0.4, 0.1, 0.),
+                (0.5, 0.2, 0.1*2**.5),
+        ]:
+            az1, el1, roll1 = pm.model_sat_v1(params, *to_rad(az, el, roll))
+            # Measure az, el on sky of a detector (xi, eta):
+            q_hs1 = (quat.rotation_lonlat(-az1, el1, roll1) *
+                     quat.rotation_xieta(xi * DEG, eta * DEG))
+            neg_az2, el2, roll2 = quat.decompose_lonlat(q_hs1)
+            d_el = el2 - el * DEG
+            d_azc = ((-neg_az2 - az*DEG - np.pi) % (2 * np.pi) + np.pi) * np.cos(el*DEG)
+            sig_meas = (d_el.std()**2 + d_azc.std()**2)**.5
+            assert(abs(sig_meas - sig * DEG) < .001*DEG)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_pointing_model.py
+++ b/tests/test_pointing_model.py
@@ -27,6 +27,12 @@ def full_vectors(az=0., el=0., roll=0.):
     z = 0 * az + 0*el + 0*roll
     return z + az, z + el, z + roll
 
+def center_branch(x, period=360., center=0):
+    # Shift values in x by multiples of period, so they're within
+    # period/w of center.
+    branch = center - period / 2
+    return (x - branch) % period + branch
+
 
 class CoordsUtilsTest(unittest.TestCase):
     def test_populate(self):
@@ -62,7 +68,7 @@ class CoordsUtilsTest(unittest.TestCase):
         # Check consistency...
         for r in results[1:]:
             for k in ['az', 'el', 'roll']:
-                d = (r[k] - results[0][k] + np.pi) % (2*np.pi) - np.pi
+                d = center_branch(r[k] - results[0][k], 2*np.pi)
                 np.testing.assert_array_almost_equal(d, 0*d)
 
     def test_sat_v1(self):
@@ -78,27 +84,42 @@ class CoordsUtilsTest(unittest.TestCase):
         params = dict(params0)
         params['enc_offset_az'] = 1.
         az1, el1, roll1 = to_deg(*pm.model_sat_v1(params, *to_rad(az, el, roll)))
-        assert np.all((az1 - az + 180) % 360 - 180 > 0)
+        assert np.all(center_branch(az1 - az) > 0)
 
-        params = dict(params0)
-        params.update({
-            'base_tilt_cos': 0 * DEG,
-            'base_tilt_sin': 1 * DEG,  # West up.
-            })
+        def tpoint_base_tilt(an, aw, az, el):
+            c, s = np.cos(az * DEG), np.sin(az * DEG)
+            delta_az = (-aw * c - an * s) * np.tan(el * DEG)
+            delta_el = aw * s - an * c
+            return az + delta_az / DEG, el + delta_el / DEG
 
-        for az0, ex in [
-                (0.,  0),
-                (90., -1),
-                (180., 0),
-                (270., +1),
+        # Trial a few different base tilt combinations.
+        az, el, roll = full_vectors(az=np.arange(0, 360), el=30.)
+        tpoint_err_max = 0.01 # deg
+        for (bt_c, bt_s, high_az) in [
+                (1 * DEG, 0 * DEG, 0.),
+                (0 * DEG, 1 * DEG, 270.),
+                (2**-0.5 * DEG, 2**-0.5 * DEG, 315.),
         ]:
-            az, el, roll = full_vectors(az=np.linspace(-1, 1, 5) + az0, el=30.)
+            params = dict(params0)
+            params.update({
+                'base_tilt_cos': bt_c,
+                'base_tilt_sin': bt_s,  # West up.
+                })
             az1, el1, roll1 = to_deg(*pm.model_sat_v1(params, *to_rad(az, el, roll)))
+
+            # Check that delta el, near the expected high_az point, is postive.
             d_el = el1 - el
-            if ex == 0:
-                assert any(d_el > 0) and any(d_el < 0)
-            else:
-                assert all(d_el * ex > 0)
+            s = abs(center_branch(az - high_az)) < 10.
+            assert (all(d_el[s]) > 0)
+
+            # Check consistency with tpoint linear approximation --
+            # bt_c and bt_s correspond to AN and AW terms,
+            # respectively.
+            az2, el2 = tpoint_base_tilt(bt_c, bt_s, az, el)
+            d_az = abs(center_branch(az2 - az1))
+            d_el = abs(center_branch(el2 - el1))
+            assert all(d_az < tpoint_err_max)
+            assert all(d_el < tpoint_err_max)
 
         # Boresight center.
         params = dict(params0)
@@ -117,7 +138,7 @@ class CoordsUtilsTest(unittest.TestCase):
                      quat.rotation_xieta(xi * DEG, eta * DEG))
             neg_az2, el2, roll2 = quat.decompose_lonlat(q_hs1)
             d_el = el2 - el * DEG
-            d_azc = ((-neg_az2 - az*DEG - np.pi) % (2 * np.pi) + np.pi) * np.cos(el*DEG)
+            d_azc = center_branch(-neg_az2 - az*DEG, 2*np.pi) * np.cos(el*DEG)
             sig_meas = (d_el.std()**2 + d_azc.std()**2)**.5
             assert(abs(sig_meas - sig * DEG) < .001*DEG)
 


### PR DESCRIPTION
Implements encoder offsets, base_tilt, and focal plane center of boresight rotation.

Given our current pointing products (measured at boresight=0), a model that specifies "bs_xi0" and "bs_eta0" should be able to cancel the pointing shifts in SATP1 arising from boresight != 0.