### PR TITLE
Fix unique constraint and indent logic error

### DIFF
--- a/sotodlib/io/g3tsmurf_db.py
+++ b/sotodlib/io/g3tsmurf_db.py
@@ -49,7 +49,12 @@ class TimeCodes(Base):
     """
 
     __tablename__ = "time_codes"
-    __table_args__ = (db.UniqueConstraint("stream_id", "suprsync_type", "timecode"),)
+    __table_args__ = (db.UniqueConstraint(
+        "stream_id", 
+        "suprsync_type", 
+        "timecode",
+        "agent",
+    ),)
     id = db.Column(db.Integer, primary_key=True)
     stream_id = db.Column(db.String)
     suprsync_type = db.Column(db.Integer)

--- a/sotodlib/io/imprinter_utils.py
+++ b/sotodlib/io/imprinter_utils.py
@@ -260,7 +260,7 @@ def set_timecode_final(imprint, time_code):
                 timecode=time_code,
                 agent=server["timestream-suprsync"],
             )
-        g3session.add(tcf)
+            g3session.add(tcf)
 
         tcm = g3session.query(TimeCodes).filter(
             TimeCodes.timecode==time_code,
@@ -274,5 +274,5 @@ def set_timecode_final(imprint, time_code):
                 timecode=time_code,
                 agent=server["smurf-suprsync"],
             )
-        g3session.add(tcm)    
+            g3session.add(tcm)    
     g3session.commit()


### PR DESCRIPTION
Found while trying to close our some LAT time codes. Change the unique constraint to deal correctly with different servers. 

closes #960 

To update existing tables will need to run. (I'll take care of doing this on site)
```
CREATE TABLE time_codes_new (
        id INTEGER NOT NULL, 
        stream_id VARCHAR, 
        suprsync_type INTEGER, 
        timecode INTEGER, 
        agent VARCHAR, 
        PRIMARY KEY (id), 
        UNIQUE (stream_id, suprsync_type, timecode, agent)
);

INSERT INTO time_codes_new SELECT * from time_codes;
DROP TABLE time_codes;
ALTER TABLE time_codes_new RENAME to time_codes;
```
