### PR TITLE
Putting the mapmaker in the same split convention as the preprocessing

### DIFF
--- a/sotodlib/mapmaking/demod_mapmaker.py
+++ b/sotodlib/mapmaking/demod_mapmaker.py
@@ -291,10 +291,9 @@ class DemodSignalMap(DemodSignal):
                 else: rot = None
                 if self.Nsplits == 1:
                     # this is the case with no splits
-                    flagnames = ['glitch_flags']
+                    cuts = obs.glitch_flags
                 else:
-                    flagnames = ['glitch_flags', split_labels[n_split]]
-                cuts = get_flags(obs, flagnames)
+                    cuts = obs.glitch_flags + obs.preprocess.split_flags.cuts[split_labels[n_split]]
                 if self.pix_scheme == "rectpix":
                     threads='domdir'
                     geom = self.rhs.geometry

--- a/sotodlib/mapmaking/demod_mapmaker.py
+++ b/sotodlib/mapmaking/demod_mapmaker.py
@@ -13,7 +13,7 @@ import so3g.proj
 from .. import core
 from .. import coords
 from .utilities import recentering_to_quat_lonlat, evaluate_recentering, MultiZipper, unarr, safe_invert_div
-from .utilities import import_optional, get_flags
+from .utilities import import_optional
 from .noise_model import NmatWhite
 
 hp = import_optional('healpy')

--- a/sotodlib/mapmaking/demod_mapmaker.py
+++ b/sotodlib/mapmaking/demod_mapmaker.py
@@ -291,9 +291,9 @@ class DemodSignalMap(DemodSignal):
                 else: rot = None
                 if self.Nsplits == 1:
                     # this is the case with no splits
-                    cuts = obs.glitch_flags
+                    cuts = obs.flags.glitch_flags
                 else:
-                    cuts = obs.glitch_flags + obs.preprocess.split_flags.cuts[split_labels[n_split]]
+                    cuts = obs.flags.glitch_flags + obs.preprocess.split_flags.cuts[split_labels[n_split]]
                 if self.pix_scheme == "rectpix":
                     threads='domdir'
                     geom = self.rhs.geometry

--- a/sotodlib/mapmaking/demod_mapmaker.py
+++ b/sotodlib/mapmaking/demod_mapmaker.py
@@ -293,7 +293,8 @@ class DemodSignalMap(DemodSignal):
                     # this is the case with no splits
                     cuts = obs.flags.glitch_flags
                 else:
-                    cuts = obs.flags.glitch_flags + obs.preprocess.split_flags.cuts[split_labels[n_split]]
+                    # remember that the dets or samples you want to keep should be false, hence we negate
+                    cuts = obs.flags.glitch_flags + ~obs.preprocess.split_flags.cuts[split_labels[n_split]]
                 if self.pix_scheme == "rectpix":
                     threads='domdir'
                     geom = self.rhs.geometry

--- a/sotodlib/mapmaking/utilities.py
+++ b/sotodlib/mapmaking/utilities.py
@@ -528,14 +528,35 @@ def downsample_obs(obs, down):
     return res
 
 def get_flags(obs, flagnames):
+    from sotodlib.core import FlagManager
+
     """Parse detector-set splits"""
     cuts_out = None
+    fm = FlagManager.for_tod(obs)
     if flagnames is None:
-        return so3g.proj.RangesMatrix.zeros(obs.shape)
+        return fm.get_zeros()
     det_splits = ['det_left','det_right','det_in','det_out','det_upper','det_lower']
     for flagname in flagnames:
         if flagname in det_splits:
-            cuts = obs.det_flags[flagname]
+            # Remember that the detectors you want to keep must be False here
+            if flagname == 'det_left':
+                fm.wrap_dets('det_left', obs.preprocess.split_flags.right_focal_plane_flag)
+                cuts = fm.det_left
+            elif flagname == 'det_right':
+                fm.wrap_dets('det_right', ~obs.preprocess.split_flags.right_focal_plane_flag)
+                cuts = fm.det_right
+            elif flagname == 'det_in':
+                fm.wrap_dets('det_in', ~obs.preprocess.split_flags.central_pixels_flag)
+                cuts = fm.det_in
+            elif flagname == 'det_out':
+                fm.wrap_dets('det_out', obs.preprocess.split_flags.central_pixels_flag)
+                cuts = fm.det_out
+            elif flagname == 'det_upper':
+                fm.wrap_dets('det_upper', ~obs.preprocess.split_flags.top_focal_plane_flag)
+                cuts = fm.det_upper
+            elif flagname == 'det_lower':
+                fm.wrap_dets('det_lower', obs.preprocess.split_flags.top_focal_plane_flag)
+                cuts = fm.det_lower
         elif flagname == 'scan_left':
             cuts = obs.flags.left_scan
         elif flagname == 'scan_right':

--- a/sotodlib/mapmaking/utilities.py
+++ b/sotodlib/mapmaking/utilities.py
@@ -527,50 +527,6 @@ def downsample_obs(obs, down):
     # doesn't matter anyway
     return res
 
-def get_flags(obs, flagnames):
-    from sotodlib.core import FlagManager
-
-    """Parse detector-set splits"""
-    cuts_out = None
-    fm = FlagManager.for_tod(obs)
-    if flagnames is None:
-        return fm.get_zeros()
-    det_splits = ['det_left','det_right','det_in','det_out','det_upper','det_lower']
-    for flagname in flagnames:
-        if flagname in det_splits:
-            # Remember that the detectors you want to keep must be False here
-            if flagname == 'det_left':
-                fm.wrap_dets('det_left', obs.preprocess.split_flags.right_focal_plane_flag)
-                cuts = fm.det_left
-            elif flagname == 'det_right':
-                fm.wrap_dets('det_right', ~obs.preprocess.split_flags.right_focal_plane_flag)
-                cuts = fm.det_right
-            elif flagname == 'det_in':
-                fm.wrap_dets('det_in', ~obs.preprocess.split_flags.central_pixels_flag)
-                cuts = fm.det_in
-            elif flagname == 'det_out':
-                fm.wrap_dets('det_out', obs.preprocess.split_flags.central_pixels_flag)
-                cuts = fm.det_out
-            elif flagname == 'det_upper':
-                fm.wrap_dets('det_upper', ~obs.preprocess.split_flags.top_focal_plane_flag)
-                cuts = fm.det_upper
-            elif flagname == 'det_lower':
-                fm.wrap_dets('det_lower', obs.preprocess.split_flags.top_focal_plane_flag)
-                cuts = fm.det_lower
-        elif flagname == 'scan_left':
-            cuts = obs.flags.left_scan
-        elif flagname == 'scan_right':
-            cuts = obs.flags.right_scan
-        else:
-            cuts = getattr(obs.flags, flagname) # obs.flags.flagname
-
-        ## Add to the output matrix
-        if cuts_out is None:
-            cuts_out = cuts
-        else:
-            cuts_out += cuts
-    return cuts_out
-
 def import_optional(module_name):
     try:
         module = importlib.import_module(module_name)

--- a/sotodlib/obs_ops/splits.py
+++ b/sotodlib/obs_ops/splits.py
@@ -82,6 +82,9 @@ def get_split_flags(aman, proc_aman=None, split_cfg=None):
     -------
     split_aman: AxisManager
         Axis manager containing splitting flags.
+        ``cuts`` field is a FlagManager containing the detector and subscan based splits used in the mapmaker.
+        ``<split_name>_threshold`` fields contain the threshold used for the split.
+        Other fields conatain info for obs-level splits.
     '''
     if proc_aman is None:
         try:
@@ -101,36 +104,59 @@ def get_split_flags(aman, proc_aman=None, split_cfg=None):
         split_cfg = default_cfg
 
     split_aman = AxisManager(aman.dets)
+    fm = FlagManager.for_tod(aman)
     # If provided split config doesn't include all of the splits in default
     for k in default_cfg.keys():
         if not k in split_cfg:
             split_cfg[k] = default_cfg[k]
         split_aman.wrap(f'{k}_threshold', split_cfg[k])
 
-    split_aman.wrap('high_gain_flag', aman.det_cal.phase_to_pW > split_cfg['high_gain'],
-                    [(0, 'dets')])
+    # Gain split
+    fm.wrap_dets('high_gain', aman.det_cal.phase_to_pW > split_cfg['high_gain'])
+    fm.wrap_dets('low_gain', aman.det_cal.phase_to_pW <= split_cfg['high_gain'])
     split_aman.wrap('gain_avg', np.nanmean(aman.det_cal.phase_to_pW))
-    split_aman.wrap('high_noise_flag', proc_aman.noiseQ_fit.fit[:,1] > split_cfg['high_noise'],
-                    [(0, 'dets')])
+    # Noise split
+    fm.wrap_dets('high_noise', proc_aman.noiseQ_fit.fit[:,1] > split_cfg['high_noise'])
+    fm.wrap_dets('low_noise', proc_aman.noiseQ_fit.fit[:,1] <= split_cfg['high_noise'])
     split_aman.wrap('noise_avg', np.nanmean(proc_aman.noiseQ_fit.fit[:,1]))
-    split_aman.wrap('high_tau_flag', aman.det_cal.tau_eff > split_cfg['high_tau'],
-                    [(0, 'dets')])
+    # Time constant split
+    fm.wrap_dets('high_tau', aman.det_cal.tau_eff > split_cfg['high_tau'])
+    fm.wrap_dets('low_tau', aman.det_cal.tau_eff <= split_cfg['high_tau'])
     split_aman.wrap('tau_avg', np.nanmean(aman.det_cal.tau_eff))
-    split_aman.wrap('det_A_flag', aman.det_info.wafer.pol <= split_cfg['det_A'],
-                    [(0, 'dets')])
-    split_aman.wrap('pol_angle_flag', aman.det_info.wafer.angle > split_cfg['pol_angle'],
-                    [(0, 'dets')])
-    split_aman.wrap('det_top_flag', aman.det_info.wafer.crossover > split_cfg['det_top'],
-                    [(0, 'dets')])
-    split_aman.wrap('high_leakage_flag', np.sqrt(proc_aman.t2p.lamQ**2 + proc_aman.t2p.lamU**2) > split_cfg['high_leakage'],
-                    [(0, 'dets')])
+    # detAB split
+    fm.wrap_dets('det_A', aman.det_info.wafer.pol <= split_cfg['det_A'])
+    fm.wrap_dets('det_B', aman.det_info.wafer.pol > split_cfg['det_A'])
+    # def pol split
+    fm.wrap_dets('high_pol_angle', aman.det_info.wafer.angle > split_cfg['pol_angle'])
+    fm.wrap_dets('low_pol_angle', aman.det_info.wafer.angle <= split_cfg['pol_angle'])
+    # det top/bottom split
+    fm.wrap_dets('det_type_top', aman.det_info.wafer.crossover > split_cfg['det_top'])
+    fm.wrap_dets('det_type_bottom', aman.det_info.wafer.crossover <= split_cfg['det_top'])
+    # T2P Leakage split
+    fm.wrap_dets('high_leakage', np.sqrt(proc_aman.t2p.lamQ**2 + proc_aman.t2p.lamU**2) > split_cfg['high_leakage'])
+    fm.wrap_dets('low_leakage', np.sqrt(proc_aman.t2p.lamQ**2 + proc_aman.t2p.lamU**2) <= split_cfg['high_leakage'])
     split_aman.wrap('leakage_avg', np.nanmean(np.sqrt(proc_aman.t2p.lamQ**2 + proc_aman.t2p.lamU**2)),
                     [(0, 'dets')])
+    # High 2f amplitude split
     a2 = aman.det_cal.phase_to_pW*np.sqrt(proc_aman.hwpss_stats.coeffs[:,2]**2 + proc_aman.hwpss_stats.coeffs[:,3]**2)
-    split_aman.wrap('high_2f_flag', a2 > split_cfg['high_2f'], [(0, 'dets')])
+    fm.wrap_dets('high_2f', a2 > split_cfg['high_2f'])
+    fm.wrap_dets('low_2f', a2 <= split_cfg['high_2f'])
     split_aman.wrap('2f_avg', np.nanmean(a2), [(0, 'dets')])
-    split_aman.wrap('right_focal_plane_flag', aman.focal_plane.xi > split_cfg['right_focal_plane'], [(0, 'dets')])
-    split_aman.wrap('top_focal_plane_flag', aman.focal_plane.eta > split_cfg['top_focal_plane'], [(0, 'dets')])
-    split_aman.wrap('central_pixels_flag', np.sqrt(aman.focal_plane.xi**2 + aman.focal_plane.eta**2) < split_cfg['central_pixels'],
-                    [(0, 'dets')])
+    # Right/left focal plane split
+    fm.wrap_dets('det_right', aman.focal_plane.xi > split_cfg['right_focal_plane'])
+    fm.wrap_dets('det_left', aman.focal_plane.xi <= split_cfg['right_focal_plane'])
+    # Top/bottom focal plane split
+    fm.wrap_dets('det_upper', aman.focal_plane.eta > split_cfg['top_focal_plane'])
+    fm.wrap_dets('det_lower', aman.focal_plane.eta <= split_cfg['top_focal_plane'])
+    # Inner/outter pixel split
+    r =  np.sqrt(aman.focal_plane.xi**2 + aman.focal_plane.eta**2)
+    fm.wrap_dets('det_in', r < split_cfg['central_pixels'])
+    fm.wrap_dets('det_out', r >= split_cfg['central_pixels'])
+    # Left/right subscans
+    if 'turnaround_flags' in proc_aman:
+        fm.wrap('scan_left', proc_aman.turnaround_flags.left_scan)
+        fm.wrap('scan_right', proc_aman.turnaround_flags.right_scan)
+
+    split_aman.wrap('cuts', fm)
+
     return split_aman

--- a/sotodlib/obs_ops/splits.py
+++ b/sotodlib/obs_ops/splits.py
@@ -64,8 +64,10 @@ def det_splits_relative(aman, det_left_right=False, det_upper_lower=False, det_i
 
 def get_split_flags(aman, proc_aman=None, split_cfg=None):
     '''
-    Function returning flags used for null splits consumed by the mapmaking and bundling codes.                             Fields labeled ``field_name_flag`` contain boolean masks and ``_avg`` are the mean
-    of the numerical based split flags to be used for observation level splits.
+    Function returning flags used for null splits consumed by the mapmaking
+    and bundling codes. Fields labeled ``field_name_flag`` contain boolean
+    masks and ``_avg`` are the mean of the numerical based split flags to 
+    be used for observation level splits.
 
     Arguments
     ---------

--- a/sotodlib/obs_ops/splits.py
+++ b/sotodlib/obs_ops/splits.py
@@ -86,20 +86,10 @@ def get_split_flags(aman, proc_aman=None, split_cfg=None):
         ``<split_name>_threshold`` fields contain the threshold used for the split.
         Other fields conatain info for obs-level splits.
     '''
-    if proc_aman is None:
-        try:
-            proc_aman = aman.preprocess
-        except:
-            raise ValueError('proc_aman is None and no preprocess field in aman provide valid preprocess metadata')
-
-    if (not 't2p' in proc_aman) | (not 'hwpss_stats' in proc_aman):
-        raise ValueError('t2p or hwpss_stats not in proc_aman must run after those steps in the pipeline.')
-
     # Set default set of splits
     default_cfg = {'high_gain': 0.115, 'high_noise': 3.5e-5, 'high_tau': 1.5e-3,
-                   'det_A': 'A', 'pol_angle': 35, 'det_top': 'B', 'high_leakage': 1e-3,
-                   'high_2f': 1.5e-3, 'right_focal_plane': 0, 'top_focal_plane': 0,
-                   'central_pixels': 0.071 }
+                   'det_A': 'A', 'pol_angle': 35, 'det_top': 'B', 'right_focal_plane': 0,
+                   'top_focal_plane': 0, 'central_pixels': 0.071 }
     if split_cfg is None:
         split_cfg = default_cfg
 
@@ -109,7 +99,6 @@ def get_split_flags(aman, proc_aman=None, split_cfg=None):
     for k in default_cfg.keys():
         if not k in split_cfg:
             split_cfg[k] = default_cfg[k]
-        split_aman.wrap(f'{k}_threshold', split_cfg[k])
 
     # Gain split
     fm.wrap_dets('high_gain', aman.det_cal.phase_to_pW > split_cfg['high_gain'])
@@ -132,16 +121,6 @@ def get_split_flags(aman, proc_aman=None, split_cfg=None):
     # det top/bottom split
     fm.wrap_dets('det_type_top', aman.det_info.wafer.crossover > split_cfg['det_top'])
     fm.wrap_dets('det_type_bottom', aman.det_info.wafer.crossover <= split_cfg['det_top'])
-    # T2P Leakage split
-    fm.wrap_dets('high_leakage', np.sqrt(proc_aman.t2p.lamQ**2 + proc_aman.t2p.lamU**2) > split_cfg['high_leakage'])
-    fm.wrap_dets('low_leakage', np.sqrt(proc_aman.t2p.lamQ**2 + proc_aman.t2p.lamU**2) <= split_cfg['high_leakage'])
-    split_aman.wrap('leakage_avg', np.nanmean(np.sqrt(proc_aman.t2p.lamQ**2 + proc_aman.t2p.lamU**2)),
-                    [(0, 'dets')])
-    # High 2f amplitude split
-    a2 = aman.det_cal.phase_to_pW*np.sqrt(proc_aman.hwpss_stats.coeffs[:,2]**2 + proc_aman.hwpss_stats.coeffs[:,3]**2)
-    fm.wrap_dets('high_2f', a2 > split_cfg['high_2f'])
-    fm.wrap_dets('low_2f', a2 <= split_cfg['high_2f'])
-    split_aman.wrap('2f_avg', np.nanmean(a2), [(0, 'dets')])
     # Right/left focal plane split
     fm.wrap_dets('det_right', aman.focal_plane.xi > split_cfg['right_focal_plane'])
     fm.wrap_dets('det_left', aman.focal_plane.xi <= split_cfg['right_focal_plane'])
@@ -152,10 +131,41 @@ def get_split_flags(aman, proc_aman=None, split_cfg=None):
     r =  np.sqrt(aman.focal_plane.xi**2 + aman.focal_plane.eta**2)
     fm.wrap_dets('det_in', r < split_cfg['central_pixels'])
     fm.wrap_dets('det_out', r >= split_cfg['central_pixels'])
+
+    # Preproc dependent splits
+    if proc_aman is None:
+        try:
+            proc_aman = aman.preprocess
+        except:
+            print('Preprocess information not present, cannot generate preprocess dependent splits.')
+            for k in split_cfg.keys():
+                split_aman.wrap(f'{k}_threshold', split_cfg[k])
+            split_aman.wrap('cuts', fm)
+            return split_aman
+
+    if 't2p' in proc_aman:
+        # T2P Leakage split
+        if not 'high_leakage' in split_cfg:
+            split_cfg['high_leakage'] = 1e-3
+        fm.wrap_dets('high_leakage', np.sqrt(proc_aman.t2p.lamQ**2 + proc_aman.t2p.lamU**2) > split_cfg['high_leakage'])
+        fm.wrap_dets('low_leakage', np.sqrt(proc_aman.t2p.lamQ**2 + proc_aman.t2p.lamU**2) <= split_cfg['high_leakage'])
+        split_aman.wrap('leakage_avg', np.nanmean(np.sqrt(proc_aman.t2p.lamQ**2 + proc_aman.t2p.lamU**2)),
+                    [(0, 'dets')])
+    if 'hwpss_stats' in proc_aman:
+        # High 2f amplitude split
+        if not 'high_2f' in split_cfg:
+            split_cfg['high_2f'] = 1.5e-3
+        a2 = aman.det_cal.phase_to_pW*np.sqrt(proc_aman.hwpss_stats.coeffs[:,2]**2 + proc_aman.hwpss_stats.coeffs[:,3]**2)
+        fm.wrap_dets('high_2f', a2 > split_cfg['high_2f'])
+        fm.wrap_dets('low_2f', a2 <= split_cfg['high_2f'])
+        split_aman.wrap('2f_avg', np.nanmean(a2), [(0, 'dets')])
     # Left/right subscans
     if 'turnaround_flags' in proc_aman:
         fm.wrap('scan_left', proc_aman.turnaround_flags.left_scan)
         fm.wrap('scan_right', proc_aman.turnaround_flags.right_scan)
+
+    for k in split_cfg.keys():
+        split_aman.wrap(f'{k}_threshold', split_cfg[k])
 
     split_aman.wrap('cuts', fm)
 

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -1450,7 +1450,7 @@ class SplitFlags(_Preprocess):
     name = "split_flags"
 
     def calc_and_save(self, aman, proc_aman):
-        split_flg_aman = obs_ops.flags.get_split_flags(aman, proc_aman, split_cfg=self.calc_cfgs)
+        split_flg_aman = obs_ops.splits.get_split_flags(aman, proc_aman, split_cfg=self.calc_cfgs)
 
         self.save(proc_aman, split_flg_aman)
 

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -1214,8 +1214,6 @@ class PCARelCal(_Preprocess):
 
             if self.calc_cfgs.get("trim_samps") is not None:
                 trim = self.calc_cfgs["trim_samps"]
-                aman.restrict('samps', (aman.samps.offset + trim,
-                                        aman.samps.offset + aman.samps.count - trim))
                 proc_aman.restrict('samps', (proc_aman.samps.offset + trim,
                                              proc_aman.samps.offset + proc_aman.samps.count - trim))
                 filt_aman.restrict('samps', (filt_aman.samps.offset + trim,
@@ -1225,7 +1223,8 @@ class PCARelCal(_Preprocess):
 
         bands = np.unique(aman.det_info.wafer.bandpass)
         bands = bands[bands != 'NC']
-        rc_aman = core.AxisManager(aman.dets, aman.samps)
+        # align samps w/ proc_aman to include samps restriction when loading back from db.
+        rc_aman = core.AxisManager(proc_aman.dets, proc_aman.samps)
         pca_det_mask = np.full(aman.dets.count, False, dtype=bool)
         relcal = np.zeros(aman.dets.count)
         pca_weight0 = np.zeros(aman.dets.count)


### PR DESCRIPTION
This changes how the mapmaker handles the focal plane splits, so that they follow the same convention as preprocessing.
Also fixes a minor bug in preprocess.