### PR TITLE
G3thk trim

### DIFF
--- a/sotodlib/io/g3thk_db.py
+++ b/sotodlib/io/g3thk_db.py
@@ -551,12 +551,11 @@ class G3tHk:
         if type(configs) == str:
             configs = load_configs(configs)
 
-        keys = configs["finalization"]["servers"][0].keys()
-        
         iids = []
-        for key in keys:
-            agent = configs["finalization"]["servers"][0][key]
-            iids.append(agent)
+        for server in configs["finalization"]["servers"]:
+            for key in server.keys():
+                # Append the value (iid) to the iids list
+                iids.append(server[key])
 
         return cls(
             hkarchive_path = os.path.join(configs["data_prefix"], "hk"), 


### PR DESCRIPTION
Draft PR for using the g3tsmurf_hwp_config.yaml file to obtain agent instance IDs for populating the Level 2 g3thk database for data packaging.

This will work for lat, satp1, satp2, satp3 g3thk level 2 databases. Was pointed to a site pipeline config file that uses the site g3thk database, but haven't yet looked into what is necessary for level 2 site g3thk database. Hence, the draft PR. 