### PR TITLE
Unify preprocessing functions

### DIFF
--- a/docs/preprocess.rst
+++ b/docs/preprocess.rst
@@ -51,13 +51,11 @@ configuration files and specific manifest databases.
 
 .. autofunction:: sotodlib.site_pipeline.preprocess_tod.preprocess_tod
 
-.. autofunction:: sotodlib.site_pipeline.preprocess_tod.load_preprocess_det_select
+.. autofunction:: sotodlib.preprocess.preprocess_util.load_preprocess_det_select
 
-.. autofunction:: sotodlib.site_pipeline.preprocess_tod.load_preprocess_tod
+.. autofunction:: sotodlib.preprocess.preprocess_util.load_and_preprocess
 
 .. autofunction:: sotodlib.site_pipeline.preprocess_obs.preprocess_obs
-
-.. autofunction:: sotodlib.site_pipeline.preprocess_obs.load_preprocess_obs
 
 Example TOD Pipeline Configuration File
 ---------------------------------------

--- a/sotodlib/mapmaking/demod_mapmaker.py
+++ b/sotodlib/mapmaking/demod_mapmaker.py
@@ -523,6 +523,7 @@ def make_demod_map(context, obslist, noise_model, info,
         List of outputs from preprocess database. To be used in cleanup_mandb.
     """
     from .. import site_pipeline
+    from ..preprocess import preprocess_util
     context = core.Context(context)
     if L is None:
         L = site_pipeline.util.init_logger("Demod filterbin mapmaking")
@@ -542,7 +543,7 @@ def make_demod_map(context, obslist, noise_model, info,
     for oi in range(len(obslist)):
         obs_id, detset, band = obslist[oi][:3]
         name = "%s:%s:%s" % (obs_id, detset, band)
-        error, output, obs = site_pipeline.preprocess_tod.preproc_or_load_group(obs_id,
+        error, output, obs = preprocess_util.preproc_or_load_group(obs_id,
                             configs=preprocess_config,
                             dets={'wafer_slot':detset, 'wafer.bandpass':band}, 
                             logger=L, context=context, overwrite=False)

--- a/sotodlib/mapmaking/demod_mapmaker.py
+++ b/sotodlib/mapmaking/demod_mapmaker.py
@@ -522,11 +522,10 @@ def make_demod_map(context, obslist, noise_model, info,
     outputs : list
         List of outputs from preprocess database. To be used in cleanup_mandb.
     """
-    from .. import site_pipeline
     from ..preprocess import preprocess_util
     context = core.Context(context)
     if L is None:
-        L = site_pipeline.util.init_logger("Demod filterbin mapmaking")
+        L = preprocess_util.init_logger("Demod filterbin mapmaking")
     pre = "" if tag is None else tag + " "
     if comm.rank == 0: L.info(pre + "Initializing equation system")
     mapmaker = setup_demod_map(noise_model, shape=shape, wcs=wcs, nside=nside,

--- a/sotodlib/preprocess/__init__.py
+++ b/sotodlib/preprocess/__init__.py
@@ -1,3 +1,3 @@
 from .pcore import _Preprocess, Pipeline
 from .processes import *
-from . import preprocess_util
+from .preprocess_util import *

--- a/sotodlib/preprocess/__init__.py
+++ b/sotodlib/preprocess/__init__.py
@@ -1,2 +1,3 @@
 from .pcore import _Preprocess, Pipeline
 from .processes import *
+from . import preprocess_util

--- a/sotodlib/preprocess/preprocess_util.py
+++ b/sotodlib/preprocess/preprocess_util.py
@@ -29,10 +29,10 @@ def load_preprocess_det_select(obs_id, configs, context=None,
     pipe[-1].select(meta)
     return meta
 
-def load_preprocess(obs_id, configs, context=None, dets=None, meta=None,
-                    no_signal=None):
-    """ Loads the saved information from the preprocessing pipeline and runs the
-    processing section of the pipeline. 
+def load_and_preprocess(obs_id, configs, context=None, dets=None, meta=None,
+                        no_signal=None):
+    """ Loads the saved information from the preprocessing pipeline and runs
+    the processing section of the pipeline. 
 
     Assumes preprocess_tod has already been run on the requested observation. 
     
@@ -73,7 +73,7 @@ def preproc_or_load_group(obs_id, configs, dets, logger=None,
     The dets dictionary must match the grouping specified in the preprocess
     config file. If the preprocess database entry for this obsid-dets group
     already exists then this function will just load back the processed tod
-    calling the ``load_preprocess`` function. If the db entry does not
+    calling the ``load_and_preprocess`` function. If the db entry does not
     exist of the overwrite flag is set to True then the full preprocessing
     steps defined in the configs are run and the outputs are written to a
     unique h5 file. Any errors, the info to populate the database, the file
@@ -150,7 +150,7 @@ def preproc_or_load_group(obs_id, configs, dets, logger=None,
 
     if dbexist and (not overwrite):
         logger.info(f"db exists for {obs_id} {dets} loading data and applying preprocessing.")
-        aman = load_preprocess(obs_id=obs_id, dets=dets, configs=configs, context=context)
+        aman = load_and_preprocess(obs_id=obs_id, dets=dets, configs=configs, context=context)
         error = 'load_success'
         return error, [obs_id, dets], aman
     else:

--- a/sotodlib/preprocess/preprocess_util.py
+++ b/sotodlib/preprocess/preprocess_util.py
@@ -106,7 +106,9 @@ def init_logger(name, announce='', verbosity=2):
 
 def get_preprocess_context(configs, context=None):
     """Load the provided config file and context file. To be used in
-    ``preprocess_*.py`` site pipeline scripts.
+    ``preprocess_*.py`` site pipeline scripts. If the provided context
+    file does not have a metadata entry for preprocess then one will
+    be added based on the definition in the config file.
 
     Parameters
     ----------

--- a/sotodlib/preprocess/preprocess_util.py
+++ b/sotodlib/preprocess/preprocess_util.py
@@ -124,13 +124,13 @@ def get_preprocess_context(configs, context=None):
     """
     if type(configs) == str:
         configs = yaml.safe_load(open(configs, "r"))
-    
+
     if context is None:
         context = core.Context(configs["context_file"])
-        
+
     if type(context) == str:
         context = core.Context(context)
-    
+
     # if context doesn't have the preprocess archive it in add it
     # allows us to use same context before and after calculations
     found=False
@@ -142,7 +142,7 @@ def get_preprocess_context(configs, context=None):
             found=True
             break
     if not found:
-        context["metadata"].append( 
+        context["metadata"].append(
             {
                 "db" : configs["archive"]["index"],
                 "name" : "preprocess"
@@ -179,7 +179,7 @@ def get_groups(obs_id, configs, context):
         if (gb == 'detset') and (len(group_by) == 1):
             groups = context.obsfiledb.get_detsets(obs_id)
             return group_by, [[g] for g in groups]
-        
+
     det_info = context.get_det_info(obs_id)
     rs = det_info.subset(keys=group_by).distinct()
     groups = [[b for a,b in r.items()] for r in rs]
@@ -189,7 +189,7 @@ def get_groups(obs_id, configs, context):
 def get_preprocess_db(configs, group_by, logger=None):
     """Get or create a ManifestDb found for a given
     config.
-    
+
     Arguments
     ----------
     configs : dict
@@ -199,16 +199,16 @@ def get_preprocess_db(configs, group_by, logger=None):
     logger : PythonLogger
         Optional. Logger object.  If None, a new logger
         is created.
-    
+
     Returns
     -------
     db : ManifestDb
         ManifestDb object
     """
-    
+
     if logger is None:
         logger = init_logger("preprocess_db")
-    
+
     if os.path.exists(configs['archive']['index']):
         logger.info(f"Mapping {configs['archive']['index']} for the "
                     "archive index.")
@@ -232,14 +232,14 @@ def swap_archive(config, fpath):
     """Update the configuration archive policy filename,
     create an output archive directory if it doesn't exist,
     and return a copy of the config.
-    
+
     Arguments
     ----------
     configs : dict
         The configuration dictionary.
     fpath : str
         The archive policy filename to write to.
-    
+
     Returns
     -------
     tc : dict
@@ -261,7 +261,7 @@ def load_preprocess_det_select(obs_id, configs, context=None,
     Arguments
     ----------
     obs_id: multiple
-        passed to `context.get_obs` to load AxisManager, see Notes for 
+        passed to `context.get_obs` to load AxisManager, see Notes for
         `context.get_obs`
     configs: string or dictionary
         config file or loaded config directory
@@ -273,7 +273,7 @@ def load_preprocess_det_select(obs_id, configs, context=None,
     """
     configs, context = get_preprocess_context(configs, context)
     pipe = Pipeline(configs["process_pipe"], logger=logger)
-    
+
     meta = context.get_meta(obs_id, dets=dets, meta=meta)
     logger.info(f"Cutting on the last process: {pipe[-1].name}")
     pipe[-1].select(meta)
@@ -282,14 +282,14 @@ def load_preprocess_det_select(obs_id, configs, context=None,
 def load_and_preprocess(obs_id, configs, context=None, dets=None, meta=None,
                         no_signal=None):
     """ Loads the saved information from the preprocessing pipeline and runs
-    the processing section of the pipeline. 
+    the processing section of the pipeline.
 
-    Assumes preprocess_tod has already been run on the requested observation. 
-    
+    Assumes preprocess_tod has already been run on the requested observation.
+
     Arguments
     ----------
     obs_id: multiple
-        passed to `context.get_obs` to load AxisManager, see Notes for 
+        passed to `context.get_obs` to load AxisManager, see Notes for
         `context.get_obs`
     configs: string or dictionary
         config file or loaded config directory
@@ -298,7 +298,7 @@ def load_and_preprocess(obs_id, configs, context=None, dets=None, meta=None,
     meta: AxisManager
         Contains supporting metadata to use for loading.
         Can be pre-restricted in any way. See context.get_meta.
-    no_signal: bool 
+    no_signal: bool
         If True, signal will be set to None.
         This is a way to get the axes and pointing info without
         the (large) TOD blob.  Not all loaders may support this.
@@ -317,7 +317,7 @@ def load_and_preprocess(obs_id, configs, context=None, dets=None, meta=None,
         return aman
 
 
-def preproc_or_load_group(obs_id, configs, dets, logger=None, 
+def preproc_or_load_group(obs_id, configs, dets, logger=None,
                           context=None, overwrite=False):
     """
     This function is expected to receive a single obs_id, and dets dictionary.
@@ -366,7 +366,7 @@ def preproc_or_load_group(obs_id, configs, dets, logger=None,
     """
     error = None
     outputs = {}
-    if logger is None: 
+    if logger is None:
         logger = init_logger("preprocess")
 
     if type(configs) == str:
@@ -437,7 +437,7 @@ def preproc_or_load_group(obs_id, configs, dets, logger=None,
         proc_aman.save(dest_file, dest_dataset, overwrite)
         # Collect info for saving h5 file.
         outputs['temp_file'] = dest_file
-        
+
         # Collect index info.
         db_data = {'obs:obs_id': obs_id,
                     'dataset': dest_dataset}
@@ -454,13 +454,13 @@ def cleanup_mandb(error, outputs, configs, logger):
     function is expected to be run from rank 0 after a ``comm.gather``.
     See the ``preproc_or_load_group`` docstring for the varying expected
     values of ``error`` and the associated ``outputs``. This function will
-    either: 
-    
+    either:
+
     1) Update the mandb sqlite file and move the h5 archive from its temporary
     location to its permanent path if error is ``None``.
-    
+
     2) Return nothing if error is ``load_success``.
-    
+
     3) Update the error log if error is anything else.
     """
     if error is None:

--- a/sotodlib/preprocess/preprocess_util.py
+++ b/sotodlib/preprocess/preprocess_util.py
@@ -1,0 +1,254 @@
+import sotodlib.site_pipeline.util as sp_util
+from sotodlib.preprocess import _Preprocess, Pipeline, processes
+
+logger = sp_util.init_logger("preprocess")
+
+def load_preprocess_det_select(obs_id, configs, context=None,
+                               dets=None, meta=None):
+    """Loads the metadata information for the Observation and runs through any
+    data selection specified by the Preprocessing Pipeline.
+
+    Arguments
+    ----------
+    obs_id: multiple
+        passed to `context.get_obs` to load AxisManager, see Notes for 
+        `context.get_obs`
+    configs: string or dictionary
+        config file or loaded config directory
+    dets: dict
+        dets to restrict on from info in det_info. See context.get_meta.
+    meta: AxisManager
+        Contains supporting metadata to use for loading.
+        Can be pre-restricted in any way. See context.get_meta.
+    """
+    configs, context = sp_util.get_preprocess_context(configs, context)
+    pipe = Pipeline(configs["process_pipe"], logger=logger)
+    
+    meta = context.get_meta(obs_id, dets=dets, meta=meta)
+    logger.info(f"Cutting on the last process: {pipe[-1].name}")
+    pipe[-1].select(meta)
+    return meta
+
+def load_preprocess(obs_id, configs, context=None, dets=None, meta=None,
+                    no_signal=None):
+    """ Loads the saved information from the preprocessing pipeline and runs the
+    processing section of the pipeline. 
+
+    Assumes preprocess_tod has already been run on the requested observation. 
+    
+    Arguments
+    ----------
+    obs_id: multiple
+        passed to `context.get_obs` to load AxisManager, see Notes for 
+        `context.get_obs`
+    configs: string or dictionary
+        config file or loaded config directory
+    dets: dict
+        dets to restrict on from info in det_info. See context.get_meta.
+    meta: AxisManager
+        Contains supporting metadata to use for loading.
+        Can be pre-restricted in any way. See context.get_meta.
+    no_signal: bool 
+        If True, signal will be set to None.
+        This is a way to get the axes and pointing info without
+        the (large) TOD blob.  Not all loaders may support this.
+    """
+    configs, context = sp_util.get_preprocess_context(configs, context)
+    meta = load_preprocess_det_select(obs_id, configs=configs, context=context,
+                                      dets=dets, meta=meta)
+
+    if meta.dets.count == 0:
+        logger.info(f"No detectors left after cuts in obs {obs_id}")
+        return None
+    else:
+        pipe = Pipeline(configs["process_pipe"], logger=logger)
+        aman = context.get_obs(meta, no_signal=no_signal)
+        pipe.run(aman, aman.preprocess)
+        return aman
+    
+def preproc_or_load_group(obs_id, configs, dets, logger=None, 
+                          context=None, overwrite=False):
+    """
+    This function is expected to receive a single obs_id, and dets dictionary.
+    The dets dictionary must match the grouping specified in the preprocess
+    config file. If the preprocess database entry for this obsid-dets group
+    already exists then this function will just load back the processed tod
+    calling the ``load_preprocess`` function. If the db entry does not
+    exist of the overwrite flag is set to True then the full preprocessing
+    steps defined in the configs are run and the outputs are written to a
+    unique h5 file. Any errors, the info to populate the database, the file
+    path of the h5 file, and the process tod are returned from this function.
+    This function is expected to be run in conjunction with the
+    ``cleanup_mandb`` function which consumes all of the outputs (except the
+    processed tod), writes to the database, and moves the multiple h5 files
+    into fewer h5 files (each <= 10 GB).
+
+    Arguments
+    ---------
+    obs_id: str
+        Obs id to process or load
+    configs: fpath or dict
+        Filepath or dictionary containing the preprocess configuration file.
+    dets: dict
+        Dictionary specifying which detectors/wafers to load see ``Context.obsdb.get_obs``.
+    logger: PythonLogger
+        Optional. Logger object or None will generate a new one.
+    context: fpath or core.Context
+        Optional. Filepath or context object used for data loading/querying.
+    overwrite: bool
+        Optional. Whether or not to overwrite existing entries in the preprocess manifest db.
+
+    Returns
+    -------
+    error: str
+        String indicating if the function succeeded in its execution or failed.
+        If ``None`` then it succeeded in processing and the mandB should be updated.
+        If ``'load_success'`` then axis manager was successfully loaded from existing preproc db.
+        If any other string then processing failed and output will be logged in the error log.
+    output: list
+        Varies depending on the value of ``error``.
+        If ``error == None`` then output is the info needed to update the manifest db.
+        If ``error == 'load_success'`` then output is just ``[obs_id, dets]``.
+        If ``error`` is anything else then output stores what to save in the error log.
+    aman: Core.AxisManager
+        Processed axis manager only returned if ``error`` is ``None`` or ``'load_success'``.
+    """
+    error = None
+    outputs = {}
+    if logger is None: 
+        logger = sp_util.init_logger("preprocess")
+
+    if type(configs) == str:
+        configs = yaml.safe_load(open(configs, "r"))
+
+    context = core.Context(configs["context_file"])
+    group_by, groups = sp_util.get_groups(obs_id, configs, context)
+    all_groups = groups.copy()
+    cur_groups = [list(np.fromiter(dets.values(), dtype='<U32'))]
+    for g in all_groups:
+        if g not in cur_groups:
+            groups.remove(g)
+
+        if len(groups) == 0:
+            logger.warning(f"group_list:{cur_groups} contains no overlap with "
+                           f"groups in observation: {obs_id}:{cur_groups}. "
+                           f"No analysis to run.")
+            error = 'no_group_overlap'
+            return error, [obs_id, dets], None
+
+    dbexist = True
+    if os.path.exists(configs['archive']['index']):
+        db = core.metadata.ManifestDb(configs['archive']['index'])
+        dbix = {'obs:obs_id':obs_id}
+        for gb, g in zip(group_by, cur_groups[0]):
+            dbix[f'dets:{gb}'] = g
+        print(dbix)
+        if len(db.inspect(dbix)) == 0:
+            dbexist = False
+    else:
+        dbexist = False
+
+    if dbexist and (not overwrite):
+        logger.info(f"db exists for {obs_id} {dets} loading data and applying preprocessing.")
+        aman = load_preprocess(obs_id=obs_id, dets=dets, configs=configs, context=context)
+        error = 'load_success'
+        return error, [obs_id, dets], aman
+    else:
+        logger.info(f"Generating new preproc db entry for {obs_id} {dets}")
+        pipe = Pipeline(configs["process_pipe"], plot_dir=configs["plot_dir"], logger=logger)
+        try:
+            aman = context.get_obs(obs_id, dets=dets)
+            tags = np.array(context.obsdb.get(aman.obs_info.obs_id, tags=True)['tags'])
+            aman.wrap('tags', tags)
+            proc_aman, success = pipe.run(aman)
+            aman.wrap('preprocess', proc_aman)
+        except Exception as e:
+            error = f'Failed to load: {obs_id} {dets}'
+            errmsg = f'{type(e)}: {e}'
+            tb = ''.join(traceback.format_tb(e.__traceback__))
+            logger.info(f"{error}\n{errmsg}\n{tb}")
+            return error, [errmsg, tb], None
+        if success != 'end':
+            # If a single group fails we don't log anywhere just mis an entry in the db.
+            return success, [obs_id, dets], None
+        newpath = f'temp/{obs_id}'
+        for cg in cur_groups[0]:
+            newpath += f'_{cg}'
+        temp_config = sp_util.swap_archive(configs, newpath+'.h5')
+        policy = sp_util.ArchivePolicy.from_params(temp_config['archive']['policy'])
+        dest_file, dest_dataset = policy.get_dest(obs_id)
+        for gb, g in zip(group_by, cur_groups[0]):
+            if gb == 'detset':
+                dest_dataset += "_" + g
+            else:
+                dest_dataset += "_" + gb + "_" + str(g)
+
+        proc_aman.save(dest_file, dest_dataset, overwrite)
+        # Collect info for saving h5 file.
+        outputs['temp_file'] = dest_file
+        
+        # Collect index info.
+        db_data = {'obs:obs_id': obs_id,
+                    'dataset': dest_dataset}
+        for gb, g in zip(group_by, cur_groups[0]):
+            db_data['dets:'+gb] = g
+        outputs['db_data'] = db_data
+        return error, outputs, aman
+
+def cleanup_mandb(error, outputs, configs, logger):
+    """
+    Function to update the manifest db when data is collected from the
+    ``preproc_or_load_group`` function. If used in an mpi framework this
+    function is expected to be run from rank 0 after a ``comm.gather``.
+    See the ``preproc_or_load_group`` docstring for the varying expected
+    values of ``error`` and the associated ``outputs``. This function will
+    either: 
+    
+    1) Update the mandb sqlite file and move the h5 archive from its temporary
+    location to its permanent path if error is ``None``.
+    
+    2) Return nothing if error is ``load_success``.
+    
+    3) Update the error log if error is anything else.
+    """
+    if error is None:
+        # Expects archive policy filename to be <path>/<filename>.h5 and then this adds
+        # <path>/<filename>_<xxx>.h5 where xxx is a number that increments up from 0 
+        # whenever the file size exceeds 10 GB.
+        nfile = 0
+        folder = os.path.dirname(configs['archive']['policy']['filename'])
+        basename = os.path.splitext(configs['archive']['policy']['filename'])[0]
+        dest_file = basename + '_' + str(nfile).zfill(3) + '.h5'
+        if not(os.path.exists(folder)):
+                os.makedirs(folder)
+        while os.path.exists(dest_file) and os.path.getsize(dest_file) > 10e9:
+            nfile += 1
+            dest_file = basename + '_' + str(nfile).zfill(3) + '.h5'
+        group_by = [k.split(':')[-1] for k in outputs['db_data'].keys() if 'dets' in k]
+        db = sp_util.get_preprocess_db(configs, group_by, logger)
+        h5_path = os.path.relpath(dest_file,
+                                  start=os.path.dirname(configs['archive']['index']))
+
+        src_file = outputs['temp_file']
+        with h5py.File(dest_file,'a') as f_dest:
+            with h5py.File(src_file,'r') as f_src:
+                for dts in f_src.keys():
+                    f_src.copy(f_src[f'{dts}'], f_dest, f'{dts}')
+                    for member in f_src[dts]:
+                        if isinstance(f_src[f'{dts}/{member}'], h5py.Dataset):
+                            f_src.copy(f_src[f'{dts}/{member}'], f_dest[f'{dts}'], f'{dts}/{member}')
+        logger.info(f"Saving to database under {outputs['db_data']}")
+        if len(db.inspect(outputs['db_data'])) == 0:
+            db.add_entry(outputs['db_data'], h5_path)
+        os.remove(src_file)
+    elif error == 'load_success':
+        return
+    else:
+        folder = os.path.dirname(configs['archive']['index'])
+        if not(os.path.exists(folder)):
+            os.makedirs(folder)
+        errlog = os.path.join(folder, 'errlog.txt')
+        f = open(errlog, 'a')
+        f.write(f'{time.time()}, {error}\n')
+        f.write(f'\t{outputs[0]}\n\t{outputs[1]}\n')
+        f.close()

--- a/sotodlib/site_pipeline/preprocess_tod.py
+++ b/sotodlib/site_pipeline/preprocess_tod.py
@@ -14,6 +14,7 @@ from sotodlib.coords import demod as demod_mm
 from sotodlib.hwp import hwp_angle_model
 from sotodlib import core
 import sotodlib.site_pipeline.util as sp_util
+from sotodlib.preprocess import preprocess_util as pp_util
 from sotodlib.preprocess import _Preprocess, Pipeline, processes
 
 logger = sp_util.init_logger("preprocess")
@@ -28,7 +29,7 @@ def dummy_preproc(obs_id, group_list, logger,
     error = None
     outputs = []
     context = core.Context(configs["context_file"])
-    group_by, groups = _get_groups(obs_id, configs, context)
+    group_by, groups = sp_util.get_groups(obs_id, configs, context)
     pipe = Pipeline(configs["process_pipe"], plot_dir=configs["plot_dir"], logger=logger)
     for group in groups:
         logger.info(f"Beginning run for {obs_id}:{group}")
@@ -55,265 +56,6 @@ def dummy_preproc(obs_id, group_list, logger,
             outputs.append(db_data)
     if run_parallel:
         return error, dest_file, outputs
-
-def _get_preprocess_context(configs, context=None):
-    if type(configs) == str:
-        configs = yaml.safe_load(open(configs, "r"))
-    
-    if context is None:
-        context = core.Context(configs["context_file"])
-        
-    if type(context) == str:
-        context = core.Context(context)
-    
-    # if context doesn't have the preprocess archive it in add it
-    # allows us to use same context before and after calculations
-    found=False
-    if context.get("metadata") is None:
-        context["metadata"] = []
-
-    for key in context.get("metadata"):
-        if key.get("unpack") == "preprocess":
-            found=True
-            break
-    if not found:
-        context["metadata"].append( 
-            {
-                "db" : configs["archive"]["index"],
-                "unpack" : "preprocess"
-            }
-        )
-    return configs, context
-
-def _get_groups(obs_id, configs, context):
-    group_by = np.atleast_1d(configs['subobs'].get('use', 'detset'))
-    for i, gb in enumerate(group_by):
-        if gb.startswith('dets:'):
-            group_by[i] = gb.split(':',1)[1]
-
-        if (gb == 'detset') and (len(group_by) == 1):
-            groups = context.obsfiledb.get_detsets(obs_id)
-            return group_by, [[g] for g in groups]
-        
-    det_info = context.get_det_info(obs_id)
-    rs = det_info.subset(keys=group_by).distinct()
-    groups = [[b for a,b in r.items()] for r in rs]
-    return group_by, groups
-
-def _get_preprocess_db(configs, group_by):
-    if os.path.exists(configs['archive']['index']):
-        logger.info(f"Mapping {configs['archive']['index']} for the "
-                    "archive index.")
-        db = core.metadata.ManifestDb(configs['archive']['index'])
-    else:
-        logger.info(f"Creating {configs['archive']['index']} for the "
-                     "archive index.")
-        scheme = core.metadata.ManifestScheme()
-        scheme.add_exact_match('obs:obs_id')
-        for gb in group_by:
-            scheme.add_exact_match('dets:' + gb)
-        scheme.add_data_field('dataset')
-        db = core.metadata.ManifestDb(
-            configs['archive']['index'],
-            scheme=scheme
-        )
-    return db
-
-def swap_archive(config, fpath):
-    tc = copy.deepcopy(config)
-    tc['archive']['policy']['filename'] = os.path.join(os.path.dirname(tc['archive']['policy']['filename']), fpath)
-    dname = os.path.dirname(tc['archive']['policy']['filename'])
-    if not(os.path.exists(dname)):
-        os.makedirs(dname)
-    return tc
-
-def preproc_or_load_group(obs_id, configs, dets, logger=None, 
-                          context=None, overwrite=False):
-    """
-    This function is expected to receive a single obs_id, and dets dictionary.
-    The dets dictionary must match the grouping specified in the preprocess
-    config file. If the preprocess database entry for this obsid-dets group
-    already exists then this function will just load back the processed tod
-    calling the ``load_preprocess_tod`` function. If the db entry does not
-    exist of the overwrite flag is set to True then the full preprocessing
-    steps defined in the configs are run and the outputs are written to a
-    unique h5 file. Any errors, the info to populate the database, the file
-    path of the h5 file, and the process tod are returned from this function.
-    This function is expected to be run in conjunction with the
-    ``cleanup_mandb`` function which consumes all of the outputs (except the
-    processed tod), writes to the database, and moves the multiple h5 files
-    into fewer h5 files (each <= 10 GB).
-
-    Arguments
-    ---------
-    obs_id: str
-        Obs id to process or load
-    configs: fpath or dict
-        Filepath or dictionary containing the preprocess configuration file.
-    dets: dict
-        Dictionary specifying which detectors/wafers to load see ``Context.obsdb.get_obs``.
-    logger: PythonLogger
-        Optional. Logger object or None will generate a new one.
-    context: fpath or core.Context
-        Optional. Filepath or context object used for data loading/querying.
-    overwrite: bool
-        Optional. Whether or not to overwrite existing entries in the preprocess manifest db.
-
-    Returns
-    -------
-    error: str
-        String indicating if the function succeeded in its execution or failed.
-        If ``None`` then it succeeded in processing and the mandB should be updated.
-        If ``'load_success'`` then axis manager was successfully loaded from existing preproc db.
-        If any other string then processing failed and output will be logged in the error log.
-    output: list
-        Varies depending on the value of ``error``.
-        If ``error == None`` then output is the info needed to update the manifest db.
-        If ``error == 'load_success'`` then output is just ``[obs_id, dets]``.
-        If ``error`` is anything else then output stores what to save in the error log.
-    aman: Core.AxisManager
-        Processed axis manager only returned if ``error`` is ``None`` or ``'load_success'``.
-    """
-    error = None
-    outputs = {}
-    if logger is None: 
-        logger = sp_util.init_logger("preprocess")
-
-    if type(configs) == str:
-        configs = yaml.safe_load(open(configs, "r"))
-
-    context = core.Context(configs["context_file"])
-    group_by, groups = _get_groups(obs_id, configs, context)
-    all_groups = groups.copy()
-    cur_groups = [list(np.fromiter(dets.values(), dtype='<U32'))]
-    for g in all_groups:
-        if g not in cur_groups:
-            groups.remove(g)
-
-        if len(groups) == 0:
-            logger.warning(f"group_list:{cur_groups} contains no overlap with "
-                           f"groups in observation: {obs_id}:{cur_groups}. "
-                           f"No analysis to run.")
-            error = 'no_group_overlap'
-            return error, [obs_id, dets], None
-
-    dbexist = True
-    if os.path.exists(configs['archive']['index']):
-        db = core.metadata.ManifestDb(configs['archive']['index'])
-        dbix = {'obs:obs_id':obs_id}
-        for gb, g in zip(group_by, cur_groups[0]):
-            dbix[f'dets:{gb}'] = g
-        print(dbix)
-        if len(db.inspect(dbix)) == 0:
-            dbexist = False
-    else:
-        dbexist = False
-
-    if dbexist and (not overwrite):
-        logger.info(f"db exists for {obs_id} {dets} loading data and applying preprocessing.")
-        aman = load_preprocess_tod(obs_id=obs_id, dets=dets,
-                                   configs=configs, context=context)
-        error = 'load_success'
-        return error, [obs_id, dets], aman
-    else:
-        logger.info(f"Generating new preproc db entry for {obs_id} {dets}")
-        pipe = Pipeline(configs["process_pipe"], plot_dir=configs["plot_dir"], logger=logger)
-        try:
-            aman = context.get_obs(obs_id, dets=dets)
-            tags = np.array(context.obsdb.get(aman.obs_info.obs_id, tags=True)['tags'])
-            aman.wrap('tags', tags)
-            proc_aman, success = pipe.run(aman)
-            aman.wrap('preprocess', proc_aman)
-        except Exception as e:
-            error = f'Failed to load: {obs_id} {dets}'
-            errmsg = f'{type(e)}: {e}'
-            tb = ''.join(traceback.format_tb(e.__traceback__))
-            logger.info(f"{error}\n{errmsg}\n{tb}")
-            return error, [errmsg, tb], None
-        if success != 'end':
-            # If a single group fails we don't log anywhere just mis an entry in the db.
-            return success, [obs_id, dets], None
-        newpath = f'temp/{obs_id}'
-        for cg in cur_groups[0]:
-            newpath += f'_{cg}'
-        temp_config = swap_archive(configs, newpath+'.h5')
-        policy = sp_util.ArchivePolicy.from_params(temp_config['archive']['policy'])
-        dest_file, dest_dataset = policy.get_dest(obs_id)
-        for gb, g in zip(group_by, cur_groups[0]):
-            if gb == 'detset':
-                dest_dataset += "_" + g
-            else:
-                dest_dataset += "_" + gb + "_" + str(g)
-
-        proc_aman.save(dest_file, dest_dataset, overwrite)
-        # Collect info for saving h5 file.
-        outputs['temp_file'] = dest_file
-        
-        # Collect index info.
-        db_data = {'obs:obs_id': obs_id,
-                    'dataset': dest_dataset}
-        for gb, g in zip(group_by, cur_groups[0]):
-            db_data['dets:'+gb] = g
-        outputs['db_data'] = db_data
-        return error, outputs, aman
-          
-def cleanup_mandb(error, outputs, configs, logger):
-    """
-    Function to update the manifest db when data is collected from the
-    ``preproc_or_load_group`` function. If used in an mpi framework this
-    function is expected to be run from rank 0 after a ``comm.gather``.
-    See the ``preproc_or_load_group`` docstring for the varying expected
-    values of ``error`` and the associated ``outputs``. This function will
-    either: 
-    
-    1) Update the mandb sqlite file and move the h5 archive from its temporary
-    location to its permanent path if error is ``None``.
-    
-    2) Return nothing if error is ``load_success``.
-    
-    3) Update the error log if error is anything else.
-    """
-    if error is None:
-        # Expects archive policy filename to be <path>/<filename>.h5 and then this adds
-        # <path>/<filename>_<xxx>.h5 where xxx is a number that increments up from 0 
-        # whenever the file size exceeds 10 GB.
-        nfile = 0
-        folder = os.path.dirname(configs['archive']['policy']['filename'])
-        basename = os.path.splitext(configs['archive']['policy']['filename'])[0]
-        dest_file = basename + '_' + str(nfile).zfill(3) + '.h5'
-        if not(os.path.exists(folder)):
-                os.makedirs(folder)
-        while os.path.exists(dest_file) and os.path.getsize(dest_file) > 10e9:
-            nfile += 1
-            dest_file = basename + '_' + str(nfile).zfill(3) + '.h5'
-        group_by =  [k.split(':')[-1] for k in outputs['db_data'].keys() if 'dets' in k]
-        db = _get_preprocess_db(configs, group_by)
-        h5_path = os.path.relpath(dest_file,
-                                  start=os.path.dirname(configs['archive']['index']))
-
-        src_file = outputs['temp_file']
-        with h5py.File(dest_file,'a') as f_dest:
-            with h5py.File(src_file,'r') as f_src:
-                for dts in f_src.keys():
-                    f_src.copy(f_src[f'{dts}'], f_dest, f'{dts}')
-                    for member in f_src[dts]:
-                        if isinstance(f_src[f'{dts}/{member}'], h5py.Dataset):
-                            f_src.copy(f_src[f'{dts}/{member}'], f_dest[f'{dts}'], f'{dts}/{member}')
-        logger.info(f"Saving to database under {outputs['db_data']}")
-        if len(db.inspect(outputs['db_data'])) == 0:
-            db.add_entry(outputs['db_data'], h5_path)
-        os.remove(src_file)
-    elif error == 'load_success':
-        return
-    else:
-        folder = os.path.dirname(configs['archive']['index'])
-        if not(os.path.exists(folder)):
-            os.makedirs(folder)
-        errlog = os.path.join(folder, 'errlog.txt')
-        f = open(errlog, 'a')
-        f.write(f'{time.time()}, {error}\n')
-        f.write(f'\t{outputs[0]}\n\t{outputs[1]}\n')
-        f.close()
 
 def preprocess_tod(obs_id, 
                     configs, 
@@ -348,7 +90,7 @@ def preprocess_tod(obs_id,
         configs = yaml.safe_load(open(configs, "r"))
   
     context = core.Context(configs["context_file"])
-    group_by, groups = _get_groups(obs_id, configs, context)
+    group_by, groups = sp_util.get_groups(obs_id, configs, context)
     all_groups = groups.copy()
     for g in all_groups:
         if group_list is not None:
@@ -382,7 +124,7 @@ def preprocess_tod(obs_id,
             return
     
     if not(run_parallel):
-        db = _get_preprocess_db(configs, group_by)
+        db = sp_util.get_preprocess_db(configs, group_by)
     
     pipe = Pipeline(configs["process_pipe"], plot_dir=configs["plot_dir"], logger=logger)
 
@@ -463,32 +205,6 @@ def preprocess_tod(obs_id,
             error = None
             return error, dest_file, outputs
 
-def load_preprocess_det_select(obs_id, configs, context=None,
-                               dets=None, meta=None):
-    """ Loads the metadata information for the Observation and runs through any
-    data selection specified by the Preprocessing Pipeline.
-
-    Arguments
-    ----------
-    obs_id: multiple
-        passed to `context.get_obs` to load AxisManager, see Notes for 
-        `context.get_obs`
-    configs: string or dictionary
-        config file or loaded config directory
-    dets: dict
-        dets to restrict on from info in det_info. See context.get_meta.
-    meta: AxisManager
-        Contains supporting metadata to use for loading.
-        Can be pre-restricted in any way. See context.get_meta.
-    """
-    configs, context = _get_preprocess_context(configs, context)
-    pipe = Pipeline(configs["process_pipe"], logger=logger)
-    
-    meta = context.get_meta(obs_id, dets=dets, meta=meta)
-    logger.info(f"Cutting on the last process: {pipe[-1].name}")
-    pipe[-1].select(meta)
-    return meta
-
 def load_preprocess_tod_sim(obs_id, sim_map,
                             configs="preprocess_configs.yaml",
                             context=None, dets=None,
@@ -517,8 +233,9 @@ def load_preprocess_tod_sim(obs_id, sim_map,
         into a modulated signal.
         If False, scan the simulation into demodulated timestreams.
     """
-    configs, context = _get_preprocess_context(configs, context)
-    meta = load_preprocess_det_select(obs_id, configs=configs, context=context, dets=dets, meta=meta)
+    configs, context = sp_util.get_preprocess_context(configs, context)
+    meta = pp_util.load_preprocess_det_select(obs_id, configs=configs,
+                                              context=context, dets=dets, meta=meta)
 
     if meta.dets.count == 0:
         logger.info(f"No detectors left after cuts in obs {obs_id}")
@@ -535,39 +252,6 @@ def load_preprocess_tod_sim(obs_id, sim_map,
         demod_mm.from_map(aman, sim_map, wrap=True, modulated=modulated)
         pipe.run(aman, aman.preprocess, sim=True)
         return aman
-
-def load_preprocess_tod(obs_id, configs="preprocess_configs.yaml",
-                        context=None, dets=None, meta=None):
-    """ Loads the saved information from the preprocessing pipeline and runs the
-    processing section of the pipeline. 
-
-    Assumes preprocess_tod has already been run on the requested observation. 
-    
-    Arguments
-    ----------
-    obs_id: multiple
-        passed to `context.get_obs` to load AxisManager, see Notes for 
-        `context.get_obs`
-    configs: string or dictionary
-        config file or loaded config directory
-    dets: dict
-        dets to restrict on from info in det_info. See context.get_meta.
-    meta: AxisManager
-        Contains supporting metadata to use for loading.
-        Can be pre-restricted in any way. See context.get_meta.
-    """
-    configs, context = _get_preprocess_context(configs, context)
-    meta = load_preprocess_det_select(obs_id, configs=configs, context=context, dets=dets, meta=meta)
-
-    if meta.dets.count == 0:
-        logger.info(f"No detectors left after cuts in obs {obs_id}")
-        return None
-    else:
-        pipe = Pipeline(configs["process_pipe"], logger=logger)
-        aman = context.get_obs(meta)
-        pipe.run(aman, aman.preprocess)
-        return aman
-
 
 def get_parser(parser=None):
     if parser is None:
@@ -639,7 +323,7 @@ def main(
         verbosity: Optional[int] = None,
         nproc: Optional[int] = 4
  ):
-    configs, context = _get_preprocess_context(configs)
+    configs, context = sp_util.get_preprocess_context(configs)
     logger = sp_util.init_logger("preprocess", verbosity=verbosity)
 
     errlog = os.path.join(os.path.dirname(configs['archive']['index']),
@@ -689,7 +373,7 @@ def main(
         db = core.metadata.ManifestDb(configs['archive']['index'])
         for obs in obs_list:
             x = db.inspect({'obs:obs_id': obs["obs_id"]})
-            group_by, groups = _get_groups(obs["obs_id"], configs, context)
+            group_by, groups = sp_util.get_groups(obs["obs_id"], configs, context)
             if x is None or len(x) == 0:
                 run_list.append( (obs, None) )
             elif len(x) != len(groups):
@@ -717,7 +401,7 @@ def main(
     with ProcessPoolExecutor(nproc) as exe:
         futures = [exe.submit(preprocess_tod, obs_id=r[0]['obs_id'],
                      group_list=r[1], verbosity=verbosity,
-                     configs=swap_archive(configs, f'temp/{r[0]["obs_id"]}.h5'),
+                     configs=sp_util.swap_archive(configs, f'temp/{r[0]["obs_id"]}.h5'),
                      overwrite=overwrite, run_parallel=True) for r in run_list]
         for future in as_completed(futures):
             logger.info('New future as_completed result')
@@ -734,7 +418,7 @@ def main(
             futures.remove(future)
 
             logger.info(f'Processing future result db_dataset: {db_datasets}')
-            db = _get_preprocess_db(configs, group_by)
+            db = sp_util.get_preprocess_db(configs, group_by)
             logger.info('Database connected')
             if os.path.exists(dest_file) and os.path.getsize(dest_file) >= 10e9:
                 nfile += 1

--- a/sotodlib/site_pipeline/preprocess_tod.py
+++ b/sotodlib/site_pipeline/preprocess_tod.py
@@ -19,7 +19,7 @@ from sotodlib.preprocess import _Preprocess, Pipeline, processes
 
 logger = sp_util.init_logger("preprocess")
 
-def dummy_preproc(obs_id, group_list, logger, 
+def dummy_preproc(obs_id, group_list, logger,
                   configs, overwrite, run_parallel):
     """
     Dummy function that can be put in place of preprocess_tod in the
@@ -45,8 +45,8 @@ def dummy_preproc(obs_id, group_list, logger,
             else:
                 dest_dataset += "_" + gb + "_" + str(g)
         logger.info(f"Saving data to {dest_file}:{dest_dataset}")
-        proc_aman.save(dest_file, dest_dataset, overwrite)        
-        
+        proc_aman.save(dest_file, dest_dataset, overwrite)
+
         # Collect index info.
         db_data = {'obs:obs_id': obs_id,
                    'dataset': dest_dataset}
@@ -57,15 +57,15 @@ def dummy_preproc(obs_id, group_list, logger,
     if run_parallel:
         return error, dest_file, outputs
 
-def preprocess_tod(obs_id, 
-                   configs, 
+def preprocess_tod(obs_id,
+                   configs,
                    verbosity=0,
-                   group_list=None, 
+                   group_list=None,
                    overwrite=False,
                    run_parallel=False):
     """Meant to be run as part of a batched script, this function calls the
     preprocessing pipeline a specific Observation ID and saves the results in
-    the ManifestDb specified in the configs.   
+    the ManifestDb specified in the configs.
 
     Arguments
     ----------
@@ -85,10 +85,10 @@ def preprocess_tod(obs_id,
     """
     outputs = []
     logger = sp_util.init_logger("preprocess", verbosity=verbosity)
-    
+
     if type(configs) == str:
         configs = yaml.safe_load(open(configs, "r"))
-  
+
     context = core.Context(configs["context_file"])
     group_by, groups = pp_util.get_groups(obs_id, configs, context)
     all_groups = groups.copy()
@@ -122,17 +122,17 @@ def preprocess_tod(obs_id,
             return error, None, [None, None]
         else:
             return
-    
+
     if not(run_parallel):
         db = pp_util.get_preprocess_db(configs, group_by)
-    
+
     pipe = Pipeline(configs["process_pipe"], plot_dir=configs["plot_dir"], logger=logger)
 
     if configs.get("lmsi_config", None) is not None:
         make_lmsi = True
     else:
         make_lmsi = False
-    
+
     n_fail = 0
     for group in groups:
         logger.info(f"Beginning run for {obs_id}:{group}")
@@ -157,7 +157,7 @@ def preprocess_tod(obs_id,
             continue
         if success != 'end':
             # If a single group fails we don't log anywhere just mis an entry in the db.
-            logger.info(f"ERROR: {obs_id} {group}\nFailed at step {success}") 
+            logger.info(f"ERROR: {obs_id} {group}\nFailed at step {success}")
             n_fail += 1
             continue
 
@@ -193,7 +193,7 @@ def preprocess_tod(obs_id,
             lmsi.core([Path(x.name) for x in Path(new_plots).glob("*.png")],
                       Path(configs["lmsi_config"]),
                       Path(os.path.join(new_plots, 'index.html')))
-    
+
     if run_parallel:
         if n_fail == len(groups):
             # If no groups make it to the end of the processing return error.
@@ -212,12 +212,12 @@ def load_preprocess_tod_sim(obs_id, sim_map,
     """ Loads the saved information from the preprocessing pipeline and runs the
     processing section of the pipeline on simulated data
 
-    Assumes preprocess_tod has already been run on the requested observation. 
-    
+    Assumes preprocess_tod has already been run on the requested observation.
+
     Arguments
     ----------
     obs_id: multiple
-        passed to ``context.get_obs`` to load AxisManager, see Notes for 
+        passed to ``context.get_obs`` to load AxisManager, see Notes for
         `context.get_obs`
     sim_map: pixell.enmap.ndmap
         signal map containing (T, Q, U) fields
@@ -258,9 +258,9 @@ def get_parser(parser=None):
         parser = argparse.ArgumentParser()
     parser.add_argument('configs', help="Preprocessing Configuration File")
     parser.add_argument(
-        '--query', 
+        '--query',
         help="Query to pass to the observation list. Use \\'string\\' to "
-             "pass in strings within the query.",  
+             "pass in strings within the query.",
         type=str
     )
     parser.add_argument(
@@ -312,8 +312,8 @@ def get_parser(parser=None):
 
 def main(
         configs: str,
-        query: Optional[str] = None, 
-        obs_id: Optional[str] = None, 
+        query: Optional[str] = None,
+        obs_id: Optional[str] = None,
         overwrite: bool = False,
         min_ctime: Optional[int] = None,
         max_ctime: Optional[int] = None,
@@ -330,8 +330,8 @@ def main(
                           'errlog.txt')
     multiprocessing.set_start_method('spawn')
 
-    obs_list = sp_util.get_obslist(context, query=query, obs_id=obs_id, min_ctime=min_ctime, 
-                                   max_ctime=max_ctime, update_delay=update_delay, tags=tags, 
+    obs_list = sp_util.get_obslist(context, query=query, obs_id=obs_id, min_ctime=min_ctime,
+                                   max_ctime=max_ctime, update_delay=update_delay, tags=tags,
                                    planet_obs=planet_obs)
     if len(obs_list)==0:
         logger.warning(f"No observations returned from query: {query}")

--- a/sotodlib/site_pipeline/update_preprocess_plots.py
+++ b/sotodlib/site_pipeline/update_preprocess_plots.py
@@ -9,7 +9,7 @@ from typing import Optional
 import copy
 
 from sotodlib import core
-import sotodlib.site_pipeline.util as sp_util
+import sotodlib.preprocess.preprocess_util as pp_util
 from sotodlib.preprocess import _Preprocess, Pipeline, processes
 
 logger = sp_util.init_logger("preprocess")
@@ -30,7 +30,7 @@ def plot_preprocess_tod(obs_id, configs, context, group_list=None, verbosity=2):
     """
     logger = sp_util.init_logger("preprocess", verbosity=verbosity)
     
-    group_by, groups = sp_util.get_groups(obs_id, configs, context)
+    group_by, groups = pp_util.get_groups(obs_id, configs, context)
     all_groups = groups.copy()
     for g in all_groups:
         if group_list is not None:
@@ -87,7 +87,7 @@ def plot_preprocess_tod_from_db(obs_id, group_by, group, configs, context, verbo
     configs: string or dictionary
         config file or loaded config directory
     """
-    logger = sp_util.init_logger("preprocess", verbosity=verbosity)
+    logger = pp_util.init_logger("preprocess", verbosity=verbosity)
     
     pipe = Pipeline(configs["process_pipe"], plot_dir=configs["plot_dir"], logger=logger)
     
@@ -182,7 +182,7 @@ def main(
     preprocess_tod to define the obs you want to run plotting on.
 
     """
-    configs, context = sp_util.get_preprocess_context(configs)
+    configs, context = pp_util.get_preprocess_context(configs)
     logger = sp_util.init_logger("preprocess", verbosity=verbosity)
 
     if not os.path.exists(configs['archive']['index']):

--- a/sotodlib/site_pipeline/update_preprocess_plots.py
+++ b/sotodlib/site_pipeline/update_preprocess_plots.py
@@ -87,7 +87,7 @@ def plot_preprocess_tod_from_db(obs_id, group_by, group, configs, context, verbo
     configs: string or dictionary
         config file or loaded config directory
     """
-    logger = pp_util.init_logger("preprocess", verbosity=verbosity)
+    logger = sp_util.init_logger("preprocess", verbosity=verbosity)
     
     pipe = Pipeline(configs["process_pipe"], plot_dir=configs["plot_dir"], logger=logger)
     


### PR DESCRIPTION
This branch moves around some of the preprocessing functions into a common `preprocessing/preprocess_util.py` file.  The ones moved specifically are:

- `load_preprocess_det_select`
- `load_preprocess_tod`/`load_preprocess_obs` (merged into `load_and_preprocess`)
- `preproc_or_load_group` (to address #1025)
- `cleanup_mandb`

Some of these aren't shared among multiple files yet but they will be when #1026 is merged.  Note that the inputs of `load_and_preprocess` are slightly modified from `load_preprocess_tod`/`load_preprocess_obs`.  It now accepts `no_signal` which defaults to `None` and the `dets` and `meta` inputs not in `load_preprocess_obs` are now added.  The default config names were removed, though we could re-add them based on the value of `no_signal` perhaps.

Some additional files have also been moved into `site_pipeline/util.py`:

- `swap_archive`
- `get_preprocess_db` (edited to accept an optional logger as input, creates one if not given)