### PR TITLE
G3thwp nan fix

### DIFF
--- a/sotodlib/hwp/g3thwp.py
+++ b/sotodlib/hwp/g3thwp.py
@@ -794,14 +794,17 @@ class G3tHWP():
 
     def _angle_interpolation(self, timestamp1, angle, timestamp2):
         """Linearly interpolate the angle to the timestamp of the detector readout.
-        numpy.interp uses constant extrapolation, and extend the first and last values
-        of the angle in the interpolation interval"""
-        return np.interp(timestamp2, timestamp1, angle)
+        Fill outside the data range constant by the first and last values of the angle."""
+        return np.interp(timestamp2, timestamp1, angle, left=angle[0], right=angle[-1])
 
-    def _bool_interpolation(self, timestamp1, data, timestamp2, round_option):
+    def _bool_interpolation(self, timestamp1, data, timestamp2, fill, round_option):
         """Linearly interpolate the boolean array. fill values by False outside of the
-        data range"""
-        interp = np.interp(timestamp2, timestamp1, data, left=0, right=0)
+        data range
+        Args
+            fill: Outside of data range is filled by this value, 0 or 1
+            round_option: round option, 'floor' or 'ceil'
+        """
+        interp = np.interp(timestamp2, timestamp1, data, left=fill, right=fill)
         if round_option == 'floor':
             interp = np.floor(interp)
         elif round_option == 'ceil':
@@ -1015,9 +1018,9 @@ class G3tHWP():
             self._write_solution_h5_logger = 'Angle calculation succeeded'
             aman['version'+suffix] = 1
             aman['stable'+suffix] = self._bool_interpolation(
-                solved['slow_time'+suffix], solved['stable'+suffix], tod.timestamps, 'floor')
+                solved['slow_time'+suffix], solved['stable'+suffix], tod.timestamps, 0, 'floor')
             aman['locked'+suffix] = self._bool_interpolation(
-                solved['slow_time'+suffix], solved['locked'+suffix], tod.timestamps, 'floor')
+                solved['slow_time'+suffix], solved['locked'+suffix], tod.timestamps, 0, 'floor')
             aman['hwp_rate'+suffix] = np.interp(
                 tod.timestamps, solved['slow_time'+suffix], solved['hwp_rate'+suffix], left=0, right=0)
             aman['logger'+suffix] = self._write_solution_h5_logger
@@ -1030,7 +1033,7 @@ class G3tHWP():
             filled_flag = np.zeros_like(solved['fast_time'+suffix], dtype=bool)
             filled_flag[solved['filled_indexes'+suffix]] = 1
             aman['filled_flag'+suffix] = self._bool_interpolation(
-                solved['fast_time'+suffix], filled_flag, tod.timestamps, 'ceil')
+                solved['fast_time'+suffix], filled_flag, tod.timestamps, 1, 'ceil')
             aman['hwp_angle_ver1'+suffix] = np.mod(self._angle_interpolation(
                 solved['fast_time'+suffix], solved['angle'+suffix], tod.timestamps), 2*np.pi)
 

--- a/sotodlib/hwp/g3thwp.py
+++ b/sotodlib/hwp/g3thwp.py
@@ -1454,6 +1454,7 @@ class G3tHWP():
         quad[(quad >= 0.5)] = 1
         quad[(quad < 0.5)] = 0
         offset = 0
+        outlier_count = 0
         for quad_split in np.array_split(quad, 1 + np.floor(len(quad) / 100)):
             if quad_split.mean() > 0.1 and quad_split.mean() < 0.9:
                 for j in range(len(quad_split)):
@@ -1462,12 +1463,9 @@ class G3tHWP():
                 continue
 
             outlier = np.argwhere(
-                np.abs(
-                    quad_split.mean() -
-                    quad_split) > 0.5).flatten()
+                np.abs(quad_split.mean() - quad_split) > 0.5).flatten()
             if len(outlier) > 5:
-                logger.warning(
-                    "flipping quad is corrected by mean value")
+                outlier_count += 1
             for i in outlier:
                 if i == 0:
                     ii, iii = i + 1, i + 2
@@ -1480,5 +1478,8 @@ class G3tHWP():
                 if quad_split[i] + quad_split[ii] + quad_split[iii] == 2:
                     quad[i + offset] = 1
             offset += len(quad_split)
+        if outlier_count > 0:
+            logger.warning("flipping quad was corrected by mean value "
+                           f"in {outlier_count} sections.")
 
         return quad

--- a/sotodlib/hwp/g3thwp.py
+++ b/sotodlib/hwp/g3thwp.py
@@ -565,11 +565,11 @@ class G3tHWP():
         logger.info('Remove offcentering effect from hwp angle and overwrite')
         # Calculate offcentering from where the first reference slot was detected by the 2nd encoder.
         if solved["ref_indexes_1"][0] > self._num_edges/2-1:
-            offcenter_idx1_start, offcenter_idx2_start = int(
-                solved["ref_indexes_1"][0]-self._num_edges/2), int(solved["ref_indexes_2"][0])
+            offcenter_idx1_start = int(solved["ref_indexes_1"][0]-self._num_edges/2)
+            offcenter_idx2_start = int(solved["ref_indexes_2"][0])
         else:
-            offcenter_idx1_start, offcenter_idx2_start = int(
-                solved["ref_indexes_1"][1]-self._num_edges/2), int(solved["ref_indexes_2"][0])
+            offcenter_idx1_start = int(solved["ref_indexes_1"][1]-self._num_edges/2)
+            offcenter_idx2_start = int(solved["ref_indexes_2"][0])
         # Calculate offcentering to the end of the shorter encoder data.
         if len(solved["fast_time_1"][offcenter_idx1_start:]) > len(solved["fast_time_2"][offcenter_idx2_start:]):
             idx_length = len(solved["fast_time_2"][offcenter_idx2_start:])
@@ -585,8 +585,11 @@ class G3tHWP():
         # Calculate the offcentering (mm).
         period = (solved["fast_time_1"][offcenter_idx1+1] -
                   solved["fast_time_1"][offcenter_idx1])*self._num_edges
-        offset_angle = offset_time/period*2*np.pi
-        offcentering = np.tan(offset_angle)*self._encoder_disk_radius
+        # When data is extremely noisy, period gets zero and offcentering becomes nan
+        period[period==0] = np.median(period)
+        offset_angle = 2 * np.pi * offset_time / period
+        offcentering = np.tan(offset_angle) * self._encoder_disk_radius
+
         solved['offcenter_idx1'] = offcenter_idx1
         solved['offcenter_idx2'] = offcenter_idx2
         solved['offcentering'] = offcentering

--- a/sotodlib/site_pipeline/make_hwp_solutions.py
+++ b/sotodlib/site_pipeline/make_hwp_solutions.py
@@ -36,20 +36,17 @@ def get_parser(parser=None):
         help="increase output verbosity. \
         0: Error, 1: Warning, 2: Info(default), 3: Debug")
     parser.add_argument(
-        '--overwrite',
+        '--overwrite', action='store_true',
         help="If true, overwrites existing entries in the database",
-        action='store_true',
     )
     parser.add_argument(
-        '--load-h5',
+        '--load-h5', action='store_true',
         help="If true, try to load raw encoder data from h5 file",
-        action='store_true',
     )
     parser.add_argument(
-        '--query',
+        '--query', type=str,
         help="Query to pass to the observation list. Use \\'string\\' to "
              "pass in strings within the query.",
-        type=str
     )
     parser.add_argument(
         '--min-ctime',
@@ -60,8 +57,8 @@ def get_parser(parser=None):
         help="Maximum timestamp for the beginning of an observation list",
     )
     parser.add_argument(
-        '--obs-id',
-        help="obs-id of particular observation if we want to run on just one",
+        '--obs-id', type=str, nargs='+',
+        help="List of obs-ids of particular observations that you want to run",
     )
     return parser
 
@@ -157,7 +154,7 @@ def main(
 
     # load observation data
     if obs_id is not None:
-        tot_query = f"obs_id=='{obs_id}'"
+        tot_query = ' or '.join([f"(obs_id=='{o}')" for o in obs_id])
     else:
         tot_query = "and "
         if min_ctime is not None:


### PR DESCRIPTION
There were hwp angle nan issues in the observations that the hwp stopped in the middle of observations. https://github.com/simonsobs/sotodlib/issues/966
This is because the old hwp angle extrapolation method returns nan when the data range of hwp angle is shorter than the range of observation. This PR improves the hwp data extrapolation methods in general and resolves the nan issue.
This PR also improves the logging of hwp solution pipeline.

This PR does not change the pipeline output except for edge cases, so I do not plan to update the version of hwp_angles metadata.