### PR TITLE
hwp_metadata delete dets axis

### DIFF
--- a/sotodlib/hwp/g3thwp.py
+++ b/sotodlib/hwp/g3thwp.py
@@ -961,7 +961,6 @@ class G3tHWP():
 
         """
 
-        # write solution, metadata loader requires a dets axis
         aman = sotodlib.core.AxisManager(tod.samps)
         aman.wrap_new('timestamps', ('samps', ))[:] = tod.timestamps
         self._set_empty_axes(aman)

--- a/sotodlib/hwp/g3thwp.py
+++ b/sotodlib/hwp/g3thwp.py
@@ -837,7 +837,7 @@ class G3tHWP():
             logger.warning('Input data is empty.')
             return
 
-        aman = sotodlib.core.AxisManager(tod.dets, tod.samps)
+        aman = sotodlib.core.AxisManager(tod.samps)
         start = int(tod.timestamps[0])-self._margin
         end = int(tod.timestamps[-1])+self._margin
 
@@ -962,7 +962,7 @@ class G3tHWP():
         """
 
         # write solution, metadata loader requires a dets axis
-        aman = sotodlib.core.AxisManager(tod.dets, tod.samps)
+        aman = sotodlib.core.AxisManager(tod.samps)
         aman.wrap_new('timestamps', ('samps', ))[:] = tod.timestamps
         self._set_empty_axes(aman)
 

--- a/sotodlib/site_pipeline/make_hwp_solutions.py
+++ b/sotodlib/site_pipeline/make_hwp_solutions.py
@@ -201,11 +201,13 @@ def main(
             aman_encoder = g3thwp.set_data(tod, h5_filename = h5_encoder)
         else:
             aman_encoder = g3thwp.set_data(tod)
+        del aman_encoder['dets']
         logger.info("Saving hwp_encoder")
         save(aman_encoder, db_encoder, h5_encoder, obs_id, overwrite, 'gzip')
         del aman_encoder
 
         aman_solution = g3thwp.make_solution(tod)
+        del aman_solution['dets']
         logger.info("Saving hwp_angle")
         save(aman_solution, db_solution, h5_solution, obs_id, overwrite, 'gzip')
         del aman_solution

--- a/sotodlib/site_pipeline/make_hwp_solutions.py
+++ b/sotodlib/site_pipeline/make_hwp_solutions.py
@@ -201,13 +201,11 @@ def main(
             aman_encoder = g3thwp.set_data(tod, h5_filename = h5_encoder)
         else:
             aman_encoder = g3thwp.set_data(tod)
-        del aman_encoder['dets']
         logger.info("Saving hwp_encoder")
         save(aman_encoder, db_encoder, h5_encoder, obs_id, overwrite, 'gzip')
         del aman_encoder
 
         aman_solution = g3thwp.make_solution(tod)
-        del aman_solution['dets']
         logger.info("Saving hwp_angle")
         save(aman_solution, db_solution, h5_solution, obs_id, overwrite, 'gzip')
         del aman_solution


### PR DESCRIPTION
Delete dets axis from hwp_angles metadata, to fix the issue that the all the detectors get eliminated when we load data with hwp_angles metadata.

Actually dets axis was always included in hwp metadata. This became a problem because we changed the timestamp loading from ctx.get_obs(obs_id, no_signal=True) to ctx.get_obs(obs_id, dets=[]) in https://github.com/simonsobs/sotodlib/pull/809