### PR TITLE
Update g3_core.py

### DIFF
--- a/sotodlib/core/g3_core.py
+++ b/sotodlib/core/g3_core.py
@@ -6,7 +6,7 @@ This module contains the core data I/O and processing tools.
 
 """
 
-from spt3g import core
+from so3g.spt3g import core
 
 
 class DataG3Module(object):


### PR DESCRIPTION
`spt3g` is under `so3g` and this import fails (caught by my linter).