### PR TITLE
Gp/feat/aman arbitrary path

### DIFF
--- a/docs/axisman.rst
+++ b/docs/axisman.rst
@@ -144,25 +144,16 @@ The output of the ``wrap`` cal should be::
 Note the boresight entry is marked with a ``*``, indicating that it's
 an AxisManager rather than a numpy array.
 
-Data access under an AxisManager is done based on field names. For example:
-    >>> n, ofs = 1000, 0
-    >>> dets = ["det0", "det1", "det2"]
-    >>> aman = core.AxisManager(core.LabelAxis("dets", dets), core.OffsetAxis("samps", n, ofs))
-    >>> child = core.AxisManager(core.LabelAxis("dets", dets + ["det3"]),core.OffsetAxis("samps", n, ofs - n // 2),)
-    >>> aman.wrap("child", child)
-    >>> print(aman.child.dets)
-    LabelAxis(3:'det0','det1','det2')
+Data access under an AxisManager is done based on field names. For example::
+
+    >>> print(dset.boresight.az)
+    [0. 0. 0. ... 0. 0. 0.]
 
 Advanced data access is possible by a path like syntax. This is especially useful when
-data access is dynamic and the field name is not known in advance. For example:
+data access is dynamic and the field name is not known in advance. For example::
 
-    >>> n, ofs = 1000, 0
-    >>> dets = ["det0", "det1", "det2"]
-    >>> aman = core.AxisManager(core.LabelAxis("dets", dets), core.OffsetAxis("samps", n, ofs))
-    >>> child = core.AxisManager(core.LabelAxis("dets", dets + ["det3"]),core.OffsetAxis("samps", n, ofs - n // 2),)
-    >>> aman.wrap("child", child)
-    >>> print(aman["child.dets"])
-    LabelAxis(3:'det0','det1','det2')
+    >>> print(dset["boresight.az"])
+    [0. 0. 0. ... 0. 0. 0.]
 
 To slice this object, use the restrict() method.  First, let's
 restrict in the 'dets' axis.  Since it's an Axis of type LabelAxis,

--- a/docs/axisman.rst
+++ b/docs/axisman.rst
@@ -144,8 +144,17 @@ The output of the ``wrap`` cal should be::
 Note the boresight entry is marked with a ``*``, indicating that it's
 an AxisManager rather than a numpy array.
 
-To access data in an AxisManager, use a path-like syntax where 
-attribute names are separated by dots::
+Data access under an AxisManager is done based on field names. For example:
+    >>> n, ofs = 1000, 0
+    >>> dets = ["det0", "det1", "det2"]
+    >>> aman = core.AxisManager(core.LabelAxis("dets", dets), core.OffsetAxis("samps", n, ofs))
+    >>> child = core.AxisManager(core.LabelAxis("dets", dets + ["det3"]),core.OffsetAxis("samps", n, ofs - n // 2),)
+    >>> aman.wrap("child", child)
+    >>> print(aman.child.dets)
+    LabelAxis(3:'det0','det1','det2')
+
+Advanced data access is possible by a path like syntax. This is especially useful when
+data access is dynamic and the field name is not known in advance. For example:
 
     >>> n, ofs = 1000, 0
     >>> dets = ["det0", "det1", "det2"]

--- a/docs/axisman.rst
+++ b/docs/axisman.rst
@@ -144,6 +144,17 @@ The output of the ``wrap`` cal should be::
 Note the boresight entry is marked with a ``*``, indicating that it's
 an AxisManager rather than a numpy array.
 
+To access data in an AxisManager, use a path-like syntax where 
+attribute names are separated by dots::
+
+    >>> n, ofs = 1000, 0
+    >>> dets = ["det0", "det1", "det2"]
+    >>> aman = core.AxisManager(core.LabelAxis("dets", dets), core.OffsetAxis("samps", n, ofs))
+    >>> child = core.AxisManager(core.LabelAxis("dets", dets + ["det3"]),core.OffsetAxis("samps", n, ofs - n // 2),)
+    >>> aman.wrap("child", child)
+    >>> print(aman["child.dets"])
+    LabelAxis(3:'det0','det1','det2')
+
 To slice this object, use the restrict() method.  First, let's
 restrict in the 'dets' axis.  Since it's an Axis of type LabelAxis,
 the restriction selector must be a list of strings::

--- a/sotodlib/core/axisman.py
+++ b/sotodlib/core/axisman.py
@@ -374,17 +374,15 @@ class AxisManager:
                 raise KeyError(attr_name)
         return tmp_item
 
-    def __setitem__(self, name, val):
+    def __setitem__(self, name:str, val: "AxisManager"):
 
+        if not isinstance(val, AxisManager):
+            raise ValueError("Only AxisManagers can be setting values")
         last_pos = name.rfind(".")
-        val_key = name[last_pos:]
+        val_key = name[last_pos + 1:]
         attrs = name[:last_pos]
         tmp_item = self[attrs]
-
-        if val_key in tmp_item._fields:
-            tmp_item._fields[name] = val
-        else:
-            raise KeyError(val_key)
+        tmp_item.wrap(name=val_key, data=val, overwrite=True)
 
     def __setattr__(self, name, value):
         # Assignment to members update those members

--- a/sotodlib/core/axisman.py
+++ b/sotodlib/core/axisman.py
@@ -394,10 +394,10 @@ class AxisManager:
             attrs = name[:last_pos]
             tmp_item = self[attrs]
 
-        if val_key in tmp_item._fields:
-            tmp_item._fields[val_key] = val
-        else:
-            raise KeyError(name)
+        if isinstance(val, AxisManager) and isinstance(tmp_item, AxisManager):
+            raise ValueError("Cannot assign AxisManager to AxisManager. Please use wrap method.")
+
+        tmp_item.__setattr__(val_key, val)
 
     def __setattr__(self, name, value):
         # Assignment to members update those members

--- a/sotodlib/core/axisman.py
+++ b/sotodlib/core/axisman.py
@@ -355,7 +355,17 @@ class AxisManager:
         self._axes[a.name] = a.copy()
 
     def __contains__(self, name):
-        return name in self._fields or name in self._axes
+        attrs = name.split(".")
+        tmp_item = self
+        while attrs:
+            attr_name = attrs.pop(0)
+            if attr_name in tmp_item._fields:
+                tmp_item = tmp_item._fields[attr_name]
+            elif attr_name in tmp_item._axes:
+                tmp_item = tmp_item._axes[attr_name]
+            else:
+                return False
+        return True
 
     def __getitem__(self, name):
 

--- a/sotodlib/core/axisman.py
+++ b/sotodlib/core/axisman.py
@@ -397,7 +397,10 @@ class AxisManager:
         if isinstance(val, AxisManager) and isinstance(tmp_item, AxisManager):
             raise ValueError("Cannot assign AxisManager to AxisManager. Please use wrap method.")
 
-        tmp_item.__setattr__(val_key, val)
+        if val_key in tmp_item._fields:
+            tmp_item._fields[val_key] = val
+        else:
+            raise KeyError(val_key)
 
     def __setattr__(self, name, value):
         # Assignment to members update those members

--- a/sotodlib/core/axisman.py
+++ b/sotodlib/core/axisman.py
@@ -374,15 +374,14 @@ class AxisManager:
                 raise KeyError(attr_name)
         return tmp_item
 
-    def __setitem__(self, name:str, val: "AxisManager"):
+    def __setitem__(self, name, val):
 
-        if not isinstance(val, AxisManager):
-            raise ValueError("Only AxisManagers can be setting values")
         last_pos = name.rfind(".")
         val_key = name[last_pos + 1:]
         attrs = name[:last_pos]
         tmp_item = self[attrs]
-        tmp_item.wrap(name=val_key, data=val, overwrite=True)
+        if val_key in tmp_item._fields:
+            tmp_item._fields[val_key] = val
 
     def __setattr__(self, name, value):
         # Assignment to members update those members

--- a/sotodlib/core/axisman.py
+++ b/sotodlib/core/axisman.py
@@ -377,11 +377,17 @@ class AxisManager:
     def __setitem__(self, name, val):
 
         last_pos = name.rfind(".")
-        val_key = name[last_pos + 1:]
-        attrs = name[:last_pos]
-        tmp_item = self[attrs]
+        val_key = name
+        tmp_item = self
+        if last_pos > -1:
+            val_key = name[last_pos + 1:]
+            attrs = name[:last_pos]
+            tmp_item = self[attrs]
+
         if val_key in tmp_item._fields:
             tmp_item._fields[val_key] = val
+        else:
+            raise KeyError(name)
 
     def __setattr__(self, name, value):
         # Assignment to members update those members

--- a/sotodlib/core/axisman_io.py
+++ b/sotodlib/core/axisman_io.py
@@ -65,7 +65,7 @@ def expand_RangesMatrix(flat_rm):
     if shape[0] == 0:
         return so3g.proj.RangesMatrix([], child_shape=shape[1:])
     # Otherwise non-trivial
-    count = np.product(shape[:-1])
+    count = np.prod(shape[:-1])
     start, stride = 0, count // shape[0]
     for i in range(0, len(ends), stride):
         _e = ends[i:i+stride] - start

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -66,7 +66,7 @@ class TestAxisManager(unittest.TestCase):
 
         # This should return a separate thing.
         rman = aman.restrict('samps', (10, 30), in_place=False)
-        #self.assertNotEqual(aman.a1[0], 0.)
+        # self.assertNotEqual(aman.a1[0], 0.)
         self.assertEqual(len(aman.a1), 100)
         self.assertEqual(len(rman.a1), 20)
         self.assertNotEqual(aman.a1[10], 0.)
@@ -190,23 +190,23 @@ class TestAxisManager(unittest.TestCase):
 
         # ... other_fields="exact"
         aman = core.AxisManager.concatenate([amanA, amanB], axis='dets')
-        
+
         ## add scalars
         amanA.wrap("ans", 42)
         amanB.wrap("ans", 42)
         aman = core.AxisManager.concatenate([amanA, amanB], axis='dets')
-        
+
         # ... other_fields="exact"
         amanB.azimuth[:] = 2.
         with self.assertRaises(ValueError):
             aman = core.AxisManager.concatenate([amanA, amanB], axis='dets')
-        
+
         # ... other_fields="exact" and arrays of different shapes
         amanB.move("azimuth", None)
         amanB.wrap("azimuth", np.array([43,5,2,3]))
         with self.assertRaises(ValueError):
             aman = core.AxisManager.concatenate([amanA, amanB], axis='dets')
-        
+
         # ... other_fields="fail"
         amanB.move("azimuth",None)
         amanB.wrap_new('azimuth', shape=('samps',))[:] = 2.
@@ -298,6 +298,20 @@ class TestAxisManager(unittest.TestCase):
         self.assertNotEqual(aman.a1[0, 0, 0, 1], 0.)
 
     # wrap of AxisManager, merge.
+
+    def test_get_set(self):
+        dets = ["det0", "det1", "det2"]
+        n, ofs = 1000, 0
+        aman = core.AxisManager(
+            core.LabelAxis("dets", dets), core.OffsetAxis("samps", n, ofs)
+        )
+        child = core.AxisManager(
+            core.LabelAxis("dets", dets + ["det3"]),
+            core.OffsetAxis("samps", n, ofs - n // 2),
+        )
+        aman.wrap("child", child)
+        self.assertAlmostEqual(aman["child.dets"].count, 3)
+        self.assertAlmostEqual(aman["child.dets"].name, "dets")
 
     def test_400_child(self):
         dets = ['det0', 'det1', 'det2']

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,9 +1,7 @@
 import unittest
 import tempfile
 import os
-import shutil
 
-from networkx import selfloop_edges
 import numpy as np
 import astropy.units as u
 from sotodlib import core
@@ -270,6 +268,64 @@ class TestAxisManager(unittest.TestCase):
         self.assertNotEqual(aman.a1[2,11], 0)
         self.assertNotEqual(aman.a1[1,10], 1.)
 
+    def test_190_get_set(self):
+        dets = ["det0", "det1", "det2"]
+        n, ofs = 1000, 0
+        aman = core.AxisManager(
+            core.LabelAxis("dets", dets), core.OffsetAxis("samps", n, ofs)
+        )
+        child = core.AxisManager(
+            core.LabelAxis("dets", dets + ["det3"]),
+            core.OffsetAxis("samps", n, ofs - n // 2),
+        )
+
+        child2 = core.AxisManager(
+            core.LabelAxis("dets2", ["det4", "det5"]),
+            core.OffsetAxis("samps", n, ofs - n // 2),
+        )
+        child2.wrap("tod", np.zeros((2, 1000)))
+        aman.wrap("child", child)
+        aman["child"].wrap("child2", child2)
+        self.assertEqual(aman["child.child2.dets2"].count, 2)
+        self.assertEqual(aman["child.dets"].name, "dets")
+        np.testing.assert_array_equal(
+            aman["child.child2.dets2"].vals, np.array(["det4", "det5"])
+        )
+        self.assertEqual(aman["child.child2.samps"].count, n // 2)
+        self.assertEqual(aman["child.child2.samps"].offset, 0)
+        self.assertEqual(
+            aman["child.child2.samps"].count, aman.child.child2.samps.count
+        )
+        self.assertEqual(
+            aman["child.child2.samps"].offset, aman.child.child2.samps.offset
+        )
+
+        np.testing.assert_array_equal(aman["child.child2.tod"], np.zeros((2, 1000)))
+
+        with self.assertRaises(KeyError):
+            aman["child2"]
+
+        with self.assertRaises(AttributeError):
+            aman["child.dets.an_extra_layer"]
+
+        self.assertIn("child.dets", aman)
+        self.assertIn("child.dets2", aman)  # I am not sure why this is true
+        self.assertNotIn("child.child2.someentry", aman)
+        self.assertNotIn("child.child2.someentry.someotherentry", aman)
+
+        with self.assertRaises(ValueError):
+            aman["child"] = child2
+
+        new_tods = np.ones((2, 500))
+        aman.child.child2.tod = new_tods
+        np.testing.assert_array_equal(aman["child.child2.tod"], np.ones((2, 500)))
+        np.testing.assert_array_equal(aman.child.child2.tod, np.ones((2, 500)))
+
+        new_tods = np.ones((2, 1500))
+        aman["child.child2.tod"] = new_tods
+        np.testing.assert_array_equal(aman["child.child2.tod"], np.ones((2, 1500)))
+        np.testing.assert_array_equal(aman.child.child2.tod, np.ones((2, 1500)))
+
     # Multi-dimensional restrictions.
 
     def test_200_multid(self):
@@ -299,56 +355,6 @@ class TestAxisManager(unittest.TestCase):
         self.assertNotEqual(aman.a1[0, 0, 0, 1], 0.)
 
     # wrap of AxisManager, merge.
-    def test_get_set(self):
-        dets = ["det0", "det1", "det2"]
-        n, ofs = 1000, 0
-        aman = core.AxisManager(
-            core.LabelAxis("dets", dets), core.OffsetAxis("samps", n, ofs)
-        )
-        child = core.AxisManager(
-            core.LabelAxis("dets", dets + ["det3"]),
-            core.OffsetAxis("samps", n, ofs - n // 2),
-        )
-
-        child2 = core.AxisManager(
-            core.LabelAxis("dets2", ["det4", "det5"]),
-            core.OffsetAxis("samps", n, ofs - n // 2),
-        )
-        child2.wrap("tod", np.zeros((2,1000)))
-        aman.wrap("child", child)
-        aman["child"].wrap("child2", child2)
-        self.assertEqual(aman["child.child2.dets2"].count, 2)
-        self.assertEqual(aman["child.dets"].name, "dets")
-        np.testing.assert_array_equal(aman["child.child2.dets2"].vals, np.array(["det4", "det5"]))
-        self.assertEqual(aman["child.child2.samps"].count, n // 2)
-        self.assertEqual(aman["child.child2.samps"].offset, 0)
-        self.assertEqual(aman["child.child2.samps"].count, aman.child.child2.samps.count)
-        self.assertEqual(aman["child.child2.samps"].offset, aman.child.child2.samps.offset)
-
-        np.testing.assert_array_equal(aman["child.child2.tod"], np.zeros((2,1000)))
-        
-        with self.assertRaises(KeyError):
-            aman["child2"]
-
-        with self.assertRaises(AttributeError):
-            aman["child.dets.an_extra_layer"]
-
-        self.assertIn("child.dets", aman)
-        self.assertIn("child.dets2", aman) # I am not sure why this is true
-        self.assertNotIn("child.child2.someentry", aman)
-
-        with self.assertRaises(ValueError):
-            aman["child"] = child2
-
-        new_tods = np.ones((2, 500))
-        aman.child.child2.tod = new_tods
-        np.testing.assert_array_equal(aman["child.child2.tod"], np.ones((2, 500)))
-        np.testing.assert_array_equal(aman.child.child2.tod, np.ones((2, 500)))
-        
-        new_tods = np.ones((2, 1500))
-        aman["child.child2.tod"] = new_tods
-        np.testing.assert_array_equal(aman["child.child2.tod"], np.ones((2, 1500)))
-        np.testing.assert_array_equal(aman.child.child2.tod, np.ones((2, 1500)))
 
     def test_400_child(self):
         dets = ['det0', 'det1', 'det2']

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -298,7 +298,6 @@ class TestAxisManager(unittest.TestCase):
         self.assertNotEqual(aman.a1[0, 0, 0, 1], 0.)
 
     # wrap of AxisManager, merge.
-
     def test_get_set(self):
         dets = ["det0", "det1", "det2"]
         n, ofs = 1000, 0
@@ -309,9 +308,34 @@ class TestAxisManager(unittest.TestCase):
             core.LabelAxis("dets", dets + ["det3"]),
             core.OffsetAxis("samps", n, ofs - n // 2),
         )
+
+        child2 = core.AxisManager(
+            core.LabelAxis("dets2", ["det4", "det5"]),
+            core.OffsetAxis("samps", n, ofs - n // 2),
+        )
         aman.wrap("child", child)
-        self.assertAlmostEqual(aman["child.dets"].count, 3)
-        self.assertAlmostEqual(aman["child.dets"].name, "dets")
+        aman["child"].wrap("child2", child2)
+        self.assertEqual(aman["child.child2.dets2"].count, 2)
+        self.assertEqual(aman["child.dets"].name, "dets")
+        np.testing.assert_array_equal(aman["child.child2.dets2"].vals, np.array(["det4", "det5"]))
+        with self.assertRaises(KeyError):
+            aman["child.someentry"]
+
+        with self.assertRaises(KeyError):
+            aman["child2"]
+
+        with self.assertRaises(AttributeError):
+            aman["child.dets.an_extra_layer"]
+
+        self.assertIn("child.dets", aman)
+        self.assertIn("child.dets2", aman) # I am not sure why this is true
+        self.assertNotIn("child.child2.someentry", aman)
+
+        aman["child"] = child2
+        print(aman["child"])
+        self.assertEqual(aman["child.dets2"].count, 2)
+        self.assertEqual(aman["child.dets2"].name, "dets2")
+        np.testing.assert_array_equal(aman["child.dets2"].vals, np.array(["det4", "det5"]))
 
     def test_400_child(self):
         dets = ['det0', 'det1', 'det2']

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3,6 +3,7 @@ import tempfile
 import os
 import shutil
 
+from networkx import selfloop_edges
 import numpy as np
 import astropy.units as u
 from sotodlib import core
@@ -313,14 +314,19 @@ class TestAxisManager(unittest.TestCase):
             core.LabelAxis("dets2", ["det4", "det5"]),
             core.OffsetAxis("samps", n, ofs - n // 2),
         )
+        child2.wrap("tod", np.zeros((2,1000)))
         aman.wrap("child", child)
         aman["child"].wrap("child2", child2)
         self.assertEqual(aman["child.child2.dets2"].count, 2)
         self.assertEqual(aman["child.dets"].name, "dets")
         np.testing.assert_array_equal(aman["child.child2.dets2"].vals, np.array(["det4", "det5"]))
-        with self.assertRaises(KeyError):
-            aman["child.someentry"]
+        self.assertEqual(aman["child.child2.samps"].count, n // 2)
+        self.assertEqual(aman["child.child2.samps"].offset, 0)
+        self.assertEqual(aman["child.child2.samps"].count, aman.child.child2.samps.count)
+        self.assertEqual(aman["child.child2.samps"].offset, aman.child.child2.samps.offset)
 
+        np.testing.assert_array_equal(aman["child.child2.tod"], np.zeros((2,1000)))
+        
         with self.assertRaises(KeyError):
             aman["child2"]
 
@@ -331,11 +337,18 @@ class TestAxisManager(unittest.TestCase):
         self.assertIn("child.dets2", aman) # I am not sure why this is true
         self.assertNotIn("child.child2.someentry", aman)
 
-        aman["child"] = child2
-        print(aman["child"])
-        self.assertEqual(aman["child.dets2"].count, 2)
-        self.assertEqual(aman["child.dets2"].name, "dets2")
-        np.testing.assert_array_equal(aman["child.dets2"].vals, np.array(["det4", "det5"]))
+        with self.assertRaises(ValueError):
+            aman["child"] = child2
+
+        new_tods = np.ones((2, 500))
+        aman.child.child2.tod = new_tods
+        np.testing.assert_array_equal(aman["child.child2.tod"], np.ones((2, 500)))
+        np.testing.assert_array_equal(aman.child.child2.tod, np.ones((2, 500)))
+        
+        new_tods = np.ones((2, 1500))
+        aman["child.child2.tod"] = new_tods
+        np.testing.assert_array_equal(aman["child.child2.tod"], np.ones((2, 1500)))
+        np.testing.assert_array_equal(aman.child.child2.tod, np.ones((2, 1500)))
 
     def test_400_child(self):
         dets = ['det0', 'det1', 'det2']


### PR DESCRIPTION
This PR updates AxisManager `__getitem__` and `__setitem__` based on the slack discussion.

`__setitem__` raises an ValueError when the value is not another AxisManager and uses wrap to add it to the main object. I selected wrap because it seemed more complete compared to merge.
