### PR TITLE
Fix for flags and downsampling.

### DIFF
--- a/sotodlib/mapmaking/utilities.py
+++ b/sotodlib/mapmaking/utilities.py
@@ -510,15 +510,17 @@ def downsample_obs(obs, down):
     res.wrap("signal", resample.resample_fft_simple(obs.signal, onsamp), [(0,"dets"),(1,"samps")])
 
     # The cuts
-    # TODO: The TOD will include a Flagmanager with all the flags. Update this part
-    # accordingly.
-    cut_keys = ["glitch_flag"]
+    # obs.flags will contain all types of flags. We should query it for glitch_flags and source_flags
+    cut_keys = ["glitch_flags"]
 
-    if "source_flags" in obs:
+    if "source_flags" in obs.flags:
         cut_keys.append("source_flags")
 
+    # We need to add a res.flags FlagManager to res
+    res = res.wrap('flags', core.FlagManager.for_tod(res))
+
     for key in cut_keys:
-        res.wrap(key, downsample_cut(getattr(obs, key), down), [(0,"dets"),(1,"samps")])
+        res.flags.wrap(key, downsample_cut(getattr(obs.flags, key), down), [(0,"dets"),(1,"samps")])
 
     # Not sure how to deal with flags. Some sort of or-binning operation? But it
     # doesn't matter anyway


### PR DESCRIPTION
This fix allows for the downsampling to be used in the ML mapmaker / depth-1 mapmaker. @iparask you left a comment about this some months ago. The partial solution we have for now is that obs.flags will contain all processing flags, including glitch_flags, etc. In the future we want to make the flags location and names to be user-defined in a config file or something, but this other solution is what we use in the mean time in other sections of the mapmaker. @tanaybhandarkar has also worked on this with me.