### PR TITLE
tod_ops.filters: restore iir_filter params as dict

### DIFF
--- a/sotodlib/tod_ops/filters.py
+++ b/sotodlib/tod_ops/filters.py
@@ -492,20 +492,20 @@ def iir_filter(freqs, tod, b=None, a=None, fscale=1., iir_params=None,
             iir_params = 'iir_params'
         if isinstance(iir_params, str):
             iir_params = tod[iir_params]
-        if 'a' not in list(iir_params._fields.keys()):
+        if (isinstance(iir_params, core.AxisManager)
+            and 'a' not in iir_params._fields):
             # Check iir_param's uniformity
-            i = 0
+            _a = None
             for _field, _sub_iir_params in iir_params._fields.items():
-                if isinstance(_sub_iir_params, core.AxisManager) and 'a' in list(_sub_iir_params._fields.keys()):
+                if isinstance(_sub_iir_params, core.AxisManager) and 'a' in _sub_iir_params._fields:
                     sub_iir_params = _sub_iir_params
-                    if i == 0:
+                    if _a is None:
                         _a, _b, _fscale = sub_iir_params['a'], sub_iir_params['b'], sub_iir_params['fscale']
                     else:
                         if np.any(np.hstack([sub_iir_params['a'] != _a,
                                              sub_iir_params['b'] != _b,
                                              sub_iir_params['fscale'] != _fscale,])):
                             raise ValueError('iir parameters are not uniform.')
-                    i += 1
             iir_params = sub_iir_params
         try:
             a = iir_params['a']


### PR DESCRIPTION
Also minor code simplifications and tests for both the dict interface and the nested parameter support.