### PR TITLE
CLI support to patch ObsDb and ObsFileDb from an upstream copy

### DIFF
--- a/tests/test_obsdb.py
+++ b/tests/test_obsdb.py
@@ -7,19 +7,21 @@ import time
 from ._helpers import mpi_multi
 
 
-def get_example():
+def get_example(stuff_missing=False):
     # Create a new Db and add two columns.
     obsdb = metadata.ObsDb()
     obsdb.add_obs_columns(['timestamp float', 'hwp_speed float', 'drift string'])
 
     # Add 10 rows.
     for i in range(10):
+        if stuff_missing and i in [2, 4]:
+            continue
         tags = []
         if i == 6:
             tags.append('cryo_problem')
         if i > 7:
             tags.append('planet')
-        else:
+        elif not stuff_missing:
             tags.append('cmb_survey')
         obsdb.update_obs(f'myobs{i}', {'timestamp': 1900000000. + i * 100,
                                        'hwp_speed': 2.0,
@@ -81,6 +83,18 @@ class TestObsDb(unittest.TestCase):
         """Check the .info method."""
         db0 = get_example()
         db0.info()
+
+    def test_diff_patch(self):
+        """Use diff/patch to update one obsdb to match another."""
+        db0 = get_example(stuff_missing=True)
+        db1 = get_example()
+        diff = metadata.obsdb.diff_obsdbs(db0, db1)
+        assert diff['different']
+        assert diff['patchable']
+
+        metadata.obsdb.patch_obsdb(diff['patch_data'], db0)
+        diff = metadata.obsdb.diff_obsdbs(db0, db1)
+        assert not diff['different']
 
 
 if __name__ == '__main__':

--- a/tests/test_obsfiledb.py
+++ b/tests/test_obsfiledb.py
@@ -136,6 +136,27 @@ class TestObsFileDB(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             db.lookup_file('notx/../x/' + target, resolve_paths=False)
 
+    def test_100_diff_patch(self):
+        db0 = self.get_simple_db()
+        db1 = self.get_simple_db()
+        pd = metadata.obsfiledb.diff_obsfiledbs(db0, db1)
+        assert not pd['different']
+
+        db0 = self.get_simple_db(n_obs=2, n_detsets=2, n_dets=4)
+        db1 = self.get_simple_db(n_obs=3, n_detsets=3, n_dets=5)
+
+        pd = metadata.obsfiledb.diff_obsfiledbs(db1, db0)
+        assert pd['different']
+        assert not pd['patchable']
+
+        pd = metadata.obsfiledb.diff_obsfiledbs(db0, db1)
+        assert pd['different']
+        assert pd['patchable']
+
+        metadata.obsfiledb.patch_obsfiledb(pd['patch_data'], db0)
+        pd = metadata.obsfiledb.diff_obsfiledbs(db0, db1)
+        assert not pd['different']
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Facilitate "in place" updates of ObsDb and ObsFileDb.  Basically if you have an upstream version that only contains new things, the code can cleanly add those new things into the downstream target.

Easiest usage is through the so-metadata cli. 

For ObsDb:
```
$ so-metadata obsdb-diff \
   satp1-may14-snapshot/satp1_obsdb_240911m_local.sqlite \
   satp1-may29-snapshot/satp1_obsdb_240911m_local.sqlite
```
which says:
```
Comparing to satp1-may29-snapshot/satp1_obsdb_240911m_local.sqlite ...
 ... upstream is different, but the target db can be patched to match.
```
and if you add `--patch`, it will modify the left one (may14) in place.

For ObsFileDb:
```
$ so-metadata obsfiledb satp1-may14-snapshot/satp1_obsfiledb.sqlite \
  diff satp1-may29-snapshot/satp1_obsfiledb.sqlite
```
will similarly print:
```
Comparing to satp1-may29-snapshot/satp1_obsfiledb.sqlite ...
 ... upstream is different, but the target db can be patched to match.
```
and you can cause the update by appending `--patch`.