### PR TITLE
Restore Python 3.8 support for now

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,10 +24,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - python: "3.8"
+            pyshort: "38"
           - python: "3.9"
             pyshort: "39"
-          - python: "3.10"
-            pyshort: "310"
           - python: "3.11"
             pyshort: "311"
     steps:

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup_opts["author_email"] = "so_software@simonsobservatory.org"
 setup_opts["url"] = "https://github.com/simonsobs/sotodlib"
 setup_opts["packages"] = find_packages(where=".", exclude="tests")
 setup_opts["license"] = "MIT"
-setup_opts["python_requires"] = ">=3.9.0"
+setup_opts["python_requires"] = ">=3.8.0"
 setup_opts["package_data"] = {
     "sotodlib": [
         "toast/ops/data/*"


### PR DESCRIPTION
Removing 3.8 broke socs builds; sorry!

Although 3.8 is end-of-life now, and 3.9 was released more than 3 years ago, it ain't broke so let's not drop it yet.

On the test matrix: it is more important to test the legacy edge (3.8, 3.9) and the bleeding edge (for us, 3.11) than to test intermediate releases.

