### PR TITLE
Pin numpy<2 in package reqs and docs

### DIFF
--- a/docs/g3tsmurf.rst
+++ b/docs/g3tsmurf.rst
@@ -304,9 +304,6 @@ an obs_id and a G3tSmurf instance and return paths or file lists.
 Usage with Context
 ------------------
 
-.. py:module:: sotodlib.io.load_smurf
-    :noindex:
-
 The G3tSmurf database can be used with the larger `sotodlib` Context system.
 In this setup, the main G3tSmurf database is both the ObsFileDb and the ObsDb.
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,7 +4,7 @@ sphinx_rtd_theme>=2.0.0
 sphinx-argparse>=0.4.0
 
 # Required because it is used at root level in some modules.
-numpy
+numpy<2
 so3g
 
 # Required in order to support using Quantities for default function

--- a/docs/rtd_requirements.txt
+++ b/docs/rtd_requirements.txt
@@ -1,4 +1,4 @@
-numpy
+numpy<2
 matplotlib
 toml
 quaternionarray

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup_opts["package_data"] = {
 }
 setup_opts["include_package_data"] = True
 setup_opts["install_requires"] = [
-    'numpy',
+    'numpy<2',
     'scipy',
     'matplotlib',
     'quaternionarray',

--- a/sotodlib/coords/planets.py
+++ b/sotodlib/coords/planets.py
@@ -488,7 +488,7 @@ def compute_source_flags(tod=None, P=None, mask=None, wrap=None,
         [so3g.proj.Ranges.from_mask(r != 0) for r in a])
 
     if wrap:
-        assert(tod is not None, "Pass in a tod to 'wrap' the output.")
+        assert tod is not None, "Pass in a tod to 'wrap' the output."
         tod.flags.wrap(wrap, source_flags, [(0, 'dets'), (1, 'samps')])
     return source_flags
 

--- a/sotodlib/io/bookbinder.py
+++ b/sotodlib/io/bookbinder.py
@@ -123,8 +123,8 @@ class HKBlock:
                         " duplicate timestamps"
                     )
                 self.times = self.times[idxs]
-            assert (np.all(np.diff(self.times)>0), f"Times from {self.name} are"
-                            " not increasing")
+            assert np.all(np.diff(self.times)>0), \
+                f"Times from {self.name} are not increasing"
             for k, v in self.data.items():
                 self.data[k] = np.hstack(v)[idxs]
         else:
@@ -694,10 +694,9 @@ class BookBinder:
                       " bookbinding"
                 )
             elif len(os.listdir(outdir)) == 1:
-                assert (os.listdir(outdir)[0] == 'Z_bookbinder_log.txt', 
-                    f"only acceptable file in new book path {outdir} is "
-                    " Z_bookbinder_log.txt"
-                )
+                assert os.listdir(outdir)[0] == 'Z_bookbinder_log.txt', \
+                    (f"only acceptable file in new book path {outdir} is "
+                     "Z_bookbinder_log.txt")
         else:
             os.makedirs(outdir)
 


### PR DESCRIPTION
Fixes a few issues with CI recently:
- pin numpy<2, because so3g probably segfaults otherwise.
- fix some warnings in docs build that have been rising to error level (including asserts that were malformed)