### PR TITLE
Use of preprocessing database to process simulated data

### DIFF
--- a/sotodlib/preprocess/pcore.py
+++ b/sotodlib/preprocess/pcore.py
@@ -34,7 +34,7 @@ class _Preprocess(object):
         self.save_cfgs = step_cfgs.get("save")
         self.select_cfgs = step_cfgs.get("select")
         self.plot_cfgs = step_cfgs.get("plot")
-
+        self.skip_on_sim = step_cfgs.get("skip_on_sim", False)
     def process(self, aman, proc_aman):
         """ This function makes changes to the time ordered data AxisManager.
         Ex: calibrating or detrending the timestreams. This function will use
@@ -382,7 +382,7 @@ class Pipeline(list):
     def __setitem__(self, index, item):
         super().__setitem__(index, self._check_item(item))
     
-    def run(self, aman, proc_aman=None, select=True):
+    def run(self, aman, proc_aman=None, select=True, sim=False):
         """
         The main workhorse function for the pipeline class. This function takes
         an AxisManager TOD and successively runs the pipeline of preprocessing
@@ -433,6 +433,8 @@ class Pipeline(list):
         
         success = 'end'
         for step, process in enumerate(self):
+            if sim and process.skip_on_sim:
+                continue
             self.logger.debug(f"Running {process.name}")
             process.process(aman, proc_aman)
             if run_calc:

--- a/sotodlib/preprocess/pcore.py
+++ b/sotodlib/preprocess/pcore.py
@@ -410,6 +410,9 @@ class Pipeline(list):
             if True, the aman detector axis is restricted as described in
             each preprocess module. Most pipelines are developed with 
             select=True. Running select=False may produce unstable behavior
+        sim: boolean (Optional)
+            if running on sim (``sim=True``), proccesses with the flag
+            ``skip_on_sim`` will be skipped.
 
         Returns
         -------

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -968,6 +968,16 @@ class FourierFilter(_Preprocess):
           filter_params:
             cutoff: 1
             width: 0.1
+    
+    or with params from a noise fit::
+
+      - name: "fourier_filter"
+        wrap_name: "lpf_sig"
+        signal_name: "signal"
+        process:
+          filt_function: "low_pass_sine2"
+          trim_samps: 2000
+          noise_fit_array: "noiseQ_fit"
 
     See :ref:`fourier-filters` documentation for more details.
     """

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -989,7 +989,7 @@ class FourierFilter(_Preprocess):
             filt_function
         )
 
-        if self.process_cfgs.get("noise_fit_params"):
+        if self.process_cfgs.get("noise_fit_array"):
             field = self.process_cfgs["noise_fit_array"]
             _noise_fit = attrgetter(field)
             noise_fit = _noise_fit(proc_aman)

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -996,7 +996,7 @@ class FourierFilter(_Preprocess):
         else:
             noise_fit = None
         
-        filter_params = tod_ops.fft_ops.build_filter_params_dict(
+        filter_params = tod_ops.fft_ops.build_hpf_params_dict(
             filt_function,
             noise_fit=noise_fit,
             filter_params=self.process_cfgs.get("filter_params", None)

--- a/sotodlib/site_pipeline/preprocess_tod.py
+++ b/sotodlib/site_pipeline/preprocess_tod.py
@@ -10,7 +10,8 @@ import multiprocessing
 from concurrent.futures import ProcessPoolExecutor, as_completed
 import h5py
 import copy
-
+from sotodlib.coords import demod as demod_mm
+from sotodlib.hwp import hwp_angle_model
 from sotodlib import core
 import sotodlib.site_pipeline.util as sp_util
 from sotodlib.preprocess import _Preprocess, Pipeline, processes
@@ -467,6 +468,47 @@ def load_preprocess_det_select(obs_id, configs, context=None,
     logger.info(f"Cutting on the last process: {pipe[-1].name}")
     pipe[-1].select(meta)
     return meta
+
+def load_preprocess_tod_sim(obs_id, sim_map,
+                            configs="preprocess_configs.yaml",
+                            context=None, dets=None,
+                            meta=None, modulated=True):
+    """ Loads the saved information from the preprocessing pipeline and runs the
+    processing section of the pipeline. 
+
+    Assumes preprocess_tod has already been run on the requested observation. 
+    
+    Arguments
+    ----------
+    obs_id: multiple
+        passed to `context.get_obs` to load AxisManager, see Notes for 
+        `context.get_obs`
+    configs: string or dictionary
+        config file or loaded config directory
+    dets: dict
+        dets to restrict on from info in det_info. See context.get_meta.
+    meta: AxisManager
+        Contains supporting metadata to use for loading.
+        Can be pre-restricted in any way. See context.get_meta.
+    """
+    configs, context = _get_preprocess_context(configs, context)
+    meta = load_preprocess_det_select(obs_id, configs=configs, context=context, dets=dets, meta=meta)
+
+    if meta.dets.count == 0:
+        logger.info(f"No detectors left after cuts in obs {obs_id}")
+        return None
+    else:
+        pipe = Pipeline(configs["process_pipe"], logger=logger)
+        aman = context.get_obs(meta, no_signal=True)
+        if modulated:
+            # Apply the HWP angle model here
+            # WARNING : should be turned off in the config file
+            # to filter simulations
+            aman = hwp_angle_model.apply_hwp_angle_model(aman)
+            aman.move("signal", None)
+        demod_mm.from_map(aman, sim_map, wrap=True, modulated=modulated)
+        pipe.run(aman, aman.preprocess, sim=True)
+        return aman
 
 def load_preprocess_tod(obs_id, configs="preprocess_configs.yaml",
                         context=None, dets=None, meta=None):

--- a/sotodlib/site_pipeline/preprocess_tod.py
+++ b/sotodlib/site_pipeline/preprocess_tod.py
@@ -481,7 +481,7 @@ def load_preprocess_tod_sim(obs_id, sim_map,
     Arguments
     ----------
     obs_id: multiple
-        passed to `context.get_obs` to load AxisManager, see Notes for 
+        passed to ``context.get_obs`` to load AxisManager, see Notes for 
         `context.get_obs`
     sim_map: pixell.enmap.ndmap
         signal map containing (T, Q, U) fields

--- a/sotodlib/site_pipeline/preprocess_tod.py
+++ b/sotodlib/site_pipeline/preprocess_tod.py
@@ -474,7 +474,7 @@ def load_preprocess_tod_sim(obs_id, sim_map,
                             context=None, dets=None,
                             meta=None, modulated=True):
     """ Loads the saved information from the preprocessing pipeline and runs the
-    processing section of the pipeline. 
+    processing section of the pipeline on simulated data
 
     Assumes preprocess_tod has already been run on the requested observation. 
     
@@ -483,6 +483,8 @@ def load_preprocess_tod_sim(obs_id, sim_map,
     obs_id: multiple
         passed to `context.get_obs` to load AxisManager, see Notes for 
         `context.get_obs`
+    sim_map: pixell.enmap.ndmap
+        signal map containing (T, Q, U) fields
     configs: string or dictionary
         config file or loaded config directory
     dets: dict
@@ -490,6 +492,10 @@ def load_preprocess_tod_sim(obs_id, sim_map,
     meta: AxisManager
         Contains supporting metadata to use for loading.
         Can be pre-restricted in any way. See context.get_meta.
+    modulated: bool
+        If True, apply the HWP angle model and scan the simulation
+        into a modulated signal.
+        If False, scan the simulation into demodulated timestreams.
     """
     configs, context = _get_preprocess_context(configs, context)
     meta = load_preprocess_det_select(obs_id, configs=configs, context=context, dets=dets, meta=meta)

--- a/sotodlib/tod_ops/fft_ops.py
+++ b/sotodlib/tod_ops/fft_ops.py
@@ -462,7 +462,7 @@ def params_from_noise_model_fit(
 ):
     """
     Take the result of the noise model fit, stored in the
-    attribute `noise_fit_array` and return the median value
+    attribute ``noise_fit_array`` and return the median value
     of the parameters accross detectors.
 
     Args

--- a/sotodlib/tod_ops/fft_ops.py
+++ b/sotodlib/tod_ops/fft_ops.py
@@ -461,6 +461,23 @@ def params_from_noise_model_fit(
     noise_fit_params
 ):
     """
+    Take the result of the noise model fit, stored in the
+    attribute `noise_fit_array` and return the median value
+    of the parameters accross detectors.
+
+    Args
+    ----
+    aman : AxisManager
+        Axis manager which has samps axis aligned with signal.
+    noise_fit_array : nparray
+        Array of noise model fit parameters sized nparams x ndets.
+    noise_fit_params : list
+        List of parameter names corresponding to the noise model fit.
+    Returns
+    -------
+    params_dict : dict
+        Returns a dictionary of the median values of the noise model fit parameters.
     """
     median_params = np.median(noise_fit_array, axis=0)
-    return {k: median_params[i] for i, k in enumerate(noise_fit_params)}
+    params_dict = {k: median_params[i] for i, k in enumerate(noise_fit_params)}
+    return params_dict

--- a/sotodlib/tod_ops/fft_ops.py
+++ b/sotodlib/tod_ops/fft_ops.py
@@ -456,7 +456,7 @@ def fit_noise_model(
     return noise_fit_stats
 
 
-def build_filter_params_dict(
+def build_hpf_params_dict(
     filter_name,
     noise_fit=None,
     filter_params=None

--- a/sotodlib/tod_ops/fft_ops.py
+++ b/sotodlib/tod_ops/fft_ops.py
@@ -454,3 +454,13 @@ def fit_noise_model(
     if merge_fit:
         aman.wrap(merge_name, noise_fit_stats)
     return noise_fit_stats
+
+def params_from_noise_model_fit(
+    aman,
+    noise_fit_array,
+    noise_fit_params
+):
+    """
+    """
+    median_params = np.median(noise_fit_array, axis=0)
+    return {k: median_params[i] for i, k in enumerate(noise_fit_params)}

--- a/sotodlib/tod_ops/fft_ops.py
+++ b/sotodlib/tod_ops/fft_ops.py
@@ -469,8 +469,8 @@ def build_filter_params_dict(
     ----
     filter_name : str
         Name of the filter to build the parameter dict for.
-    noise_fit: nparray
-        Array of noise model fit parameters sized nparams x ndets.
+    noise_fit: AxisManager
+        AxisManager containing the result of the noise model fit sized nparams x ndets.
     filter_params: dict
         Filter parameters dictionary to complement parameters
         derived from the noise fit (or to be used if noise fit is None).


### PR DESCRIPTION
This PR includes new functions to process a simulation following the data processing (using PR #873) : 

- New function `site_pipeline/preprocess_tod.load_preprocess_tod_sim` that allows to load a CAR map into tods
- Changes of the `Pipeline.run()` method allowing to skip some steps in the pre-processing configuration file with a boolean flag `skip_on_sim`
- New function to derive the median across detectors of the noise fit parameters to allow for non-fixed parameters in the pre-processing configuration file in the `fourier_filter` steps.
  e.g. : 
  ```
  - name: "fourier_filter"
      signal_name: "demodU"
      wrap_name: "demodU"
      process:
        filt_function: "counter_1_over_f"
        trim_samps: 2000
        noise_fit_params: True
        noise_fit_array: "noiseQ_fit"
        filter_params:
          fk: "fknee"
          n: "alpha"
  ```