### PR TITLE
coords.pmat: fix tiling .from_map behavior

### DIFF
--- a/sotodlib/coords/pmat.py
+++ b/sotodlib/coords/pmat.py
@@ -648,18 +648,6 @@ class P:
                     map = enmap.ndmap(map, uf_info['wcs'])
         return map
 
-    def _get_hp_tile_list(self, tiled_arr=None):
-        """For healpix maps, get len(nTile) bool array of whether tiles are active. None if un-tiled.
-        If tiled_arr is not None, get tiling from there. Else get from self.geom"""
-        if isinstance(tiled_arr, list): # Assume we are tiled iff tiled_arr is a list instead of ndarr
-            tile_list = hp_utils.get_active_tile_list(tiled_arr)
-        elif self.tiled:
-            tile_list = np.zeros(12*self.geom.nside_tile**2, dtype='bool')
-            tile_list[self.active_tiles] = True # The tiling must be initiated already
-        else:
-            tile_list = None # Un-tiled
-        return tile_list
-
 
 class P_PrecompDebug:
     def __init__(self, geom, pixels, phases):

--- a/tests/test_pmat.py
+++ b/tests/test_pmat.py
@@ -69,6 +69,10 @@ def run_test(obs, geom, comps, wcs_kernel, is_healpix, is_tiled):
     tod2 = pmat.from_map(remove_weights)
     assert np.all(np.abs(tod - tod2) < TOL)
 
+    # And also zeros.
+    pmat = coords.pmat.P.for_tod(obs, comps=comps, geom=geom, wcs_kernel=wcs_kernel)
+    pmat.zeros()
+
     if is_tiled:
         if is_healpix:
             remove_weights = hp_utils.tiled_to_full(remove_weights)

--- a/tests/test_pmat.py
+++ b/tests/test_pmat.py
@@ -24,8 +24,8 @@ class PmatTest(unittest.TestCase):
         comps = 'T'
         out = run_test(obs, (shape, wcs), comps, None, False, False) # Basic
         _ = run_test(obs, None, comps, wcs, False, False) # Use wcs_kernel
-        #out2 = run_test(obs, tilemap.geometry(shape, wcs, tile_shape=(100, 100)), comps, None, False, True) # Tiled
-        #assert np.array_equal(out, out2)
+        out2 = run_test(obs, tilemap.geometry(shape, wcs, tile_shape=(100, 100)), comps, None, False, True) # Tiled
+        assert np.array_equal(out, out2)
 
     def test_pmat_healpix(self):
         obs = quick_tod(10, 10000)

--- a/tests/test_pmat.py
+++ b/tests/test_pmat.py
@@ -57,6 +57,18 @@ def run_test(obs, geom, comps, wcs_kernel, is_healpix, is_tiled):
     tod = pmat.from_map(remove_weights)
     TOL = 1e-9
     assert np.all(np.abs(tod-obs.signal) < TOL)
+
+    # Confirm we can do map-space ops without a pointing op first
+    pmat = coords.pmat.P.for_tod(obs, comps=comps, geom=geom, wcs_kernel=wcs_kernel)
+    _ = pmat.to_inverse_weights(weights)
+    pmat = coords.pmat.P.for_tod(obs, comps=comps, geom=geom, wcs_kernel=wcs_kernel)
+    _ = pmat.remove_weights(weights)
+
+    # Confirm from_map works on uninitialized pmat
+    pmat = coords.pmat.P.for_tod(obs, comps=comps, geom=geom, wcs_kernel=wcs_kernel)
+    tod2 = pmat.from_map(remove_weights)
+    assert np.all(np.abs(tod - tod2) < TOL)
+
     if is_tiled:
         if is_healpix:
             remove_weights = hp_utils.tiled_to_full(remove_weights)


### PR DESCRIPTION
Re-enable the test for rectpix tiled case.  This required a lot of custom checking for the rectpix+tiled case... and when combined with the healpix checking, this was hard to read.  So I've also abstracted that away using the notion of "flatten" and "unflatten" for maps.  This affects healpix and rectpix.