### PR TITLE
Add lowpass filter to PCA Relcal

### DIFF
--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -1143,7 +1143,7 @@ class PCARelCal(_Preprocess):
             if self.calc_cfgs.get("pca") is None:
                 result_aman = tod_ops.pca.pca_cuts_and_cal(band_aman, pca_signal)
             else:
-                result_aman = tod_ops.pca.pca_cuts_and_cal(band_aman, pca_signal, self.calc_cfgs.get("pca"))
+                result_aman = tod_ops.pca.pca_cuts_and_cal(band_aman, pca_signal, **self.calc_cfgs.get("pca"))
 
             pca_det_mask[m0] = np.logical_or(pca_det_mask[m0], result_aman['pca_det_mask'])
             relcal[m0] = result_aman['relcal']


### PR DESCRIPTION
This branch adds an optional lowpass filter to the `PCARelCal `stage of the pipeline.  Previously, the lowpass was run as a separate filter stage before `PCARelCal` which results in a copy of timestreams being saved.  Now, the filtering occurs in the PCA `calc_and_save` function and is only temporarily stored.  The `lpf` configs, as well as the number of samples to trim, can be added to the `PCARelCal` config step.