### PR TITLE
Fixes bug in HKDB file-indexing

### DIFF
--- a/sotodlib/io/hkdb.py
+++ b/sotodlib/io/hkdb.py
@@ -186,7 +186,10 @@ def update_file_index(hkcfg: HkConfig, session=None):
             if f.endswith('.g3')
         ])
 
-    existing_files = [path for path, in session.query(HkFile.path).all()]
+    existing_files = [
+        os.path.join(hkcfg.hk_root, path)
+        for path, in session.query(HkFile.path).all()
+    ]
     new_files = sorted(list(set(all_files) - set(existing_files)))
 
     files = []


### PR DESCRIPTION
This fixes a bug when indexing hk files, which currently fails when the db has a combination of relative and absolute paths.