### PR TITLE
Load wafer list / freqs from obsdb

### DIFF
--- a/sotodlib/mapmaking/obs_grouping.py
+++ b/sotodlib/mapmaking/obs_grouping.py
@@ -216,14 +216,14 @@ def build_period_obslists(obs_info, periods, context, nset=None,
         if wafer is not None:
             wafer_list = [wafer]
         else:
-            meta = context.get_meta(row.obs_id)
-            wafer_list = np.unique(meta.det_info.wafer_slot)
+            wafer_list = row.wafer_slots_list.split(',')
         if freq is not None:
             band_list = [freq]
         else:
-            if 'meta' not in locals(): meta = context.get_meta(row.obs_id)
-            band_list = np.unique(meta.det_info.wafer.bandpass)
-            band_list = np.delete(band_list,np.where(band_list=='NC'))
+            if row.tube_flavor == 'mf':
+                band_list = ['f090', 'f150']
+            elif row.tube_flavor == 'uhf':
+                band_list = ['f230', 'f280']
         for detset in wafer_list[:nset]:
             for band in band_list:
                 key = (pids[i], detset, band)

--- a/sotodlib/mapmaking/obs_grouping.py
+++ b/sotodlib/mapmaking/obs_grouping.py
@@ -224,6 +224,8 @@ def build_period_obslists(obs_info, periods, context, nset=None,
                 band_list = ['f090', 'f150']
             elif row.tube_flavor == 'uhf':
                 band_list = ['f230', 'f280']
+            elif row.tube_flavor == 'lf':
+                raise ValueError('Band list for lf not implemented yet.')
         for detset in wafer_list[:nset]:
             for band in band_list:
                 key = (pids[i], detset, band)


### PR DESCRIPTION
Addressing #1011, we use the obsdb to get the wafer list. The freq list is hard coded (if mf we do f090, f150, etc.) We need to complete this for uhf and lf in the future.