### PR TITLE
Apply net_corr factors by default to TOAST focalplanes

### DIFF
--- a/sotodlib/toast/instrument.py
+++ b/sotodlib/toast/instrument.py
@@ -127,6 +127,9 @@ class SOFocalplane(Focalplane):
         thinfp (int):  The factor by which to reduce the number of detectors.
         creation_time (float):  Optional timestamp to use when building readout_id.
         comm (MPI.Comm):  Optional MPI communicator.
+        apply_net_corr (bool):  Degrade NETs according to the correlation factors.
+            If False, the correlation factors are just recorded in the instrument
+            model.
 
     """
 

--- a/sotodlib/toast/instrument.py
+++ b/sotodlib/toast/instrument.py
@@ -144,6 +144,7 @@ class SOFocalplane(Focalplane):
         thinfp=None,
         creation_time=None,
         comm=None,
+        apply_net_corr=True,
     ):
         log = Logger.get()
         meta = dict()
@@ -339,13 +340,16 @@ class SOFocalplane(Focalplane):
             )
             # Get noise parameters.  If detector-specific entries are
             # absent, use band averages
-            nets.append(
-                get_par_float(det_data, "NET", band_data["NET"])
-                * 1.0e-6
-                * u.K
-                * u.s**0.5
+            net_corr = get_par_float(
+                det_data, "NET_corr", band_data["NET_corr"]
             )
-            net_corrs.append(get_par_float(det_data, "NET_corr", band_data["NET_corr"]))
+            net = get_par_float(det_data, "NET", band_data["NET"]) \
+                * 1.0e-6 * u.K * u.s**0.5
+            if apply_net_corr:
+                net *= net_corr
+                net_corr = 1.0
+            nets.append(net)
+            net_corrs.append(net_corr)
             fknees.append(get_par_float(det_data, "fknee", band_data["fknee"]) * u.mHz)
             fmins.append(get_par_float(det_data, "fmin", band_data["fmin"]) * u.mHz)
             alphas.append(get_par_float(det_data, "alpha", band_data["alpha"]))


### PR DESCRIPTION
Found another stale branch. This one seems still relevant.