### PR TITLE
Reimplementation of LoadContext Operator

### DIFF
--- a/sotodlib/toast/ops/act_sign.py
+++ b/sotodlib/toast/ops/act_sign.py
@@ -25,7 +25,7 @@ class ActSign(Operator):
     )
 
     fp_column = Unicode(
-        "det_info_optical_sign", help="Focalplane table column with sign factor"
+        "det_info:optical_sign", help="Focalplane table column with sign factor"
     )
 
     def __init__(self, **kwargs):

--- a/sotodlib/toast/ops/load_context.py
+++ b/sotodlib/toast/ops/load_context.py
@@ -1143,7 +1143,7 @@ class LoadContext(Operator):
                             det_data[self.det_data] = (key, dt, None)
                         elif data_key in det_flag_fields:
                             # One of the flag fields
-                            det_data[self.det_data] = (
+                            det_data[self.det_flags] = (
                                 key,
                                 dt,
                                 det_flag_fields[data_key],

--- a/sotodlib/toast/ops/load_context.py
+++ b/sotodlib/toast/ops/load_context.py
@@ -3,8 +3,8 @@
 
 import os
 import re
-import datetime
 import yaml
+from datetime import datetime, timezone
 
 import numpy as np
 import traitlets
@@ -15,7 +15,15 @@ import toast
 from toast.dist import distribute_uniform
 from toast.timing import function_timer, Timer
 from toast.traits import (
-    trait_docs, Int, Unicode, Instance, List, Unit, Dict, Bool, Float
+    trait_docs,
+    Int,
+    Unicode,
+    Instance,
+    List,
+    Unit,
+    Dict,
+    Bool,
+    Float,
 )
 from toast.ops.operator import Operator
 from toast.utils import Environment, Logger
@@ -30,13 +38,20 @@ from ...preprocess import Pipeline as PreProcPipe
 
 from ..instrument import SOFocalplane, SOSite
 
+from .load_context_utils import (
+    compute_boresight_pointing,
+    parse_metadata,
+    read_and_preprocess_wafers,
+    open_context,
+    close_context,
+    distribute_detector_data,
+    distribute_detector_props,
+)
+
 
 @trait_docs
 class LoadContext(Operator):
-    """Load one or more observations from a Context.
-
-    NOTE:  each "observation" in the Context system maps to a toast "observing
-    session".
+    """Load one or more observations from a Context into observing sessions.
 
     Given a context, load one or more observations.  If specified, the context
     should exist on all processes in the group.  The `readout_ids`, `detsets`,
@@ -53,6 +68,19 @@ class LoadContext(Operator):
     metadata objects based on whether they use detector / sample axes.  The
     nested structure is flattened into names built from the keys in the
     hierarchy.
+
+    Important considerations for data distribution:
+
+    - Each "observation" in the Context system maps to a toast "observing
+      session".  By default, a Context observation is turned into a toast
+      observing session with one observation per wafer.  If `combine_wafers`
+      is True, then all wafers will be combined into a single toast
+      observation.
+
+    - In the default case of one observation per wafer, recall that only
+      one process in a group loads data from disk.  For jobs that are I/O
+      bound and loading multiple wafers, you should use multiple process
+      groups to parallelize the data loading (which is the dominant cost).
 
     """
 
@@ -90,10 +118,6 @@ class LoadContext(Operator):
         help="Apply pre-processing with this configuration",
     )
 
-    read_independent = Bool(
-        False, help="If True, all processes read det data independently"
-    )
-
     observations = List(list(), help="List of observation IDs to load")
 
     readout_ids = List(list(), help="Only load this list of readout_id values")
@@ -104,6 +128,11 @@ class LoadContext(Operator):
 
     dets_select = Dict(
         dict(), help="The `dets` selection dictionary to pass to get_obs()"
+    )
+
+    combine_wafers = Bool(
+        False,
+        help="If True, combine all wafers into a single observation",
     )
 
     ax_times = Unicode(
@@ -128,19 +157,19 @@ class LoadContext(Operator):
     )
 
     ax_boresight_az = Unicode(
-        "boresight_az",
+        "boresight:az",
         allow_none=True,
         help="Field with boresight Az",
     )
 
     ax_boresight_el = Unicode(
-        "boresight_el",
+        "boresight:el",
         allow_none=True,
         help="Field with boresight El",
     )
 
     ax_boresight_roll = Unicode(
-        "boresight_roll",
+        "boresight:roll",
         allow_none=True,
         help="Field with boresight Roll",
     )
@@ -149,6 +178,16 @@ class LoadContext(Operator):
         "hwp_angle",
         allow_none=True,
         help="Field with HWP angle",
+    )
+
+    ax_pathsep = Unicode(
+        ":",
+        help="Path separator when flattening nested fields",
+    )
+
+    ax_detinfo_wafer_key = Unicode(
+        "stream_id",
+        help="Name of the det_info property containing the wafer ID",
     )
 
     axis_detector = Unicode(
@@ -236,21 +275,6 @@ class LoadContext(Operator):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-    def _open_context(self):
-        if self.context is None:
-            # The user did not specify a context- create a temporary
-            # one from the file
-            return Context(self.context_file)
-        else:
-            # Just return the user-specified context.
-            return self.context
-
-    def _close_context(self, ctx):
-        if self.context is None:
-            # We previously created a context from a file.  Close
-            # / delete that now.
-            del ctx
-
     @function_timer
     def _exec(self, data, detectors=None, **kwargs):
         log = Logger.get()
@@ -267,13 +291,6 @@ class LoadContext(Operator):
             if self.context_file is not None:
                 msg = "Only one of the context or context_file should be specified"
                 raise RuntimeError(msg)
-
-        if not self.read_independent:
-            msg = "Parallel reading from a context is temporarily broken."
-            msg += " Forcing read_independent=True, but this will be very"
-            msg += " slow for more that ~64 processes."
-            self.read_independent = True
-            log.warning_rank(msg, comm=comm.comm_world)
 
         # Build our detector selection dictionary
         dets_select = None
@@ -321,7 +338,7 @@ class LoadContext(Operator):
             if self.preprocess_config is not None:
                 with open(self.preprocess_config, "r") as f:
                     preproc_conf = yaml.safe_load(f)
-            ctx = self._open_context()
+            ctx = open_context(context=self.context, context_file=self.context_file)
             if self.observation_regex is not None:
                 # Match against the full list of observation IDs
                 obs_list = []
@@ -333,12 +350,34 @@ class LoadContext(Operator):
 
             for iobs, obs_id in enumerate(obs_list):
                 meta = ctx.get_meta(obs_id=obs_id, dets=dets_select)
-                oprops = dict()
-                oprops["name"] = obs_id
-                oprops["duration"] = meta["obs_info"]["duration"]
-                oprops["n_det"] = len(meta["dets"].vals)
-                obs_props.append(oprops)
-            self._close_context(ctx)
+                if self.combine_wafers:
+                    # Place all wafers into a single session
+                    oprops = dict()
+                    oprops["name"] = obs_id
+                    oprops["session_name"] = obs_id
+                    oprops["wafer"] = "all"
+                    oprops["duration"] = meta["obs_info"]["duration"]
+                    oprops["n_det"] = len(meta["dets"].vals)
+                    obs_props.append(oprops)
+                else:
+                    # Get list of wafers from meta...
+                    duration = meta["obs_info"]["duration"]
+                    selected_wafers = list(
+                        sorted(set(meta["det_info"][self.ax_detinfo_wafer_key]))
+                    )
+                    for wf in selected_wafers:
+                        oprops = dict()
+                        oprops["name"] = f"{obs_id}_{wf}"
+                        oprops["session_name"] = obs_id
+                        oprops["wafer"] = wf
+                        oprops["duration"] = duration
+
+                        # Get number of dets in this wafer
+                        oprops["n_det"] = np.count_nonzero(
+                            meta["det_info"][self.ax_detinfo_wafer_key] == wf
+                        )
+                        obs_props.append(oprops)
+            close_context(ctx, context_file=self.context_file)
 
         if comm.comm_world is not None:
             obs_props = comm.comm_world.bcast(obs_props, root=0)
@@ -367,490 +406,463 @@ class LoadContext(Operator):
             otimer = Timer()
             otimer.start()
 
+            # If we have an observation with a specific wafer, modify the detector
+            # selection dictionary to include only that wafer.
+            obs_dets_select = dets_select
+            if obs_props[obindx]["wafer"] != "all":
+                if obs_dets_select is None:
+                    obs_dets_select = dict()
+                obs_dets_select[self.ax_detinfo_wafer_key] = obs_props[obindx]["wafer"]
+
             # One process in the group loads the metadata, builds the focalplane
             # model, and broadcasts to the rest of the group.
-
-            det_props = None
-            obs_meta = None
-            n_samp = None
-            if comm.group_rank == 0:
-                # Load metadata
-                ctx = self._open_context()
-                meta = ctx.get_meta(obs_name, dets=dets_select)
-                self._close_context(ctx)
-                n_samp = meta["samps"].count
-
-                if self.preprocess_config is not None:
-                    # Cut detectors with preprocessing
-                    prepipe = PreProcPipe(
-                        preproc_conf["process_pipe"],
-                        logger=log,
-                    )
-                    for process in prepipe:
-                        log.debug(f"Preprocess selecting on {process.name}")
-                        process.select(meta)
-
-                # For each element of meta we do the following:
-                # - If the object has one axis and it is the detector axis,
-                #   treat it as a column in the detector property table
-                # - If the object has one axis and it is the sample axis,
-                #   it will be loaded later as shared data.
-                # - If the object has multiple axes, load it later
-                # - If the object has no axes, then treat it as observation
-                #   metadata
-                # - If the object is a nested AxisManager, descend and apply
-                #   the same steps as above.
-                obs_meta = dict()
-                fp_cols = dict()
-                self._parse_meta(meta, None, obs_meta, None, fp_cols)
-
-                if self.analytic_bandpass:
-                    # Add bandpass information to the focalplane
-                    try:
-                        band = fp_cols["det_info_band"].data
-                    except KeyError:
-                        band = fp_cols["det_info_wafer_bandpass"].data
-                    freq = [float(b[1:]) for b in band]
-                    bandcenter = np.array(freq) * u.GHz
-                    bandwidth = bandcenter * self.bandwidth
-                    fp_cols["bandcenter"] = Column(name="bandcenter", data=bandcenter)
-                    fp_cols["bandwidth"] = Column(name="bandwidth", data=bandwidth)
-
-                # Construct table
-                det_props = QTable(fp_cols)
-                del meta
-
-            log.info_rank(
-                f"LoadContext {obs_name} metadata loaded in",
-                comm=comm.comm_group,
-                timer=otimer,
+            obs_meta, det_props, n_samp = self._load_metadata(
+                obs_name,
+                obs_props[obindx]["session_name"],
+                comm.comm_group,
+                obs_dets_select,
+                preproc_conf,
             )
 
-            if comm.comm_group is not None:
-                obs_meta = comm.comm_group.bcast(obs_meta, root=0)
-                det_props = comm.comm_group.bcast(det_props, root=0)
-                n_samp = comm.comm_group.bcast(n_samp, root=0)
-
-            log.info_rank(
-                f"LoadContext {obs_name} metadata bcast took",
-                comm=comm.comm_group,
-                timer=otimer,
+            # Create the instrument model for the observation
+            telescope, fp_flags = self._create_obs_instrument(
+                obs_name,
+                comm.comm_group,
+                det_props,
             )
 
-            # Create the observation.  We intentionally use the generic focalplane
-            # and class here, in case we are loading data from legacy experiments.
-
-            # Convert any focalplane quaternion offsets to toast format.  We also
-            # look for any detectors with NaN values and flag those with the
-            # processing bit.
-
-            name_col = Column(name="name", data=det_props["det_info_readout_id"])
-            det_props.add_column(name_col, index=0)
-
-            fp_flags = dict()
-            if "focal_plane_xi" in det_props.colnames:
-                fp_bad = np.logical_or(
-                    np.isnan(det_props["focal_plane_xi"]),
-                    np.logical_or(
-                        np.isnan(det_props["focal_plane_eta"]),
-                        np.isnan(det_props["focal_plane_gamma"]),
-                    ),
-                )
-                fp_flags = {
-                    x: defaults.det_mask_processing
-                    for x, y in zip(det_props["name"], fp_bad)
-                    if y
-                }
-                det_props["focal_plane_xi"][fp_bad] = 0
-                det_props["focal_plane_eta"][fp_bad] = 0
-                det_props["focal_plane_gamma"][fp_bad] = 0
-                quat_data = toast.instrument_coords.xieta_to_quat(
-                    det_props["focal_plane_xi"],
-                    det_props["focal_plane_eta"],
-                    det_props["focal_plane_gamma"],
-                )
-            else:
-                # No detector offsets yet
-                quat_data = np.tile(
-                    np.array([0, 0, 0, 1], dtype=np.float64),
-                    len(det_props["det_info_readout_id"]),
-                ).reshape((-1, 4))
-
-            # Do we have any good detectors left?
-            n_good = 0
-            for det in det_props["name"]:
-                if det not in fp_flags or fp_flags[det] == 0:
-                    n_good += 1
-            if n_good == 0:
-                log.warning_rank(
-                    f"LoadContext {obs_name} has no unflagged detectors, skipping!",
-                    comm=comm.comm_group,
-                )
-                continue
-
-            quat_col = Column(
-                name="quat",
-                data=quat_data,
-            )
-            det_props.add_column(quat_col, index=0)
-
-            focalplane = toast.instrument.Focalplane(
-                detector_data=det_props,
-                sample_rate=1.0 * u.Hz,
-            )
-
-            if self.detset_key is None:
-                detsets = None
-            else:
-                detsets = focalplane.detector_groups(self.detset_key)
-
-            # For now, this should be good enough position for instruments near the
-            # S.O. location.
-            site = SOSite()
-
-            telescope = toast.instrument.Telescope(
-                self.telescope_name, focalplane=focalplane, site=site
-            )
-
-            # Note:  the session times will be updated later when reading timestamps
-            session = toast.instrument.Session(obs_name)
-
-            ob = toast.Observation(
+            # Create the observation and allocate data objects
+            ob, have_pointing = self._create_observation(
+                obs_name,
+                obs_props[obindx]["session_name"],
                 comm,
                 telescope,
                 n_samp,
-                name=obs_name,
-                session=session,
-                detector_sets=detsets,
-                sample_sets=None,
-                process_rows=comm.group_size,
+                fp_flags,
             )
 
+            # Read and communicate data
+            self._load_data(ob, have_pointing, preproc_conf)
+
+            # Compute the boresight pointing and observatory position
+            if have_pointing:
+                compute_boresight_pointing(
+                    ob,
+                    self.times,
+                    self.azimuth,
+                    self.elevation,
+                    self.roll,
+                    self.boresight_azel,
+                    self.boresight_radec,
+                    defaults.position,
+                    defaults.velocity,
+                    self.shared_flags,
+                    defaults.shared_mask_processing,
+                )
+            data.obs.append(ob)
             log.info_rank(
-                f"LoadContext {obs_name} construct Observation in",
+                f"LoadContext {obs_name} loaded in",
                 comm=comm.comm_group,
                 timer=otimer,
             )
 
-            # Apply detector flags for bad pointing reconstruction
-            local_dets = set(ob.local_detectors)
-            local_fp_flags = {x: y for x, y in fp_flags.items() if x in local_dets}
-            ob.update_local_detector_flags(local_fp_flags)
+    def _load_metadata(self, obs_name, session_name, gcomm, dets_select, preproc_conf):
+        """Load observation metadata and the focalplane properties.
 
-            # Create observation fields
+        One process in the group loads the metadata, builds the focalplane
+        model, and broadcasts to the rest of the group.
+
+        Args:
+            obs_name (str):  The observation name
+            session_name (str):  The observing session name (context obs ID).
+            gcomm (MPI.Comm):  The group communicator or None.
+            dets_select (dict):  The detector selection dictionary passed to
+                Context.get_meta()
+            preproc_conf:  If not None, the preprocessing config dictionary used
+                to cut detectors when loading.
+
+        Returns:
+            (tuple):  The (observation metadata, detector property table, samples)
+                for the observation.
+
+        """
+        log = Logger.get()
+        timer = Timer()
+        timer.start()
+        if gcomm is None:
+            rank = 0
+        else:
+            rank = gcomm.rank
+
+        det_props = None
+        obs_meta = None
+        n_samp = None
+        if rank == 0:
+            # Load metadata
+            ctx = open_context(context=self.context, context_file=self.context_file)
+            meta = ctx.get_meta(session_name, dets=dets_select)
+            close_context(ctx, context_file=self.context_file)
+            n_samp = meta["samps"].count
+
+            if self.preprocess_config is not None:
+                # Cut detectors with preprocessing
+                prepipe = PreProcPipe(
+                    preproc_conf["process_pipe"],
+                    logger=log,
+                )
+                for process in prepipe:
+                    log.debug(f"Preprocess selecting on {process.name}")
+                    process.select(meta)
+
+            # Parse the axis manager metadata into observation metadata
+            # and detector properties.
+            obs_meta = dict()
+            fp_cols = dict()
+            parse_metadata(
+                meta,
+                obs_meta,
+                fp_cols,
+                self.ax_pathsep,
+                self.axis_detector,
+                None,
+                None,
+            )
+
+            # Set the column used by toast as the detector name.
+            fp_cols["name"] = Column(
+                name="name",
+                data=fp_cols[f"det_info{self.ax_pathsep}readout_id"].data,
+            )
+
+            if self.analytic_bandpass:
+                # Add bandpass information to the focalplane
+                try:
+                    band = fp_cols[f"det_info{self.ax_pathsep}band"].data
+                except KeyError:
+                    band = fp_cols[
+                        f"det_info{self.ax_pathsep}wafer{self.ax_pathsep}bandpass"
+                    ].data
+                freq = [float(b[1:]) for b in band]
+                bandcenter = np.array(freq) * u.GHz
+                bandwidth = bandcenter * self.bandwidth
+                fp_cols["bandcenter"] = Column(name="bandcenter", data=bandcenter)
+                fp_cols["bandwidth"] = Column(name="bandwidth", data=bandwidth)
+
+            # Construct table
+            det_props = QTable(fp_cols)
+            del meta
+
+            # Detector ordering.  When distributing and reading data, we
+            # need to have the detectors sorted into contiguous blocks of
+            # of detectors.  We sort the table now by wafer and then by name.
+            wafer_key = f"det_info{self.ax_pathsep}{self.ax_detinfo_wafer_key}"
+            det_props.sort([wafer_key, "name"])
+
+        log.debug_rank(
+            f"LoadContext {obs_name} metadata loaded in",
+            comm=gcomm,
+            timer=timer,
+        )
+
+        if gcomm is not None:
+            obs_meta = gcomm.bcast(obs_meta, root=0)
+            det_props = gcomm.bcast(det_props, root=0)
+            n_samp = gcomm.bcast(n_samp, root=0)
+
+        log.debug_rank(
+            f"LoadContext {obs_name} metadata bcast took",
+            comm=gcomm,
+            timer=timer,
+        )
+        return (obs_meta, det_props, n_samp)
+
+    def _create_obs_instrument(self, obs_name, gcomm, det_props):
+        """Create telescope, session, and focalplane flags.
+
+        These are objects needed prior to instantiating the Observation.
+
+        Args:
+            obs_name (str):  The observation name
+            gcomm (MPI.Comm):  The group communicator or None.
+            det_props (QTable):  The astropy table of detector properties.
+
+        Returns:
+            (tuple):  The (Telescope, per-detector flags) where the flags
+                cut detectors with the processing bit if they have no
+                pointing reconstruction.
+
+        """
+        log = Logger.get()
+
+        # Convert any focalplane quaternion offsets to toast format.  We also
+        # look for any detectors with NaN values and flag those with the
+        # processing bit.
+
+        xi_key = f"focal_plane{self.ax_pathsep}xi"
+        eta_key = f"focal_plane{self.ax_pathsep}eta"
+        gamma_key = f"focal_plane{self.ax_pathsep}gamma"
+
+        fp_flags = dict()
+        if xi_key in det_props.colnames:
+            fp_bad = np.logical_or(
+                np.isnan(det_props[xi_key]),
+                np.logical_or(
+                    np.isnan(det_props[eta_key]),
+                    np.isnan(det_props[gamma_key]),
+                ),
+            )
+            fp_flags = {
+                x: defaults.det_mask_processing
+                for x, y in zip(det_props["name"], fp_bad)
+                if y
+            }
+            det_props[xi_key][fp_bad] = 0
+            det_props[eta_key][fp_bad] = 0
+            det_props[gamma_key][fp_bad] = 0
+            quat_data = toast.instrument_coords.xieta_to_quat(
+                det_props[xi_key],
+                det_props[eta_key],
+                det_props[gamma_key],
+            )
+        else:
+            # No detector offsets yet
+            quat_data = np.tile(
+                np.array([0, 0, 0, 1], dtype=np.float64),
+                len(det_props[f"det_info{self.ax_pathsep}readout_id"]),
+            ).reshape((-1, 4))
+
+        # Do we have any good detectors left?
+        n_good = 0
+        for det in det_props["name"]:
+            if det not in fp_flags or fp_flags[det] == 0:
+                n_good += 1
+        if n_good == 0:
+            log.warning_rank(
+                f"LoadContext {obs_name} has no unflagged detectors, skipping!",
+                comm=gcomm,
+            )
+            return
+
+        quat_col = Column(
+            name="quat",
+            data=quat_data,
+        )
+        det_props.add_column(quat_col, index=0)
+
+        focalplane = toast.instrument.Focalplane(
+            detector_data=det_props,
+            sample_rate=1.0 * u.Hz,
+        )
+
+        # For now, this should be good enough position for instruments near the
+        # S.O. location.
+        site = SOSite()
+
+        telescope = toast.instrument.Telescope(
+            self.telescope_name, focalplane=focalplane, site=site
+        )
+        return telescope, fp_flags
+
+    def _create_observation(
+        self, obs_name, session_name, comm, telescope, n_samp, fp_flags
+    ):
+        """Create the observation.
+
+        Note that the focalplane table has already been sorted by wafer
+        name and then detector name.
+
+        Args:
+            obs_name (str):  The observation name
+            session_name (str):  The observing session name (context obs ID).
+            gcomm (MPI.Comm):  The group communicator or None.
+            telescope (Telescope):  The Telescope for this observation.
+            n_samp (int):  The number of samples in the observation.
+            fp_flags (dict):  The per-detector flags to apply.
+
+        Returns:
+            (tuple):  The (Observation, have_pointing), where the second
+                element is True if the observation has boresight pointing.
+
+        """
+        log = Logger.get()
+        timer = Timer()
+        timer.start()
+
+        # Computer the detector sets
+        if self.detset_key is None:
+            detsets = None
+        else:
+            detsets = telescope.focalplane.detector_groups(self.detset_key)
+
+        # Note:  the session times will be updated later when reading timestamps
+        session = toast.instrument.Session(session_name)
+
+        # Create the observation
+        ob = toast.Observation(
+            comm,
+            telescope,
+            n_samp,
+            name=obs_name,
+            session=session,
+            detector_sets=detsets,
+            sample_sets=None,
+            process_rows=comm.group_size,
+        )
+
+        # Apply detector flags for bad pointing reconstruction
+        local_dets = set(ob.local_detectors)
+        local_fp_flags = {x: y for x, y in fp_flags.items() if x in local_dets}
+        ob.update_local_detector_flags(local_fp_flags)
+
+        # Create observation fields
+        ob.shared.create_column(
+            self.times,
+            shape=(ob.n_local_samples,),
+            dtype=np.float64,
+        )
+
+        have_pointing = True
+        if self.ax_boresight_az is None:
+            have_pointing = False
+        else:
             ob.shared.create_column(
-                self.times,
+                self.azimuth,
+                shape=(ob.n_local_samples,),
+                dtype=np.float64,
+            )
+        if self.ax_boresight_el is None:
+            have_pointing = False
+        else:
+            ob.shared.create_column(
+                self.elevation,
+                shape=(ob.n_local_samples,),
+                dtype=np.float64,
+            )
+        if self.ax_boresight_roll is None:
+            have_pointing = False
+        else:
+            ob.shared.create_column(
+                self.roll,
                 shape=(ob.n_local_samples,),
                 dtype=np.float64,
             )
 
-            have_pointing = True
-            if self.ax_boresight_az is None:
-                have_pointing = False
-            else:
-                ob.shared.create_column(
-                    self.azimuth,
-                    shape=(ob.n_local_samples,),
-                    dtype=np.float64,
-                )
-            if self.ax_boresight_el is None:
-                have_pointing = False
-            else:
-                ob.shared.create_column(
-                    self.elevation,
-                    shape=(ob.n_local_samples,),
-                    dtype=np.float64,
-                )
-            if self.ax_boresight_roll is None:
-                have_pointing = False
-            else:
-                ob.shared.create_column(
-                    self.roll,
-                    shape=(ob.n_local_samples,),
-                    dtype=np.float64,
-                )
-            if have_pointing:
-                ob.shared.create_column(
-                    self.boresight_azel,
-                    shape=(ob.n_local_samples, 4),
-                    dtype=np.float64,
-                )
-                ob.shared.create_column(
-                    self.boresight_radec,
-                    shape=(ob.n_local_samples, 4),
-                    dtype=np.float64,
-                )
-            if self.hwp_angle is not None and self.ax_hwp_angle is not None:
-                ob.shared.create_column(
-                    self.hwp_angle,
-                    shape=(ob.n_local_samples,),
-                    dtype=np.float64,
-                )
-            if self.boresight_angle is not None:
-                ob.shared.create_column(
-                    self.boresight_angle,
-                    shape=(ob.n_local_samples,),
-                    dtype=np.float64,
-                )
-            if self.corotator_angle is not None:
-                ob.shared.create_column(
-                    self.corotator_angle,
-                    shape=(ob.n_local_samples,),
-                    dtype=np.float64,
-                )
+        if have_pointing:
             ob.shared.create_column(
-                self.shared_flags,
+                self.boresight_azel,
+                shape=(ob.n_local_samples, 4),
+                dtype=np.float64,
+            )
+            ob.shared.create_column(
+                self.boresight_radec,
+                shape=(ob.n_local_samples, 4),
+                dtype=np.float64,
+            )
+        if self.hwp_angle is not None and self.ax_hwp_angle is not None:
+            ob.shared.create_column(
+                self.hwp_angle,
                 shape=(ob.n_local_samples,),
-                dtype=np.uint8,
+                dtype=np.float64,
             )
-            if have_pointing:
-                ob.shared.create_column(
-                    defaults.position,
-                    shape=(ob.n_local_samples, 3),
-                    dtype=np.float64,
-                )
-                ob.shared.create_column(
-                    defaults.velocity,
-                    shape=(ob.n_local_samples, 3),
-                    dtype=np.float64,
-                )
-            if self.ax_det_signal is not None:
-                ob.detdata.create(
-                    self.det_data, dtype=np.float64, units=self.det_data_units
-                )
-                ob.detdata.create(self.det_flags, dtype=np.uint8)
-
-            log.info_rank(
-                f"LoadContext {obs_name} allocated TOD in",
-                comm=comm.comm_group,
-                timer=otimer,
+        if self.boresight_angle is not None:
+            ob.shared.create_column(
+                self.boresight_angle,
+                shape=(ob.n_local_samples,),
+                dtype=np.float64,
             )
-
-            # Load and distribute the detector data
-            axtod = self._read_detdata(
-                ob, preproc_conf, allread=self.read_independent
+        if self.corotator_angle is not None:
+            ob.shared.create_column(
+                self.corotator_angle,
+                shape=(ob.n_local_samples,),
+                dtype=np.float64,
             )
-
-            log.info_rank(
-                f"LoadContext {obs_name} AxisManager loaded in",
-                comm=comm.comm_group,
-                timer=otimer,
+        ob.shared.create_column(
+            self.shared_flags,
+            shape=(ob.n_local_samples,),
+            dtype=np.uint8,
+        )
+        if have_pointing:
+            ob.shared.create_column(
+                defaults.position,
+                shape=(ob.n_local_samples, 3),
+                dtype=np.float64,
             )
-
-            self._parse_data(ob, have_pointing, axtod, None)
-
-            # No longer needed
-            del axtod
-
-            log.info_rank(
-                f"LoadContext {obs_name} AxisManager to Observation conversion took",
-                comm=comm.comm_group,
-                timer=otimer,
+            ob.shared.create_column(
+                defaults.velocity,
+                shape=(ob.n_local_samples, 3),
+                dtype=np.float64,
             )
+        if self.ax_det_signal is not None:
+            ob.detdata.create(
+                self.det_data, dtype=np.float64, units=self.det_data_units
+            )
+            ob.detdata.create(self.det_flags, dtype=np.uint8)
 
-            # Position and velocity of the observatory are simply computed.  Only the
-            # first row of the process grid needs to do this.
-            if have_pointing:
-                position = None
-                velocity = None
-                if ob.comm_col_rank == 0:
-                    position, velocity = site.position_velocity(ob.shared[self.times])
-                ob.shared[defaults.position].set(position, offset=(0, 0), fromrank=0)
-                ob.shared[defaults.velocity].set(velocity, offset=(0, 0), fromrank=0)
-                log.info_rank(
-                    f"LoadContext {obs_name} site position/velocity took",
-                    comm=comm.comm_group,
-                    timer=otimer,
-                )
+        log.debug_rank(
+            f"LoadContext {obs_name} allocate Observation in",
+            comm=comm.comm_group,
+            timer=timer,
+        )
+        return ob, have_pointing
 
-                # Since this step takes some time, all processes in the group
-                # contribute
-                pnt_dist = distribute_uniform(ob.n_all_samples, comm.group_size)
+    def _load_data(self, ob, have_pointing, pconf):
+        """Recursively load AxisManager data.
 
-                bore_azel = None
-                bore_radec = None
-                bore_flags = None
+        The first process with detectors from a given wafer will read
+        all data for that wafer.  Some examples:
 
-                slc_off = pnt_dist[comm.group_rank].offset
-                slc_n = pnt_dist[comm.group_rank].n_elem
-                slc = slice(slc_off, slc_n, 1)
+        - 1 processes, 7 wafers:  rank 0 reads all wafers
+        - 2 processes, 7 wafers:  rank 0 reads 3 wafers, rank 1 reads 4 wafers
+        - 16 processes, 7 wafers:  ranks 0, 2, 4, 6, 9, 11, 13 read one wafer each
 
-                bore_bad = np.logical_or(
-                    np.isnan(ob.shared[self.azimuth].data[slc]),
-                    np.logical_or(
-                        np.isnan(ob.shared[self.elevation].data[slc]),
-                        np.isnan(ob.shared[self.roll].data[slc]),
-                    ),
-                )
-                bore_flags = np.array(ob.shared[self.shared_flags].data[slc])
-                bore_flags[bore_bad] |= defaults.shared_mask_processing
-                temp_az = np.array(ob.shared[self.azimuth].data[slc])
-                temp_el = np.array(ob.shared[self.elevation].data[slc])
-                temp_roll = np.array(ob.shared[self.roll].data[slc])
-                temp_az[bore_bad] = 0
-                temp_el[bore_bad] = 0
-                temp_roll[bore_bad] = 0
-                bore_azel = toast.qarray.from_lonlat_angles(
-                    -temp_az,
-                    temp_el,
-                    temp_roll,
-                )
-                bore_radec = toast.coordinates.azel_to_radec(
-                    site,
-                    ob.shared[self.times].data[slc],
-                    bore_azel,
-                    use_qpoint=True,
-                )
+        Each reading process will optionally apply the preprocessing
+        to the loaded data prior to distribution. The rank zero process (which
+        is always a reader) extracts any shared data and additional metadata that
+        is found.  Reading processes communicate slices of detector data to all
+        other processes.
 
-                if comm.comm_group is None:
-                    all_bore_flags = bore_flags
-                    all_bore_azel = bore_azel
-                    all_bore_radec = bore_radec
-                else:
-                    if ob.comm_col_rank == 0:
-                        all_bore_flags = np.concatenate(
-                            comm.comm_group.gather(bore_flags, root=0)
-                        )
-                    else:
-                        all_bore_flags = None
-                        _ = comm.comm_group.gather(bore_flags, root=0)
-                    del bore_flags
-                    if ob.comm_col_rank == 0:
-                        all_bore_azel = np.concatenate(
-                            comm.comm_group.gather(bore_azel, root=0)
-                        )
-                    else:
-                        all_bore_azel = None
-                        _ = comm.comm_group.gather(bore_azel, root=0)
-                    del bore_azel
-                    if ob.comm_col_rank == 0:
-                        all_bore_radec = np.concatenate(
-                            comm.comm_group.gather(bore_radec, root=0)
-                        )
-                    else:
-                        all_bore_radec = None
-                        _ = comm.comm_group.gather(bore_radec, root=0)
-                    del bore_radec
+        Args:
+            ob (Observation):  The observation to populate.
+            have_pointing (bool):  True if the data contains boresight pointing.
+            pconf (dict):  The optional preprocessing config.
 
-                ob.shared[self.shared_flags].set(
-                    all_bore_flags, offset=(0,), fromrank=0
-                )
-                ob.shared[self.boresight_azel].set(
-                    all_bore_azel, offset=(0, 0), fromrank=0
-                )
-                ob.shared[self.boresight_radec].set(
-                    all_bore_radec, offset=(0, 0), fromrank=0
-                )
+        Returns:
+            None
 
-                log.info_rank(
-                    f"LoadContext {obs_name} boresight pointing conversion took",
-                    comm=comm.comm_group,
-                    timer=otimer,
-                )
-
-            data.obs.append(ob)
-
-    def _read_detdata(self, obs, pconf, allread=False):
+        """
         log = Logger.get()
-        obs_name = obs.name
+        timer = Timer()
+        timer.start()
 
-        # By default, we attempt to use a single reading process and send
-        # restricted axis managers to each process.  Since these are potentially
-        # larger than 2GB, we try to use the new mpi4py support for pickle-5.
-        # If that is not available, we revert to having every process read
-        # independently.
-        gcomm = obs.comm.comm_group
-        if gcomm is None or gcomm.size == 1:
-            allread = True
-        elif not allread:
-            try:
-                from mpi4py.util import pkl5
+        comm = ob.comm
+        gcomm = comm.comm_group
+        rank = ob.comm.group_rank
 
-                gcomm = pkl5.Intracomm(gcomm)
-            except Exception:
-                msg = "Could not use pickle-5 communication, falling back to"
-                msg += " independent det data reading"
-                log.warning_rank(msg, comm=gcomm)
-                allread = True
+        # Compute the data distribution of detectors
+        wafer_key = f"det_info{self.ax_pathsep}{self.ax_detinfo_wafer_key}"
+        wafer_dets, wafer_readers, wafer_proc_dets, proc_wafer_dets = (
+            distribute_detector_props(ob, wafer_key)
+        )
 
-        if allread:
-            msg = f"LoadContext {obs_name} {obs.comm.group_size} processes "
-            msg += "reading independently"
-            log.info_rank(msg, comm=gcomm)
-            # Independent reading
-            ctx = self._open_context()
-            axtod = ctx.get_obs(obs_name, dets=obs.local_detectors)
-            self._close_context(ctx)
-            # Apply preprocessing.
-            if self.preprocess_config is not None:
-                prepipe = PreProcPipe(pconf["process_pipe"], logger=log)
-                prepipe.run(axtod, axtod.preprocess)
-        else:
-            msg = f"LoadContext {obs_name} one reader sending"
-            msg += f" data to {obs.comm.group_size} processes"
-            log.info_rank(msg, comm=gcomm)
-            # One process loads the whole observation and applies preprocessing
-            if gcomm.rank == 0:
-                ctx = self._open_context()
-                axfull = ctx.get_obs(obs_name, dets=obs.all_detectors)
-                self._close_context(ctx)
-                # Apply preprocessing.
-                if self.preprocess_config is not None:
-                    prepipe = PreProcPipe(pconf["process_pipe"], logger=log)
-                    prepipe.run(axfull, axfull.preprocess)
+        # Load data and apply preprocessing.
+        axwafers = read_and_preprocess_wafers(
+            ob.name,
+            ob.session.name,
+            gcomm,
+            wafer_readers,
+            wafer_dets,
+            pconf=pconf,
+            context=self.context,
+            context_file=self.context_file,
+        )
 
-            if gcomm.rank == 0:
-                # We will keep 2 buffers in memory to better overlap
-                # axis manager restriction and communication.
-                req_even = None
-                req_odd = None
-                tod_even = None
-                tod_odd = None
-                # Loop in reverse order so that the rank zero process
-                # can restrict its own data while waiting for communication
-                # to finish at the end.
-                for grank in range(gcomm.size - 1, -1, -1):
-                    rank_dets = obs.dist.dets[grank]
-                    if grank == 0:
-                        # Extract our own data
-                        axtod = axfull.restrict("dets", rank_dets, in_place=False)
-                    else:
-                        # Restrict and send
-                        if grank % 2 == 0:
-                            if req_even is not None:
-                                req_even.wait()
-                                del tod_even
-                        else:
-                            if req_odd is not None:
-                                req_odd.wait()
-                                del tod_odd
-                        if grank % 2 == 0:
-                            tod_even = axfull.restrict(
-                                "dets", rank_dets, in_place=False
-                            )
-                        else:
-                            tod_odd = axfull.restrict("dets", rank_dets, in_place=False)
-                        if grank % 2 == 0:
-                            req_even = gcomm.isend(tod_even, grank, tag=grank)
-                        else:
-                            req_odd = gcomm.isend(tod_odd, grank, tag=grank)
-                if req_even is not None:
-                    req_even.wait()
-                    del tod_even
-                if req_odd is not None:
-                    req_odd.wait()
-                    del tod_odd
-                del axfull
-            else:
-                # Receive our data
-                axtod = gcomm.recv(source=0, tag=gcomm.rank)
-            gcomm.barrier()
-        return axtod
+        log.debug_rank(
+            f"LoadContext {ob.name} AxisManager data loaded in",
+            comm=gcomm,
+            timer=timer,
+        )
 
-    def _parse_data(self, obs, have_pointing, axman, base):
-        # Some metadata has already been parsed, but some new values
-        # may only show up when reading data, so we need to handle those
-        # as well.
+        # Track the fields we are extracting
         shared_ax_to_obs = {self.ax_times: self.times}
         if have_pointing:
             shared_ax_to_obs[self.ax_boresight_az] = self.azimuth
@@ -863,15 +875,192 @@ class LoadContext(Operator):
         det_flag_invert = {x[0]: (x[1] < 0) for x in self.ax_det_flags}
         det_flag_fields = {x[0]: abs(x[1]) for x in self.ax_det_flags}
 
+        # The results of the recursive parsing
+        extra_meta = dict()
+        shared_data = dict()
+        det_data = dict()
+        interval_data = dict()
+
+        # Recursively parse axis managers and build list of data to
+        # populate in the observation.  Since all wafers have the same
+        # ancil data (and the same field names, just with different
+        # detectors), we can just do this on one process and broadcast
+        # the result
+        temp_shared = None
+        if ob.comm.group_rank == 0:
+            first_wafer = list(axwafers.keys())[0]
+            self._parse_data(
+                ob,
+                axwafers[first_wafer],
+                shared_ax_to_obs,
+                shared_flag_fields,
+                shared_flag_invert,
+                det_flag_fields,
+                det_flag_invert,
+                extra_meta,
+                shared_data,
+                det_data,
+                interval_data,
+                None,
+            )
+            temp_shared = {x: None for x, y in shared_data.items()}
+
+        if gcomm is not None:
+            extra_meta = gcomm.bcast(extra_meta, root=0)
+            temp_shared = gcomm.bcast(temp_shared, root=0)
+            if ob.comm.group_rank != 0:
+                shared_data = temp_shared
+            det_data = gcomm.bcast(det_data, root=0)
+            interval_data = gcomm.bcast(interval_data, root=0)
+
+        # Add extra metadata that was discovered.
+        ob.update(extra_meta)
+
+        log.debug_rank(
+            f"LoadContext {ob.name} AxisManager field parsing took",
+            comm=gcomm,
+            timer=timer,
+        )
+
+        # Create the intervals
+        for intr_name, sampspans in interval_data.items():
+            ob.intervals[intr_name] = toast.intervals.IntervalList(
+                ob.shared[self.times], samplespans=sampspans
+            )
+
+        # Collectively store shared data.  All readers have a full copy of
+        # this data, but we only set this from rank zero.
+        for shr_obs_name, shrbuf in shared_data.items():
+            ob.shared[shr_obs_name].set(shrbuf, fromrank=0)
+
+        log.debug_rank(
+            f"LoadContext {ob.name} Shared data copy took",
+            comm=gcomm,
+            timer=timer,
+        )
+
+        # Now that we have timestamps loaded, update our focalplane sample rate
+        # and observing session times.
+        (rate, dt, dt_min, dt_max, dt_std) = toast.utils.rate_from_times(
+            ob.shared[self.times].data
+        )
+        ob.telescope.focalplane.rate = rate * u.Hz
+
+        ob.session.start = datetime.fromtimestamp(
+            ob.shared[self.times].data[0]
+        ).astimezone(timezone.utc)
+        ob.session.end = datetime.fromtimestamp(
+            ob.shared[self.times].data[-1]
+        ).astimezone(timezone.utc)
+
+        log.debug_rank(
+            f"LoadContext {ob.name} sample rate calculation took",
+            comm=gcomm,
+            timer=timer,
+        )
+
+        # Distribute detector data
+        for field, (ax_field, ax_dtype, mask) in det_data.items():
+            do_invert = False
+            if ax_field in det_flag_invert:
+                do_invert = det_flag_invert[ax_field]
+            distribute_detector_data(
+                ob,
+                field,
+                axwafers,
+                ax_field,
+                ax_dtype,
+                wafer_readers,
+                wafer_proc_dets,
+                proc_wafer_dets,
+                is_flag=(mask is not None),
+                flag_invert=do_invert,
+                flag_mask=mask,
+            )
+
+        # Original wafer data no longer needed
+        del axwafers
+
+        log.debug_rank(
+            f"LoadContext {ob.name} Detector data distribution took",
+            comm=gcomm,
+            timer=timer,
+        )
+
+    def _parse_data(
+        self,
+        obs,
+        axman,
+        shared_ax_to_obs,
+        shared_flag_fields,
+        shared_flag_invert,
+        det_flag_fields,
+        det_flag_invert,
+        extra_meta,
+        shared_data,
+        det_data,
+        interval_data,
+        base,
+    ):
+        """Recursively parse AxisManager data products.
+
+        This (mostly) does not actually extract the data, but instead builds
+        up information needed to extract that data in following steps.
+
+        Args:
+            obs (Observation):  The observation
+            axman (AxisManager):  The top-level axis manager
+            shared_ax_to_obs (dict):  For each ancil axis manager field, the
+                corresponding observation shared key.
+            shared_flag_fields (dict):  For each shared axis manager field, the
+                (target observation flag field, bit mask) where this should be
+                merged.
+            shared_flag_invert (dict):  For each shared axis manager flag field,
+                whether the meaning of the flag should be inverted.
+            det_flag_fields (dict):  For each axis manager detector flag field,
+                the (target observation detdata field, bit mask) where this
+                should be merged.
+            det_flag_invert (dict):  For each axis manager detector flag field,
+                whether the meaning of the flag should be inverted.
+            extra_meta (dict):  Any new / additional metadata found on the root
+                process.
+            shared_data (dict):  For each shared observation field, a handle to
+                the axis manager data buffer to use.  This is only significant
+                on the rank zero process.
+            det_data (dict):  For each detector data field, a tuple of (axman
+                field, flag mask).  This is significant on the reading processes.
+                If the data is signal then flag mask will be None.
+            interval_data (dict):  For each observation interval field, the
+                sample spans to use.  Only significant on the rank zero process.
+            base (str):  The current dictionary key for this recursion level.
+
+        Returns:
+            None
+
+        """
+        # Some metadata has already been parsed, but some new values
+        # may only show up when reading data, so we need to handle those
+        # as well.
+        rank = obs.comm.group_rank
+
+        created_meta_extra = False
+        created_meta_obs = False
+
         if base is None:
-            om = obs
+            mcur = obs
+            mext = extra_meta
         else:
             if base not in obs:
+                created_meta_obs = True
                 obs[base] = dict()
-            om = obs[base]
+            mcur = obs[base]
+            if base not in extra_meta:
+                created_meta_extra = True
+                extra_meta[base] = dict()
+            mext = extra_meta[base]
         for key in axman.keys():
             if base is not None:
-                data_key = f"{base}_{key}"
+                data_key = f"{base}{self.ax_pathsep}{key}"
             else:
                 data_key = key
             if isinstance(axman[key], AxisInterface):
@@ -879,10 +1068,36 @@ class LoadContext(Operator):
                 continue
             if isinstance(axman[key], FlagManager):
                 # Descend- Anything different we need to do here?
-                self._parse_data(obs, have_pointing, axman[key], key)
+                self._parse_data(
+                    obs,
+                    axman[key],
+                    shared_ax_to_obs,
+                    shared_flag_fields,
+                    shared_flag_invert,
+                    det_flag_fields,
+                    det_flag_invert,
+                    extra_meta,
+                    shared_data,
+                    det_data,
+                    interval_data,
+                    key,
+                )
             elif isinstance(axman[key], AxisManager):
                 # Descend
-                self._parse_data(obs, have_pointing, axman[key], key)
+                self._parse_data(
+                    obs,
+                    axman[key],
+                    shared_ax_to_obs,
+                    shared_flag_fields,
+                    shared_flag_invert,
+                    det_flag_fields,
+                    det_flag_invert,
+                    extra_meta,
+                    shared_data,
+                    det_data,
+                    interval_data,
+                    key,
+                )
             else:
                 # FIXME:  It would be nicer if this information was available
                 # through a public member...
@@ -890,8 +1105,8 @@ class LoadContext(Operator):
                 if len(field_axes) == 0:
                     # This data is not associated with an axis.  If it does not
                     # yet exist in the observation metadata, then add it.
-                    if key not in om:
-                        om[key] = axman[key]
+                    if key not in mcur:
+                        mext[key] = axman[key]
                 elif field_axes[0] == self.axis_detector:
                     if len(field_axes) == 1:
                         # This is a detector property
@@ -900,155 +1115,77 @@ class LoadContext(Operator):
                             continue
                         # This must be some per-detector derived data- add to the
                         # observation dictionary
-                        if data_key not in om:
-                            om[key] = axman[key]
+                        if data_key not in mcur:
+                            mext[key] = axman[key]
                     elif field_axes[1] == self.axis_sample:
                         # This is detector data.  See if it is one of the standard
                         # fields we are parsing.
+                        dt = axman[key].dtype
                         if data_key == self.ax_det_signal:
-                            obs.detdata[self.det_data][:, :] = axman[key]
+                            # Detector signal
+                            det_data[self.det_data] = (key, dt, None)
                         elif data_key in det_flag_fields:
-                            if isinstance(axman[key], so3g.proj.RangesMatrix):
-                                temp = np.empty(obs.n_local_samples, dtype=np.uint8)
-                                if det_flag_invert[data_key]:
-                                    for idet, det in enumerate(obs.local_detectors):
-                                        temp[:] = det_flag_fields[data_key]
-                                        for rg in axman[key][idet].ranges():
-                                            temp[rg[0] : rg[1]] = 0
-                                        obs.detdata[self.det_flags][det] |= temp
-                                else:
-                                    for idet, det in enumerate(obs.local_detectors):
-                                        temp[:] = 0
-                                        for rg in axman[key][idet].ranges():
-                                            temp[rg[0] : rg[1]] = det_flag_fields[
-                                                data_key
-                                            ]
-                                        obs.detdata[self.det_flags][det] |= temp
-                            else:
-                                # Explicit flags per sample
-                                temp = det_flag_fields[data_key] * np.ones_like(
-                                    obs.detdata[self.det_flags][:]
-                                )
-                                if det_flag_invert[data_key]:
-                                    temp[axman[key] != 0] = 0
-                                else:
-                                    temp[axman[key] == 0] = 0
-                                obs.detdata[self.det_flags][:] |= temp
-                        else:
-                            # Some other kind of detector data
-                            if len(axman[key].shape) > 2:
-                                shp = axman[key].shape[2:]
-                            else:
-                                shp = None
-                            obs.detdata.create(
-                                data_key,
-                                sample_shape=shp,
-                                dtype=axman[key].dtype,
-                                units=u.dimensionless_unscaled,
+                            # One of the flag fields
+                            det_data[self.det_data] = (
+                                key,
+                                dt,
+                                det_flag_fields[data_key],
                             )
-                            for idet, det in enumerate(obs.local_detectors):
-                                obs.detdata[data_key][idet] = axman[key][idet]
+                        else:
+                            # Some other kind of detector data.  Ignore this for now,
+                            # since this needs to be pre-created in the observation
+                            # for all processes (not just the readers).  If we need
+                            # to read other detector data fields we should add a trait
+                            # for those specifying the shape and type.
+                            pass
                     else:
                         # Must be some other type of object...
-                        if data_key not in om:
-                            om[key] = axman[key]
+                        if data_key not in mcur:
+                            mext[key] = axman[key]
                 elif field_axes[0] == self.axis_sample:
                     # This is shared data
                     if isinstance(axman[key], so3g.proj.Ranges):
                         # This is a set of 1D shared ranges.  Translate this to a
                         # toast interval list.
-                        samplespans = list()
-                        for rg in axman[key].ranges():
-                            samplespans.append((rg[0], rg[1] - 1))
-                        obs.intervals[data_key] = toast.intervals.IntervalList(
-                            obs.shared[self.times], samplespans=samplespans
-                        )
+                        if rank == 0:
+                            samplespans = list()
+                            for rg in axman[key].ranges():
+                                samplespans.append((rg[0], rg[1] - 1))
+                            interval_data[data_key] = samplespans
                     elif data_key in shared_ax_to_obs:
-                        axbuf = None
-                        if obs.comm_col_rank == 0:
-                            axbuf = axman[key]
-                        obs.shared[shared_ax_to_obs[data_key]].set(
-                            axbuf,
-                            fromrank=0,
-                        )
+                        # One of our selected shared data fields
+                        if rank == 0:
+                            shared_data[shared_ax_to_obs[data_key]] = axman[key]
                     elif data_key in shared_flag_fields:
-                        axbuf = None
-                        if obs.comm_col_rank == 0:
-                            axbuf = np.array(obs.shared[self.shared_flags])
-                            temp = shared_flag_fields[data_key] * np.ones_like(axbuf)
+                        # One of our selected flag fields
+                        if obs.rank == 0:
+                            if self.shared_flags not in shared_data:
+                                shared_data[self.shared_flags] = np.array(
+                                    obs.shared[self.shared_flags].data
+                                )
+                            temp = shared_flag_fields[data_key] * np.ones_like(
+                                axman[key]
+                            )
                             if shared_flag_invert[data_key]:
                                 temp[axman[key] != 0] = 0
                             else:
                                 temp[axman[key] == 0] = 0
-                            axbuf |= temp
-                        obs.shared[self.shared_flags].set(
-                            axbuf,
-                            fromrank=0,
-                        )
+                            shared_data[self.shared_flags] |= temp
+                            del temp
                     else:
                         # This is some other shared data.
-                        # FIXME: we skip this for now.  If we want to re-enable,
-                        # we should pre-create this shared data or debug a
-                        # deadlock that occurs when running the code as it is.
+                        # FIXME: we skip this for now.
                         continue
-                        obs.shared.create_column(
-                            data_key,
-                            shape=axman[key].shape,
-                            dtype=axman[key].dtype,
-                        )
-                        sdata = None
-                        if obs.comm_col_rank == 0:
-                            sdata = axman[key]
-                        obs.shared[data_key].set(sdata)
                 else:
                     # Some other object...
-                    if data_key not in om:
-                        om[key] = axman[key]
+                    if data_key not in mcur:
+                        mext[key] = axman[key]
 
-        # Now that we have timestamps loaded, update our focalplane sample rate
-        (rate, dt, dt_min, dt_max, dt_std) = toast.utils.rate_from_times(
-            obs.shared[self.times].data
-        )
-        obs.telescope.focalplane.rate = rate * u.Hz
-
-        if base is not None and len(om) == 0:
-            # We created a dictionary that was not used, clean it up
+        # Clean up any dictionaries that we created if they were empty
+        if created_meta_extra and len(mext) == 0:
+            del extra_meta[base]
+        if created_meta_obs and len(mcur) == 0:
             del obs[base]
-
-    def _parse_meta(self, axman, obs_base, obs_meta, fp_base, fp_cols):
-        if obs_base is None:
-            om = obs_meta
-        else:
-            obs_meta[obs_base] = dict()
-            om = obs_meta[obs_base]
-        for key in axman.keys():
-            if fp_base is not None:
-                fp_key = f"{fp_base}_{key}"
-            else:
-                fp_key = key
-            if isinstance(axman[key], AxisInterface):
-                # This is one of the axes
-                continue
-            if isinstance(axman[key], AxisManager):
-                # Descend
-                self._parse_meta(axman[key], key, obs_meta, fp_key, fp_cols)
-            else:
-                # FIXME:  It would be nicer if this information was available
-                # through a public member...
-                field_axes = axman._assignments[key]
-                if len(field_axes) == 0:
-                    # This data is not associated with an axis.
-                    om[key] = axman[key]
-                elif len(field_axes) == 1 and field_axes[0] == self.axis_detector:
-                    # This is a detector property
-                    if fp_key in fp_cols:
-                        msg = f"Context meta key '{fp_key}' is duplicated in nested"
-                        msg += " AxisManagers"
-                        raise RuntimeError(msg)
-                    fp_cols[fp_key] = Column(name=fp_key, data=np.array(axman[key]))
-        if obs_base is not None and len(om) == 0:
-            # There were no meta data keys- delete this dict
-            del obs_meta[obs_base]
 
     def _finalize(self, data, **kwargs):
         return

--- a/sotodlib/toast/ops/load_context.py
+++ b/sotodlib/toast/ops/load_context.py
@@ -643,11 +643,18 @@ class LoadContext(Operator):
             )
             return
 
+        # Add a column for the quaternion offset of each detector, as well
+        # as the gamma angle with standard naming.
         quat_col = Column(
             name="quat",
             data=quat_data,
         )
         det_props.add_column(quat_col, index=0)
+        gamma_col = Column(
+            name="gamma",
+            data=det_props[gamma_key],
+        )
+        det_props.add_column(gamma_col)
 
         focalplane = toast.instrument.Focalplane(
             detector_data=det_props,

--- a/sotodlib/toast/ops/load_context.py
+++ b/sotodlib/toast/ops/load_context.py
@@ -652,7 +652,7 @@ class LoadContext(Operator):
         det_props.add_column(quat_col, index=0)
         gamma_col = Column(
             name="gamma",
-            data=det_props[gamma_key],
+            data=det_props[gamma_key] * u.radian,
         )
         det_props.add_column(gamma_col)
 

--- a/sotodlib/toast/ops/load_context.py
+++ b/sotodlib/toast/ops/load_context.py
@@ -956,7 +956,7 @@ class LoadContext(Operator):
         (rate, dt, dt_min, dt_max, dt_std) = toast.utils.rate_from_times(
             ob.shared[self.times].data
         )
-        ob.telescope.focalplane.rate = rate * u.Hz
+        ob.telescope.focalplane.sample_rate = rate * u.Hz
 
         ob.session.start = datetime.fromtimestamp(
             ob.shared[self.times].data[0]

--- a/sotodlib/toast/ops/load_context_utils.py
+++ b/sotodlib/toast/ops/load_context_utils.py
@@ -32,13 +32,7 @@ def open_context(context=None, context_file=None):
         return context
 
 
-def close_context(context=None, context_file=None):
-    if context_file is None:
-        # We are using a pre-created context, do nothing
-        return
-    del context
-
-
+@function_timer
 def read_and_preprocess_wafers(
     obs_name,
     session_name,
@@ -81,7 +75,8 @@ def read_and_preprocess_wafers(
         if reader == rank:
             ctx = open_context(context=context, context_file=context_file)
             axtod = ctx.get_obs(session_name, dets=wafer_dets[wf])
-            close_context(ctx, context_file=context_file)
+            if context_file is not None:
+                del ctx
             timer.stop()
             elapsed = timer.seconds()
             timer.start()
@@ -265,6 +260,7 @@ def distribute_detector_props(obs, wafer_key):
     return (wafer_dets, wafer_readers, wafer_proc_dets, proc_wafer_dets)
 
 
+@function_timer
 def distribute_detector_data(
     obs,
     field,
@@ -406,6 +402,7 @@ def distribute_detector_data(
     del send_data
 
 
+@function_timer
 def compute_boresight_pointing(
     obs,
     times_key,

--- a/sotodlib/toast/ops/load_context_utils.py
+++ b/sotodlib/toast/ops/load_context_utils.py
@@ -1,0 +1,555 @@
+# Copyright (c) 2022-2024 Simons Observatory.
+# Full license can be found in the top level "LICENSE" file.
+"""Helper functions for LoadContext operator."""
+
+import os
+import numpy as np
+
+from astropy import units as u
+from astropy.table import Column, QTable
+
+import so3g
+
+import toast
+from toast.mpi import MPI
+from toast.timing import function_timer, Timer
+from toast.utils import Environment, Logger
+from toast.dist import distribute_discrete, distribute_uniform
+
+from ...core import Context, AxisManager, FlagManager
+from ...core.axisman import AxisInterface
+from ...preprocess import Pipeline as PreProcPipe
+from ...hwp.hwp_angle_model import apply_hwp_angle_model
+
+
+def open_context(context=None, context_file=None):
+    if context is None:
+        # The user did not specify a context- create a temporary
+        # one from the file
+        return Context(context_file)
+    else:
+        # Just return the user-specified context.
+        return context
+
+
+def close_context(context=None, context_file=None):
+    if context_file is None:
+        # We are using a pre-created context, do nothing
+        return
+    del context
+
+
+def read_and_preprocess_wafers(
+    obs_name,
+    session_name,
+    gcomm,
+    wafer_readers,
+    wafer_dets,
+    pconf=None,
+    context=None,
+    context_file=None,
+):
+    """Read the wafer data.
+
+    Each process reads zero or more wafers and applies preprocessing.
+
+    Args:
+        obs_name (str):  The observation name.
+        session_name (str):  The observing session.
+        gcomm (MPIComm):  The observation group communicator, or None.
+        wafer_readers (dict):  For each wafer name, the group rank assigned
+            to read this wafer.
+        wafer_dets (dict):  For each wafer name, the list of detectors.
+        pconf (dict):  The preprocessing configuration to apply (or None).
+        context (Context):  The pre-existing Context or None.
+        context_file (str):  The context file to open or None.
+
+    Returns:
+        (dict):  The AxisManager data for each wafer on this process (or None).
+
+    """
+    log = Logger.get()
+    timer = Timer()
+    timer.start()
+    if gcomm is None:
+        rank = 0
+    else:
+        rank = gcomm.rank
+
+    results = dict()
+    for wf, reader in wafer_readers.items():
+        if reader == rank:
+            ctx = open_context(context=context, context_file=context_file)
+            axtod = ctx.get_obs(session_name, dets=wafer_dets[wf])
+            close_context(ctx, context_file=context_file)
+            timer.stop()
+            elapsed = timer.seconds()
+            timer.start()
+            log.debug(
+                f"LoadContext {obs_name} loaded wafer {wf} in {elapsed} seconds",
+            )
+
+            # If the axis manager has a HWP angle solution, apply it.
+            if "hwp_solution" in axtod:
+                axtod = apply_hwp_angle_model(axtod)
+                timer.stop()
+                elapsed = timer.seconds()
+                timer.start()
+                log.debug(
+                    f"LoadContext {obs_name} HWP model wafer {wf} in {elapsed} seconds",
+                )
+
+            if pconf is not None:
+                prepipe = PreProcPipe(pconf["process_pipe"], logger=log)
+                prepipe.run(axtod, axtod.preprocess)
+                timer.stop()
+                elapsed = timer.seconds()
+                timer.start()
+                msg = f"LoadContext {obs_name} apply preproc to {wf}"
+                msg += f" in {elapsed} seconds"
+                log.debug(msg)
+            results[wf] = axtod
+    return results
+
+
+def parse_metadata(axman, obs_meta, fp_cols, path_sep, det_axis, obs_base, fp_base):
+    """Parse Context metadata.
+
+    This is a recursive function which starts with the AxisManger returned
+    by `Context.get_meta()` and splits meta data into "detector properties"
+    which will be placed in the focalplane model and "other metadata" which
+    will be stored in the Observation dictionary.
+
+    For each element of the input AxisManager we do the following:
+
+    - If the object has one axis and it is the detector axis,
+      treat it as a column in the detector property table
+    - If the object has one axis and it is the sample axis,
+      it will be loaded later as shared data.
+    - If the object has multiple axes, load it later
+    - If the object has no axes, then treat it as observation
+      metadata
+    - If the object is a nested AxisManager, descend and apply
+      the same steps as above.
+
+    Args:
+        axman (AxisManager):  The input axismanager.
+        obs_meta (dict):  The working dictionary of observation metadata.
+        fp_cols (dict):  Dictionary of table Columns of detector properties.
+        path_sep (str):  The path separation char when building flattened names.
+        det_axis (str):  The name of the detector axis.
+        obs_base (str):  The current key in the nested observation metadata.
+        fp_base (str):  The current key to use when appending focalplane columns.
+
+    Returns:
+        None
+
+    """
+    if obs_base is None:
+        om = obs_meta
+    else:
+        obs_meta[obs_base] = dict()
+        om = obs_meta[obs_base]
+    for key in axman.keys():
+        if fp_base is not None:
+            fp_key = f"{fp_base}{path_sep}{key}"
+        else:
+            fp_key = key
+        if isinstance(axman[key], AxisInterface):
+            # This is one of the axes
+            continue
+        if isinstance(axman[key], AxisManager):
+            # Descend
+            parse_metadata(
+                axman[key], obs_meta, fp_cols, path_sep, det_axis, key, fp_key
+            )
+        else:
+            # FIXME:  It would be nicer if this information was available
+            # through a public member...
+            field_axes = axman._assignments[key]
+            if len(field_axes) == 0:
+                # This data is not associated with an axis.
+                om[key] = axman[key]
+            elif len(field_axes) == 1 and field_axes[0] == det_axis:
+                # This is a detector property
+                if fp_key in fp_cols:
+                    msg = f"Context meta key '{fp_key}' is duplicated in nested"
+                    msg += " AxisManagers"
+                    raise RuntimeError(msg)
+                fp_cols[fp_key] = Column(name=fp_key, data=np.array(axman[key]))
+    if obs_base is not None and len(om) == 0:
+        # There were no meta data keys- delete this dict
+        del obs_meta[obs_base]
+
+
+def distribute_detector_props(obs, wafer_key):
+    """Compute the communication patterns for detector data.
+
+    This computes the range of local detector indices for each wafer on all
+    processes, and also the corresponding range of indices in the wafer data
+    on the reading process.
+
+    Args:
+        obs (Observation):  The observation.
+        wafer_key (str):  The column of the focalplane table with the wafer name.
+
+    Returns:
+        (tuple):  The (wafer_dets, wafer_readers, wafer_proc_dets, proc_wafer_dets)
+
+    """
+    gcomm = obs.comm.comm_group
+    rank = obs.comm.group_rank
+    gsize = obs.comm.group_size
+
+    det_table = obs.telescope.focalplane.detector_data
+    det_names = obs.all_detectors
+    det_wafers = list(det_table[wafer_key])
+
+    proc_wafer_dets = dict()
+    wafer_proc_dets = dict()
+    wafer_readers = dict()
+    wafer_dets = dict()
+
+    wafer_off = 0
+    cur_wafer = det_wafers[0]
+    wafer_proc_dets[cur_wafer] = dict()
+    wafer_readers[cur_wafer] = 0
+    wafer_dets[cur_wafer] = list()
+    for proc in range(gsize):
+        proc_wafer_dets[proc] = dict()
+        full_indices = obs.dist.det_indices[proc]
+        full_slc = slice(
+            full_indices.offset, full_indices.offset + full_indices.n_elem, 1
+        )
+        local_det_names = det_names[full_slc]
+        local_det_wafers = det_wafers[full_slc]
+        local_wafers = list(sorted(set(local_det_wafers)))
+        if local_det_wafers[0] != cur_wafer:
+            # This process starts on a new wafer
+            cur_wafer = local_det_wafers[0]
+            wafer_off = 0
+        # Check for wafer transitions in this process's data
+        wafer_change = [
+            x
+            for x, (y, z) in enumerate(zip(local_det_wafers[:-1], local_det_wafers[1:]))
+            if y != z
+        ]
+        # Add the detector ranges to the mapping dictionaries
+        wfirst = 0
+        for wc in wafer_change:
+            wlast = wc
+            nwblock = wlast - wfirst + 1
+            # Extend list of detectors for this wafer
+            wafer_dets[cur_wafer].extend(local_det_names[wfirst : wlast + 1])
+            # Detector indices for this wafer in the local data
+            proc_wafer_dets[proc][cur_wafer] = (wfirst, wlast + 1)
+            # Detector indices for this process's local data within the full
+            # wafer data.
+            wafer_proc_dets[cur_wafer][proc] = (wafer_off, wafer_off + nwblock)
+            wfirst = wlast + 1
+            # We are now on a new wafer.  Reset the wafer detector offset and
+            # also assign the reading to this process.
+            cur_wafer = local_det_wafers[wlast + 1]
+            wafer_off = 0
+            wafer_dets[cur_wafer] = list()
+            wafer_readers[cur_wafer] = proc
+            wafer_proc_dets[cur_wafer] = dict()
+        # Handle final block
+        wlast = len(local_det_wafers) - 1
+        nwblock = wlast - wfirst + 1
+        wafer_dets[cur_wafer].extend(local_det_names[wfirst : wlast + 1])
+        proc_wafer_dets[proc][cur_wafer] = (wfirst, wlast + 1)
+        wafer_proc_dets[cur_wafer][proc] = (wafer_off, wafer_off + nwblock)
+        wafer_off += nwblock
+
+    return (wafer_dets, wafer_readers, wafer_proc_dets, proc_wafer_dets)
+
+
+def distribute_detector_data(
+    obs,
+    field,
+    axwafers,
+    axfield,
+    axdtype,
+    wafer_readers,
+    wafer_proc_dets,
+    proc_wafer_dets,
+    is_flag=False,
+    flag_invert=False,
+    flag_mask=None,
+):
+    gcomm = obs.comm.comm_group
+    rank = obs.comm.group_rank
+    gsize = obs.comm.group_size
+
+    # If the blocks of detector data exceed 2^30 elements in total, they might hit
+    # MPI limitations on the communication message sizes.  Work around that here.
+    try:
+        from mpi4py.util import pkl5
+
+        if gcomm is not None:
+            gcomm = pkl5.Intracomm(gcomm)
+    except Exception:
+        pass
+
+    def _process_flag(mask, inbuf, outbuf, invert):
+        temp = mask * np.ones_like(inbuf)
+        if invert:
+            temp[inbuf != 0] = 0
+        else:
+            temp[inbuf == 0] = 0
+        outbuf |= temp
+
+    # Keep a handle to our send buffers to ensure that any temporary objects
+    # remain in existance until after all receives have happened.
+    send_data = dict()
+    send_req = list()
+    recv_data = None
+
+    # The tag value stride, to ensure unique tags for every sender / receiver / wafer
+    # combination.
+    tag_stride = 1000
+
+    wf_index = {y: x for x, y in enumerate(wafer_readers.keys())}
+
+    for wafer, reader in wafer_readers.items():
+        if reader == rank:
+            send_data[wafer] = dict()
+            for receiver, send_dets in wafer_proc_dets[wafer].items():
+                recv_dets = proc_wafer_dets[receiver][wafer]
+                # Is this some detector flag data using ranges instead of samples?
+                # If so, we construct a temporary buffer and build sample flags
+                # from the ranges.
+                n_send_det = send_dets[1] - send_dets[0]
+                flat_size = n_send_det * obs.n_local_samples
+                if isinstance(axwafers[wafer][axfield], so3g.proj.RangesMatrix):
+                    # Yes, flagged ranges
+                    sdata = np.empty(
+                        flat_size,
+                        dtype=np.uint8,
+                    )
+                    if flag_invert:
+                        sdata[:] = flag_mask
+                        for idet in range(n_send_det):
+                            off = idet * obs.n_local_samples
+                            for rg in axwafers[wafer][axfield][idet].ranges():
+                                sdata[off + rg[0] : off + rg[1]] = 0
+                    else:
+                        sdata[:] = 0
+                        for idet in range(n_send_det):
+                            off = idet * obs.n_local_samples
+                            for rg in axwafers[wafer][axfield][idet].ranges():
+                                sdata[off + rg[0] : off + rg[1]] = flag_mask
+                else:
+                    # Either normal sample flags or signal data
+                    sdata = np.empty(
+                        flat_size,
+                        dtype=axdtype,
+                    )
+                    sdata[:] = np.ravel(
+                        axwafers[wafer][axfield][send_dets[0] : send_dets[1], :]
+                    )
+                if receiver == rank:
+                    # We just need to process the data locally
+                    if is_flag:
+                        _process_flag(
+                            flag_mask,
+                            sdata.reshape((n_send_det, -1)),
+                            obs.detdata[field][recv_dets[0] : recv_dets[1], :],
+                            flag_invert,
+                        )
+                    else:
+                        obs.detdata[field][recv_dets[0] : recv_dets[1], :] = (
+                            sdata.reshape((n_send_det, -1))
+                        )
+                else:
+                    # Send asynchronously.
+                    tag = (rank * gsize + receiver) * tag_stride + wf_index[wafer]
+                    req = gcomm.isend(sdata, dest=receiver, tag=tag)
+                    # Save a handle to this buffer while send operation is in progress
+                    send_data[wafer][axfield] = sdata
+                    send_req.append(req)
+
+    my_wafer_dets = proc_wafer_dets[rank]
+    for wafer, recv_dets in my_wafer_dets.items():
+        sender = wafer_readers[wafer]
+        if sender == rank:
+            # This data was already copied locally above
+            continue
+        else:
+            # Receive from sender.  We always allocate a contiguous temporary buffer.
+            tag = (sender * gsize + rank) * tag_stride + wf_index[wafer]
+            n_recv_det = recv_dets[1] - recv_dets[0]
+            recv_data = gcomm.recv(source=sender, tag=tag)
+            if is_flag:
+                _process_flag(
+                    flag_mask,
+                    recv_data.reshape((n_recv_det, -1)),
+                    obs.detdata[field][recv_dets[0] : recv_dets[1], :],
+                    flag_invert,
+                )
+            else:
+                # Just assign
+                obs.detdata[field][recv_dets[0] : recv_dets[1], :] = recv_data.reshape(
+                    (n_recv_det, -1)
+                )
+            del recv_data
+
+    # Wait for communication
+    for req in send_req:
+        req.wait()
+    if gcomm is not None:
+        gcomm.barrier()
+
+    # Now safe to delete our dictionary of isend buffer handles, which might include
+    # temporary buffers of ranges flags.
+    del send_data
+
+
+def compute_boresight_pointing(
+    obs,
+    times_key,
+    az_key,
+    el_key,
+    roll_key,
+    quat_azel_key,
+    quat_radec_key,
+    position_key,
+    velocity_key,
+    flag_key,
+    flag_mask,
+):
+    """Compute boresight pointing in parallel.
+
+    Use the loaded Az / El / Roll angles to compute the boresight Az / El
+    quaternions and also the RA / DEC boresight quaternions.  Also compute
+    the observatory position and velocity.
+
+    Args:
+        obs (Observation):  The observation to modify.
+        times_key (str):  The shared times field.
+        az_key (str):  The shared Azimuth field.
+        el_key (str):  The shared Elevation field.
+        roll_key (str):  The shared Roll field.
+        quat_azel_key (str):  The shared boresight Az/El quaternion field.
+        quat_radec_key (str):  The shared boresight Ra/Dec quaternion field.
+        position_key (str):  The shared telescope position field.
+        velocity_key (str):  The shared telescope velocity field.
+        flag_key (str):  The shared flag field.
+        flag_mask (int):  The shared flag mask.
+
+    Returns:
+        None
+
+    """
+    log = Logger.get()
+    timer = Timer()
+    timer.start()
+
+    comm = obs.comm
+    gcomm = comm.comm_group
+    rank = comm.group_rank
+
+    site = obs.telescope.site
+
+    # Position and velocity of the observatory are simply computed.  Only the
+    # first row of the process grid needs to do this.
+    position = None
+    velocity = None
+    if rank == 0:
+        position, velocity = site.position_velocity(obs.shared[times_key])
+    obs.shared[position_key].set(position, offset=(0, 0), fromrank=0)
+    obs.shared[velocity_key].set(velocity, offset=(0, 0), fromrank=0)
+    log.debug_rank(
+        f"LoadContext {obs.name} site position/velocity took",
+        comm=gcomm,
+        timer=timer,
+    )
+
+    # Since this step takes some time, all processes in the group
+    # contribute
+    pnt_dist = distribute_uniform(obs.n_all_samples, comm.group_size)
+
+    bore_azel = None
+    bore_radec = None
+    bore_flags = None
+
+    # The sample counts and displacement for each process
+    sample_count = [x.n_elem for x in pnt_dist]
+    sample_displ = [x.offset for x in pnt_dist]
+
+    # The local sample range as a slice
+    slc = slice(sample_displ[rank], sample_displ[rank] + sample_count[rank], 1)
+
+    bore_bad = np.logical_or(
+        np.isnan(obs.shared[az_key].data[slc]),
+        np.logical_or(
+            np.isnan(obs.shared[el_key].data[slc]),
+            np.isnan(obs.shared[roll_key].data[slc]),
+        ),
+    )
+    bore_flags = np.array(obs.shared[flag_key].data[slc])
+    bore_flags[bore_bad] |= flag_mask
+    temp_az = np.array(obs.shared[az_key].data[slc])
+    temp_el = np.array(obs.shared[el_key].data[slc])
+    temp_roll = np.array(obs.shared[roll_key].data[slc])
+    temp_az[bore_bad] = 0
+    temp_el[bore_bad] = 0
+    temp_roll[bore_bad] = 0
+    bore_azel = toast.qarray.from_lonlat_angles(
+        -temp_az,
+        temp_el,
+        temp_roll,
+    )
+    bore_radec = toast.coordinates.azel_to_radec(
+        site,
+        obs.shared[times_key].data[slc],
+        bore_azel,
+        use_qpoint=True,
+    )
+
+    # Gather all samples to rank zero and set the shared object elements.
+    ftype = None
+    qtype = None
+    if gcomm is not None:
+        ftype = MPI.UNSIGNED_CHAR
+        qtype = MPI.DOUBLE
+    for name, local_data, nnz, mtype in [
+        (flag_key, bore_flags, 1, ftype),
+        (quat_azel_key, bore_azel, 4, qtype),
+        (quat_radec_key, bore_radec, 4, qtype),
+    ]:
+        all_data = None
+        final_data = None
+
+        if gcomm is None:
+            all_data = local_data
+        else:
+            counts = [x * nnz for x in sample_count]
+            displ = [x * nnz for x in sample_displ]
+
+            if rank == 0:
+                # Flat buffer for the gather
+                all_data = np.empty(obs.n_all_samples * nnz, dtype=local_data.dtype)
+            gcomm.Gatherv(
+                local_data.reshape((-1)), [all_data, counts, displ, mtype], root=0
+            )
+
+            if rank == 0:
+                if nnz == 1:
+                    final_data = all_data
+                else:
+                    final_data = all_data.reshape((-1, nnz))
+        obs.shared[name].set(final_data, fromrank=0)
+        del final_data
+        del all_data
+
+    del bore_flags
+    del bore_azel
+    del bore_radec
+
+    log.debug_rank(
+        f"LoadContext {obs.name} boresight pointing conversion took",
+        comm=gcomm,
+        timer=timer,
+    )

--- a/sotodlib/toast/scripts/so_map.py
+++ b/sotodlib/toast/scripts/so_map.py
@@ -159,7 +159,6 @@ def main():
     wrk.setup_deconvolve_detector_timeconstant(operators)
     wrk.setup_raw_statistics(operators)
 
-    wrk.setup_readout_filter(operators)
     wrk.setup_filter_hwpss(operators)
     wrk.setup_filter_common_mode(operators)
     wrk.setup_filter_ground(operators)

--- a/sotodlib/toast/workflows/sim_observe.py
+++ b/sotodlib/toast/workflows/sim_observe.py
@@ -96,6 +96,7 @@ def setup_simulate_observing(parser, operators):
             weather="atacama",
             detset_key="pixel",
             session_split_key="wafer_slot",
+            enabled=False,
         )
     )
     operators.append(so_ops.CoRotator(name="corotate_lat"))


### PR DESCRIPTION
- Extract many functions into a separate source file.

- Change the way that data is read.  The first process with data from a wafer is the reading process for that wafer.  Each reading process loads the data and optionally applies the HWP model and preprocessing.

- More robust and general distribution of detector data on the group communicator.

- Correct support of observing sessions.  By default each Context obs ID is split into observations with one per wafer.  This can be overridden to place all wafers into a single observation if desired.

I have tested this on a single observation and verified consistent binned maps in the following cases:

1. Single wafer, single process group, [1, 4, 16, 64, 128] processes.
2. Two wafers, single process group, [4, 16, 64, 128] processes, both per-wafer observations and single combined observation.  Also two process groups at the same total concurrencies, with per-wafer observations.
3. Seven wafers, single process group, [4, 16, 64, 128] processes, single combined observation.  Also four process groups at the same total concurrencies with per-wafer observations.