### PR TITLE
make-det-info-wafer: updates and fixes

### DIFF
--- a/docs/site_pipeline.rst
+++ b/docs/site_pipeline.rst
@@ -183,6 +183,13 @@ Here is a basic configuration file::
     - ufm_mv33
     - ufm_mv35
 
+Check the det_ids for sensibility... and if you need to force bandpass
+values, add a config file entry like this::
+
+  bandpass_remap:
+    90: 220
+    150: 280
+
 
 The output database ``wafer_info.sqlite`` and HDF5 file
 ``wafer_info.h5`` are written to the ``output_dir``, which is created

--- a/sotodlib/site_pipeline/make_det_info_wafer.py
+++ b/sotodlib/site_pipeline/make_det_info_wafer.py
@@ -104,7 +104,7 @@ def main(config_file=None, target=None, overwrite=False, debug=False, log_file=N
         if not array_name in existing:
             db_data = {'dets:stream_id': stream_id,
                        'dataset': stream_id}
-            db.add_entry(db_data, h5_rel)
+            db.add_entry(db_data, h5_rel, replace=overwrite)
 
 
 def replace_none(val, replace_val=np.nan):


### PR DESCRIPTION
- Support bandpass remapping so we can make UHF info from files that insist the two bands are 90 and 150
- Change mux_subband 'NC' indicator from '-1' to 'NC'. This was found because if you include -1 in an array of strings, the dtype becomes 'U21' or larger... that's too much.
- Apply --overwrite option to also clobber manifestdb entry.

@skhrg Heads up the LAT UHF wafer_infos should be redone with the bandpass_remap option, too.