### PR TITLE
fix mismatching samples

### DIFF
--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -686,10 +686,10 @@ class Demodulate(_Preprocess):
         hwp.demod_tod(aman, **self.process_cfgs["demod_cfgs"])
         if self.process_cfgs.get("trim_samps"):
             trim = self.process_cfgs["trim_samps"]
-            aman.restrict('samps', (aman.samps.offset + trim,
-                                    aman.samps.offset + aman.samps.count - trim))
             proc_aman.restrict('samps', (aman.samps.offset + trim,
                                          aman.samps.offset + aman.samps.count - trim))
+            aman.restrict('samps', (aman.samps.offset + trim,
+                                    aman.samps.offset + aman.samps.count - trim))
 
 
 class EstimateAzSS(_Preprocess):


### PR DESCRIPTION
This branch should address the comment made in #1050 where the number of samples between original axis manager and the processed axis manager are not the same.  The difference occurred because the original axis manager was trimmed during demodulation and the processed axis manager was then trimmed based on the already trimmed axis manager, resulting in even fewer samples.