### PR TITLE
Removing the map = weights^-1*wmap calculation

### DIFF
--- a/sotodlib/mapmaking/demod_mapmaker.py
+++ b/sotodlib/mapmaking/demod_mapmaker.py
@@ -297,11 +297,6 @@ class DemodSignalMap(DemodSignal):
                 self.rhs  = utils.allreduce(self.rhs, self.comm)
                 self.div  = utils.allreduce(self.div, self.comm)
                 self.hits = utils.allreduce(self.hits,self.comm)
-        self.idiv  = safe_invert_div(self.div)
-        if self.tiled:
-            self.map = tilemap.map_mul(self.idiv, self.rhs)
-        else: 
-            self.map = enmap.map_mul(self.idiv, self.rhs)
         self.ready = True
 
     @property


### PR DESCRIPTION
I added the calculation of the map in the demod mapmaker object, but now I'm realizing this makes no sense since this can be potentially repeated in every MPI job. I believe it makes much more sense to not have it here and do the inverse of the weights times the weighted map on the script side, where you can have much more control over exactly what you want to do.