### PR TITLE
Add hwp model for satp2

### DIFF
--- a/sotodlib/hwp/hwp_angle_model.py
+++ b/sotodlib/hwp/hwp_angle_model.py
@@ -17,6 +17,13 @@ def default_model(telescope):
         model.wrap('mechanical_offset_1', np.deg2rad(-1.66 - 90 + 49.1))
         model.wrap('mechanical_offset_2', np.deg2rad(-1.66 + 90 + 49.1))
 
+    elif telescope == 'satp2':
+        sign = core.AxisManager()
+        sign.wrap('pid', 1)
+        sign.wrap('offcenter', -1)
+        model.wrap('mechanical_offset_1', np.deg2rad(-1.66 - 90 + 7.7))
+        model.wrap('mechanical_offset_2', np.deg2rad(-1.66 + 90 + 7.7))
+
     elif telescope == 'satp3':
         sign = core.AxisManager()
         sign.wrap('pid', -1)


### PR DESCRIPTION
The hwp angle model for satp2 has been added.
The definition of the rotation angle and angle offset is based on this page.
https://simonsobs.atlassian.net/wiki/spaces/PRO/pages/185434251/CHWP+main+page#Rotation-direction-definition