### PR TITLE
Add venn package dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ setup_opts["install_requires"] = [
 setup_opts["extras_require"] = {
     "site_pipeline": [
         "influxdb",
+        "venn"
     ],
     "tests": [
         "socs",


### PR DESCRIPTION
Adds `venn` package dependency to extras `sotodlib[site_pipeline]`, used in `plot_det_bias_flags`