### PR TITLE
Track stream_ids and wafer slots

### DIFF
--- a/sotodlib/site_pipeline/update_obsdb.py
+++ b/sotodlib/site_pipeline/update_obsdb.py
@@ -228,6 +228,7 @@ def main(config: str,
                 wafer_slots = index["wafer_slots"]
                 if len(wafer_slots) < len(stream_ids):
                     logger.error("Missing info on some stream_ids")
+                    continue
                 bookcartobsdb.add_obs_columns(["wafer_slots_list str", "stream_ids_list str"])
                 wafer_slots_list = ""
                 stream_ids_list = ",".join(stream_ids)

--- a/sotodlib/site_pipeline/update_obsdb.py
+++ b/sotodlib/site_pipeline/update_obsdb.py
@@ -219,10 +219,25 @@ def main(config: str,
             except KeyError:
                 logger.error("No telescope key in index file or error with lat_tube_list")
                 very_clean["telescope_flavor"] = "unknown"
-            stream_ids = index.pop("stream_ids")
-            if stream_ids is not None:
+            
+            #Stream_ids and wafers
+            try:
+                stream_ids = index["stream_ids"]
                 bookcartobsdb.add_obs_columns(["wafer_count int"])
                 very_clean["wafer_count"] = len(stream_ids)
+                wafer_slots = index["wafer_slots"]
+                if len(wafer_slots) < len(stream_ids):
+                    logger.error("Missing info on some stream_ids")
+                bookcartobsdb.add_obs_columns(["wafer_slots_list str", "stream_ids_list str"])
+                wafer_slots_list = ""
+                stream_ids_list = ",".join(stream_ids)
+                for slot in wafer_slots:
+                    if slot["stream_id"] in stream_ids:
+                        wafer_slots_list += slot["wafer_slot"]+","
+                very_clean["wafer_slots_list"] = wafer_slots_list[:-1]#Eliminate last comma
+                very_clean["stream_ids_list"] = stream_ids_list
+            except KeyError:
+                logger.error("Unable to find stream_ids or wafer slots")
 
             #Time
             try:


### PR DESCRIPTION
Creates two new columns in ObsDb with respectively stream_ids and wafer_slots for each observation, as comma separated strings. E.g. wafer_slots_list: 'ws0,ws1,ws2,ws3,ws4,ws5,ws6' and stream_ids_list: 'ufm_mv19,ufm_mv18,ufm_mv22,ufm_mv29,ufm_mv7,ufm_mv9,ufm_mv15'