### PR TITLE
Adds psycopg2-binary requirement for hkdb

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,8 @@ setup_opts["install_requires"] = [
     'pixell',
     'scikit-image',
     'pyfftw',
-    'numdifftools'
+    'numdifftools',
+    'psycopg2-binary',
 ]
 setup_opts["extras_require"] = {
     "site_pipeline": [


### PR DESCRIPTION
This PR adds the `psycopg2-binary` requirement, which is necessary for reading and updating postgres databases such as hkdb.