### PR TITLE
load_book: don't over-optimize getting the file list

### DIFF
--- a/sotodlib/core/metadata/obsfiledb.py
+++ b/sotodlib/core/metadata/obsfiledb.py
@@ -278,13 +278,16 @@ class ObsFileDb:
             prefix = self.prefix
 
         if detsets is None:
-            detsets = self.get_detsets(obs_id)
-
-        c = self.conn.execute('select detset, name, sample_start, sample_stop '
-                              'from files where obs_id=? and detset in (%s) '
-                              'order by detset, sample_start' %
-                              ','.join(['?' for _ in detsets]),
-                              (obs_id,) + tuple(detsets))
+            c = self.conn.execute('select detset, name, sample_start, sample_stop '
+                                  'from files where obs_id=? '
+                                  'order by detset, sample_start',
+                                  (obs_id,))
+        else:
+            c = self.conn.execute('select detset, name, sample_start, sample_stop '
+                                  'from files where obs_id=? and detset in (%s) '
+                                  'order by detset, sample_start' %
+                                  ','.join(['?' for _ in detsets]),
+                                  (obs_id,) + tuple(detsets))
         output = OrderedDict()
         for r in c:
             if not r[0] in output:

--- a/sotodlib/io/load_book.py
+++ b/sotodlib/io/load_book.py
@@ -111,7 +111,9 @@ def load_obs_book(db, obs_id, dets=None, prefix=None, samples=None,
         dets_req.extend([p[1] for p in pairs_req if p[0] == _ds])
     del pairs_req
 
-    file_map = db.get_files(obs_id, detsets=detsets_req)
+    # Don't pass a restriction of detsets here, as we need at least
+    # one result for some downstream processing.
+    file_map = db.get_files(obs_id)
     one_group = list(file_map.values())[0]  # [('file0', 0, 1000), ('file1', 1000, 2000), ...]
     
     # Figure out how many samples we're loading.


### PR DESCRIPTION
Although it's usually an error load dets=[], make-hwp-solution does that, using a basic context. This re-enables that support by optimizing obsfiledb.get_files.