### PR TITLE
feat(site_pipeline.qa): Use JobDB to track processed observations.

### DIFF
--- a/sotodlib/site_pipeline/record_qa.py
+++ b/sotodlib/site_pipeline/record_qa.py
@@ -5,6 +5,7 @@ from sotodlib import core
 import sotodlib.site_pipeline.util as sp_util
 from sotodlib.qa import metrics as qa_metrics
 from sotodlib.site_pipeline.monitor import Monitor
+from sotodlib.site_pipeline.jobdb import JobManager
 
 logger = sp_util.init_logger("qa_metrics")
 
@@ -18,6 +19,7 @@ def main(config):
 
     monitor = Monitor.from_configs(config["monitor"])
     context = core.Context(config["context_file"])
+    jdb = JobManager(sqlite_file=config["jobdb"])
 
     # get a list of metrics from the config
     metrics = []
@@ -31,41 +33,74 @@ def main(config):
         # Instantiate class with remaining elements as kwargs
         metrics.append(metric_class(context=context, monitor=monitor, **m))
 
-    # get a list of obs_id to process
-    obs_id = []
+    # get a list of obs_id to process and add to the JobDB
+    jobs = []
+    all_obs_id = set()
     for m in metrics:
-        obs_id.append(m.get_new_obs())
-    all_obs_id = list(set.union(*obs_id))
+        # observations that have not been recorded to Influx
+        new_obs = m.get_new_obs()
+
+        # check if failed jobs exist already for these
+        jclass = f"{m._influx_meas}.{m._influx_field}"
+        skipped_jobs = jdb.get_jobs(jclass=jclass, jstate=["done", "failed", "ignored"])
+        skipped_obs = set([j.tags["obs_id"] for j in skipped_jobs])
+        logger.debug(f"Found {len(skipped_obs)} obs_id to skip for metric {m._influx_meas}.{m._influx_field}")
+        new_obs -= skipped_obs
+
+        # create list of jobs to process
+        new_jobs = {}
+        open_jobs = jdb.get_jobs(jclass=jclass, jstate=["open"])
+        open_obs = [j.tags["obs_id"] for j in open_jobs]
+        for oid in new_obs:
+            if oid in open_obs:
+                job = open_jobs[open_obs.index(oid)]
+            else:
+                job = jdb.create_job(jclass, {"obs_id": oid})
+            new_jobs[oid] = job
+
+        jobs.append(new_jobs)
+        all_obs_id |= new_obs
 
     logger.info(f"Found {len(all_obs_id)} obs_id with new metrics to record.")
 
     n = len(all_obs_id)
-    i = 1
     # process one obs_id at a time
-    for oid in all_obs_id:
+    for i, oid in enumerate(all_obs_id):
         logger.info(f"Recording metrics for obs_id {oid} ({i}/{n})...")
         # load metadata once
+        meta_fail = False
         try:
             # this can fail if crucial metadata is unavailable
             meta = context.get_meta(oid, ignore_missing=True)
+            # check that obsdb info is available
+            if len(meta.obs_info.keys()) < 2:
+                logger.warning("This observation is missing obs_info. Skipping.")
+                raise ValueError("Missing obs_info.")
         except Exception as e:
             logger.error(f"Failed to load metadata for {oid}.\n{type(e)}: {e}")
-            continue
-        # check that obsdb info is available
-        if len(meta.obs_info.keys()) < 2:
-            logger.warning("This observation is missing obs_info. Skipping.")
-            i += 1
-            continue
-        for m, m_obs in zip(metrics, obs_id):
+            meta_fail = True
+
+        # iterate over metrics and record, or mark failure to load metadata
+        for m, m_obs in zip(metrics, jobs):
             if oid in m_obs:
+                if meta_fail:  # no metadata, record job as ignored
+                    with jdb.locked(m_obs[oid]) as job:
+                        job.mark_visited()
+                        job.jstate = "ignored"
+                    continue
                 try:
                     m.process_and_record(oid, meta)
+                    with jdb.locked(m_obs[oid]) as job:
+                        job.mark_visited()
+                        job.jstate = "done"
                 except Exception:
                     logger.error(
                         f"Processing metric {m._influx_meas}.{m._influx_field} failed.",
                         exc_info=True
                     )
-        i += 1
+                    with jdb.locked(m_obs[oid]) as job:
+                        job.mark_visited()
+                        job.jstate = "failed"
 
 
 def get_parser(parser=None):


### PR DESCRIPTION
I mocked up my understanding of how JobDB could be used to track processed observations in the `record_qa` metrics pipeline. I'm using it pretty minimally with the main objective to avoid re-attempting to process observations that failed previously. We could consider exercising some more functionality like retrying some number of times before quitting.

@mhasself if you have time to take a look and let me know if what I did makes sense, I'll proceed to testing this out next.