### PR TITLE
hkdb: Fix bug where first G3 frame was being skipped

### DIFF
--- a/sotodlib/io/hkdb.py
+++ b/sotodlib/io/hkdb.py
@@ -429,6 +429,7 @@ def load_hk(load_spec: Union[LoadSpec, dict], show_pb=False):
         for field in load_spec.fields:
             if field.matches(f):
                 result[key] = [[], []]
+                return result[key]
         return None
     ds_factor = load_spec.downsample_factor
 


### PR DESCRIPTION
@mjrand found an issue with the HK loader where the first G3 frame was being skipped and not included in the result, leading to incomplete queries such as the one shown below:

![image](https://github.com/user-attachments/assets/f4f09805-3c33-454f-bf0f-484ccaa7f875)

This is caused by a small bug in the loader where the first time a field was found in the HKarchive it would be skipped. This PR fixes that issue.