### PR TITLE
Delete futures as they're processed.

### DIFF
--- a/sotodlib/site_pipeline/preprocess_tod.py
+++ b/sotodlib/site_pipeline/preprocess_tod.py
@@ -427,6 +427,7 @@ def main(
                      overwrite=overwrite, run_parallel=True) for r in run_list]
         for future in as_completed(futures):
             err, src_file, db_datasets = future.result()
+            futures.remove(future)
             db = _get_preprocess_db(configs, group_by)
             if os.path.exists(dest_file) and os.path.getsize(dest_file) >= 10e9:
                 nfile += 1


### PR DESCRIPTION
Trying out a fix for preprocess_tod memory leak introduced with futures based on this S.E. post found by @guanyilun https://stackoverflow.com/questions/73287939/threadpoolexecutor-threads-futures-do-not-release-memory-when-completed-and-t