### PR TITLE
Add lmsi to preprocess_obs and preprocess_tod

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ setup_opts["extras_require"] = {
         "influxdb",
         "venn",
         "sodetlib @ git+https://github.com/simonsobs/sodetlib",
+        "let-me-scroll-it",
     ],
     "tests": [
         "socs",

--- a/sotodlib/site_pipeline/preprocess_obs.py
+++ b/sotodlib/site_pipeline/preprocess_obs.py
@@ -110,6 +110,17 @@ def preprocess_obs(
                 start=os.path.dirname(configs['archive']['index']))
         db.add_entry(db_data, h5_path)
 
+    if configs.get("lmsi_config", None) is not None:
+        from pathlib import Path
+        import lmsi.core as lmsi
+
+        new_plots = os.path.join(configs["plot_dir"],
+                                 f'{str(aman.timestamps[0])[:5]}',
+                                 aman.obs_info.obs_id)
+        lmsi.core([Path(x.name) for x in Path(new_plots).glob("*.png")],
+                  Path(configs["lmsi_config"]),
+                  Path(os.path.join(new_plots, 'index.html')))
+
 def load_preprocess_obs(obs_id, configs="preprocess_obs_configs.yaml", context=None ):
     """ Loads the saved information from the preprocessing pipeline and runs the
     processing section of the pipeline. 


### PR DESCRIPTION
Adds [lmsi](https://github.com/jborrow/lmsi) to `preprocess_obs` and `preprocess_tod` site pipeline scripts, to be used on prefect. To use, simply add the path to the lmsi config file as `lmsi_config` in the preprocess config. This will produce an HTML file to serve the plots as a simple gallery. @guanyilun has already run a catchup on the existing plot directories.