### PR TITLE
Source flags update

### DIFF
--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -1072,10 +1072,14 @@ class SourceFlags(_Preprocess):
         if self.select_cfgs is None:
             return meta
         if proc_aman is None:
-            proc_aman = meta.preprocess
-        for field in proc_aman.source_flags._fields:
-            keep = ~has_any_cuts(proc_aman.source_flags[field])
-        meta.restrict("dets", meta.dets.vals[keep])
+            source_flags = meta.preprocess.source_flags
+        else:
+            source_flags = proc_aman.source_flags
+
+        for field in source_flags._fields:
+            keep = ~has_any_cuts(source_flags[field])
+            meta.restrict("dets", meta.dets.vals[keep])
+            source_flags.restrict("dets", source_flags.dets.vals[keep])
         return meta
 
 class HWPAngleModel(_Preprocess):

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -1072,8 +1072,8 @@ class SourceFlags(_Preprocess):
         # add sources that were not nearby from source list
         for source in source_list:
             if source not in source_aman._fields:
-                source_flags = RangesMatrix.zeros([aman.dets.count, aman.samps.count])
-                source_aman.wrap(source, source_flags, [(0, 'dets'), (1, 'samps')])
+                source_aman.wrap(source, RangesMatrix.zeros([aman.dets.count, aman.samps.count]),
+                                 [(0, 'dets'), (1, 'samps')])
 
         self.save(proc_aman, source_aman)
 

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -1021,7 +1021,6 @@ class SourceFlags(_Preprocess):
      Example config block::
 
         - name : "source_flags"
-          signal: "signal" # optional
           calc:
             mask: {'shape': 'circle',
                    'xyr': [0, 0, 1.]}
@@ -1057,11 +1056,12 @@ class SourceFlags(_Preprocess):
         # find if source is within footprint + distance
         positions = planets.get_nearby_sources(tod=aman, source_list=source_list,
                                                distance=self.calc_cfgs.get('distance', 0))
+
         for p in positions:
             source_flags = tod_ops.flags.get_source_flags(aman,
                                                           merge=self.calc_cfgs.get('merge', False),
                                                           overwrite=self.calc_cfgs.get('overwrite', True),
-                                                          source_flags_name=p[0],
+                                                          source_flags_name=self.calc_cfgs.get('source_flags_name', None),
                                                           mask=self.calc_cfgs.get('mask', None),
                                                           center_on=p[0],
                                                           res=self.calc_cfgs.get('res', None),

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -1043,7 +1043,7 @@ class SourceFlags(_Preprocess):
                 from sotodlib.coords.planets import SOURCE_LIST
                 matches = [x for x in aman.tags if x in SOURCE_LIST]
                 if len(matches) != 0:
-                    sources = matches[0]
+                    source = matches[0]
                 else:
                     raise ValueError("No tags match source list")
             else:

--- a/sotodlib/tod_ops/flags.py
+++ b/sotodlib/tod_ops/flags.py
@@ -1,4 +1,3 @@
-import time
 import numpy as np
 import scipy.stats as stats
 from scipy.signal import find_peaks

--- a/sotodlib/tod_ops/flags.py
+++ b/sotodlib/tod_ops/flags.py
@@ -583,26 +583,19 @@ def get_dark_dets(aman, merge=True, overwrite=True, dark_flags_name='darks'):
 
     return mskdarks
 
-def get_source_flags(aman, merge=True, overwrite=True, source_flags_name='source_flags',
-                     mask=None, center_on=None, res=None, max_pix=None, distance=None):
-    if merge:
-        wrap = source_flags_name
-    else:
-        wrap = None
+def get_source_flags(aman, merge=True, overwrite=True, source_flags_name=None,
+                     mask=None, center_on=None, res=None, max_pix=None):
+
     if res:
         res = np.radians(res/60) # config input in arcminutes
-    if not distance:
-        distance = 0
 
-    # find if source is within footprint + distance
-    positions = coords.planets.get_nearby_sources(tod=aman, source_list=[center_on], distance=distance)
-
-    if positions:
-        source_flags = coords.planets.compute_source_flags(tod=aman, wrap=wrap, mask=mask, center_on=center_on, res=res, max_pix=max_pix)
-    else:
-        source_flags = RangesMatrix.zeros([aman.dets.count, aman.samps.count])
+    source_flags = coords.planets.compute_source_flags(tod=aman, wrap=None,
+                                                       mask=mask, center_on=center_on,
+                                                       res=res, max_pix=max_pix)
 
     if merge:
+        if source_flags_name is None:
+            source_flags_name = center_on
         if source_flags_name in aman.flags and not overwrite:
             raise ValueError(f"Flag name {source_flags_name} already exists in aman.flags")
         if source_flags_name in aman.flags:

--- a/sotodlib/tod_ops/flags.py
+++ b/sotodlib/tod_ops/flags.py
@@ -589,8 +589,8 @@ def get_source_flags(aman, merge=True, overwrite=True, source_flags_name=None,
     if res:
         res = np.radians(res/60) # config input in arcminutes
 
-    source_flags = coords.planets.compute_source_flags(tod=aman, wrap=None,
-                                                       mask=mask, center_on=center_on,
+    source_flags = coords.planets.compute_source_flags(tod=aman, mask=mask,
+                                                       center_on=center_on,
                                                        res=res, max_pix=max_pix)
 
     if merge:


### PR DESCRIPTION
Updates `SourceFlags` preprocess functions.  Adds a check to see if the input source is nearby and does the flagging as before.  Returns a zero `RangeMatrix` if no source is found.  Now, it accepts a list of sources and loops through them which are wrapped into `proc_aman.source_flags.source_name`.  Currently requires `FocalplaneNanFlags` to be run first so that any focal plane `NaNs` are removed.