### PR TITLE
Data Packaging: Updates for repairing failed books

### DIFF
--- a/sotodlib/io/bookbinder.py
+++ b/sotodlib/io/bookbinder.py
@@ -15,7 +15,7 @@ import sys
 import shutil
 import yaml
 import datetime as dt
-from zipfile import ZipFile
+from zipfile import ZipFile, ZIP_DEFLATED
 import sotodlib
 from sotodlib.site_pipeline.util import init_logger
 from .datapkg_utils import walk_files
@@ -1297,7 +1297,7 @@ class TimeCodeBinder:
             with ZipFile(self.outdir, mode='x') as zf:
                 for f in self.file_list:
                     relpath = os.path.relpath(f, self.indir)
-                    zf.write(f, arcname=relpath)
+                    zf.write(f, arcname=relpath, compress_type=ZIP_DEFLATED)
         elif self.file_list is None:
             shutil.copytree(
                 self.indir,

--- a/sotodlib/io/bookbinder.py
+++ b/sotodlib/io/bookbinder.py
@@ -533,7 +533,7 @@ class SmurfStreamProcessor:
         self.readout_ids = readout_ids
         self.out_files = []
         self.book_id = book_id
-        self.allow_bad_timing = allow_bad_timing,
+        self.allow_bad_timing = allow_bad_timing
 
         if log is None:
             self.log = logging.getLogger('bookbinder')

--- a/sotodlib/io/datapkg_completion.py
+++ b/sotodlib/io/datapkg_completion.py
@@ -610,7 +610,8 @@ class DataPackaging:
         if len(missed_files) == 0 and len(extra_files) == 0:
             self.logger.info(f"Timecode {timecode} has complete coverage")
         if len(missed_files)>0:
-            msg = f"Files on disk but not in database {len(missed_files)}:\n"
+            msg = f"Files on disk but not marked as uploaded in database"
+            msg += f" {len(missed_files)}:\n"
             for f in missed_files:
                 msg += f"\t{f}\n"
             self.logger.warning(msg)

--- a/sotodlib/io/datapkg_completion.py
+++ b/sotodlib/io/datapkg_completion.py
@@ -560,7 +560,16 @@ class DataPackaging:
                 for k in flist:
                     x.extend(flist[k])
                 flist=x
-            file_list.extend(flist)
+            ## annoying edge case catcher because we use datetimes in
+            ## book.start and book.stop
+            for f in flist:
+                if f"/{timecode}/" not in f:
+                    self.logger.info(
+                        f"Not adding {f} to file list because it is not in "
+                        f"the {timecode} folder"
+                    )
+                    continue
+                file_list.append(f)
         # add suprsync files 
         file_list.extend( self.get_suprsync_files(timecode) )
         return file_list, deletable

--- a/sotodlib/io/datapkg_completion.py
+++ b/sotodlib/io/datapkg_completion.py
@@ -309,8 +309,8 @@ class DataPackaging:
         )
         if incomplete.count() > 0:
             ic_list = incomplete.all()
-            """Check if these are actually incomplete, imprinter incomplete checker
-            includes making sure the stop isn't beyond max ctime. 
+            """Check if these are actually incomplete, imprinter incomplete 
+            checker includes making sure the stop isn't beyond max ctime. 
             """
             obs_list = []
             for obs in ic_list:
@@ -636,7 +636,7 @@ class DataPackaging:
         for book in book_list:
             stat = self.imprint.delete_level2_files(
                 book, verify_with_librarian=verify_with_librarian,
-                n_copies_in_lib=2, dry_run=dry_run
+                n_copies_in_lib=2, dry_run=dry_run, n_tries=2
             )
             if stat > 0:
                 books_not_deleted.append(book)    

--- a/sotodlib/io/g3tsmurf_utils.py
+++ b/sotodlib/io/g3tsmurf_utils.py
@@ -90,7 +90,7 @@ def get_last_bg_map(my_obs_id, SMURF):
     obs = session.query(Observations).filter(Observations.obs_id == my_obs_id).one()
     oper = _get_last_oper(obs.timestamp, obs.stream_id, "oper,bgmap%", session)
     if oper is None:
-        logger.error(f"Unable to find Bias Step associated with {my_obs_id}")
+        logger.error(f"Unable to find bg_map associated with {my_obs_id}")
 
     files = get_obs_outputs(oper.obs_id, SMURF)
     file = [f for f in files if "bg_map.npy" in f]

--- a/sotodlib/io/imprinter.py
+++ b/sotodlib/io/imprinter.py
@@ -803,6 +803,7 @@ class Imprinter:
                 allow_bad_timing=allow_bad_timing,
                 require_acu=require_acu,
                 require_hwp=require_hwp,
+                require_monotonic_times=require_monotonic_times,
             )
             binder.bind(pbar=pbar)
             

--- a/sotodlib/io/imprinter.py
+++ b/sotodlib/io/imprinter.py
@@ -1805,6 +1805,7 @@ class Imprinter:
         except Exception as e:
             self.logger.warning(f"Failed to remove {book_path}: {e}")
             self.logger.error(traceback.format_exc())
+            return 4
         book.status = DONE
         self.session.commit()
         return 0

--- a/sotodlib/io/imprinter.py
+++ b/sotodlib/io/imprinter.py
@@ -1649,9 +1649,14 @@ class Imprinter:
                 self.logger.info(f"received response from librarian {resp}")
                 if n_tries > 1:
                     if book.type == 'smurf':
-                        time.sleep(30)
+                        wait=30
                     else: 
-                        time.sleep(5)
+                        wait=5
+                    self.logger.warning(
+                        f"Waiting {wait} seconds and trying book {book.bid} "
+                        "with the librarian again"
+                    )
+                    time.sleep(wait)
                     return self.check_book_in_librarian(
                         book, n_copies=n_copies, 
                         n_tries=n_tries-1, 

--- a/sotodlib/io/imprinter.py
+++ b/sotodlib/io/imprinter.py
@@ -659,6 +659,8 @@ class Imprinter:
         require_hwp=True,
         require_acu=True,
         require_monotonic_times=True,
+        min_ctime=None, 
+        max_ctime=None,
     ):
         """get the appropriate bookbinder for the book based on its type"""
 
@@ -685,6 +687,7 @@ class Imprinter:
                 require_hwp=require_hwp,
                 require_acu=require_acu,
                 require_monotonic_times=require_monotonic_times,
+                min_ctime=min_ctime, max_ctime=max_ctime,
             )
             return bookbinder
 
@@ -745,6 +748,7 @@ class Imprinter:
         require_hwp=True,
         require_acu=True,
         require_monotonic_times=True,
+        min_ctime=None, max_ctime=None,
         check_configs={}
     ):
         """Bind book using bookbinder
@@ -768,6 +772,20 @@ class Imprinter:
             expected to be turned on by hand.
         allow_bad_timing: if true, will bind books even if the timing is low 
             precision
+        require_hwp: bool, optional
+            if True, requires that we find HWP data before binding the book. 
+            hard-coded to False if self.daq_node is lat
+        require_acu: bool, optional
+            if True, requires that we have ACU data and that it has no dropouts 
+            longer than 10s
+        require_monotonic_times: bool, optional
+            if True, requires that all HK data is monotonically increasing, 
+            should never be set to False for obs books but less important for 
+            oper books if there were ACU aggregation issues
+        min_ctime: float, optional
+            if not None, cuts the book down to have this minimum ctime
+        max_ctime: float, optional
+            if not None, cuts the book down to have this maximum ctime
         check_configs: dict
             additional non-default configurations to send to check book
         """
@@ -804,6 +822,7 @@ class Imprinter:
                 require_acu=require_acu,
                 require_hwp=require_hwp,
                 require_monotonic_times=require_monotonic_times,
+                min_ctime=min_ctime, max_ctime=max_ctime
             )
             binder.bind(pbar=pbar)
             

--- a/sotodlib/io/imprinter.py
+++ b/sotodlib/io/imprinter.py
@@ -658,6 +658,7 @@ class Imprinter:
         allow_bad_timing=False,
         require_hwp=True,
         require_acu=True,
+        require_monotonic_times=True,
     ):
         """get the appropriate bookbinder for the book based on its type"""
 
@@ -683,6 +684,7 @@ class Imprinter:
                 allow_bad_timing=allow_bad_timing,
                 require_hwp=require_hwp,
                 require_acu=require_acu,
+                require_monotonic_times=require_monotonic_times,
             )
             return bookbinder
 
@@ -742,6 +744,7 @@ class Imprinter:
         allow_bad_timing=False,
         require_hwp=True,
         require_acu=True,
+        require_monotonic_times=True,
         check_configs={}
     ):
         """Bind book using bookbinder

--- a/sotodlib/io/imprinter.py
+++ b/sotodlib/io/imprinter.py
@@ -1653,8 +1653,9 @@ class Imprinter:
                     else: 
                         time.sleep(5)
                     return self.check_book_in_librarian(
-                        self, book, n_copies=n_copies, 
-                        n_tries=n_tries-1, raise_on_error=raise_on_error
+                        book, n_copies=n_copies, 
+                        n_tries=n_tries-1, 
+                        raise_on_error=raise_on_error
                     )
         except Exception as e:
             if raise_on_error:

--- a/sotodlib/io/imprinter_cli.py
+++ b/sotodlib/io/imprinter_cli.py
@@ -54,7 +54,8 @@ def fix_single_book(imprint:Imprinter, book:Books):
             "\n\t2. Retry Binding with lvl2 updates"
             "\n\t3. Rebind with flag(s)"
             "\n\t4. Permanently Skip Binding"
-            "\n\t5. Do Nothing"
+            "\n\t5. Permanently Skip Binding. Delete lvl2."
+            "\n\t6. Do Nothing"
             "\nInput Response: "
         )
         try: 
@@ -62,7 +63,7 @@ def fix_single_book(imprint:Imprinter, book:Books):
         except:
             print(f"Invalid Response {resp}")
             resp=None
-        if resp is None or resp < 1 or resp > 5:
+        if resp is None or resp < 1 or resp > 6:
             print(f"Invalid Response {resp}")
             resp=None
     print(f"You selected {resp}")
@@ -93,6 +94,14 @@ def fix_single_book(imprint:Imprinter, book:Books):
     elif resp == 4:
         utils.set_book_wont_bind(imprint, book)
     elif resp == 5:
+        sure = set_tag_and_validate(
+            "Are you sure you want to delete level 2?"
+        )
+        if sure:
+            utils.delete_level2_obs_and_book(imprint, book)
+        else:
+            print("Skipping")
+    elif resp == 6:
         pass
     else:
         raise ValueError("how did I get here?")

--- a/sotodlib/io/imprinter_cli.py
+++ b/sotodlib/io/imprinter_cli.py
@@ -77,7 +77,7 @@ def fix_single_book(imprint:Imprinter, book:Books):
             "Drop Ancillary Duplicates? (y/[n])"
         )
         allow_bad_timing = set_tag_and_validate(
-            "Allow Low Precision Timing? (y/[n])"
+            "Allow Bad Timing? (Low Precision or Dropped Samples)? (y/[n])"
         )
         require_acu = set_tag_and_validate("Require ACU data? ([y]/n)")
         require_hwp = set_tag_and_validate("Require HWP data? ([y]/n)")

--- a/sotodlib/io/imprinter_cli.py
+++ b/sotodlib/io/imprinter_cli.py
@@ -252,7 +252,7 @@ class BadTimeSamples(BookError):
         msg = f"{self.book.bid} has dropped time samples\n"
         for l in self.book.message.split('\n'):
             if len(l)>0 and l[0] == '\t':
-                msg += l
+                msg += l + "\n"
         return msg
 
 AUTOFIX_ERRORS = [

--- a/sotodlib/io/imprinter_cli.py
+++ b/sotodlib/io/imprinter_cli.py
@@ -81,7 +81,7 @@ def fix_single_book(imprint:Imprinter, book:Books):
         require_acu = set_tag_and_validate("Require ACU data? ([y]/n)")
         require_hwp = set_tag_and_validate("Require HWP data? ([y]/n)")
         require_monotonic_times = set_tag_and_validate(
-            "Require Monotonic Housekeeping times? [y]/n"
+            "Require Monotonic Housekeeping times? ([y]/n)"
         )
         imprint.bind_book(
             book, ignore_tags=ignore_tags, ancil_drop_duplicates=ancil_drop_duplicates,

--- a/sotodlib/io/imprinter_utils.py
+++ b/sotodlib/io/imprinter_utils.py
@@ -112,7 +112,7 @@ def delete_level2_obs_and_book(imprint, book, session=None):
     
     if session is None:
         session = imprint.get_session()
-
+    print(f"Removing Level 2 for {book.bid}")
     obs_dict = imprint.get_g3tsmurf_obs_for_book(book)
     g3session, SMURF = imprint.get_g3tsmurf_session(
         return_archive=True

--- a/sotodlib/io/imprinter_utils.py
+++ b/sotodlib/io/imprinter_utils.py
@@ -17,6 +17,8 @@ from sotodlib.io.imprinter import (
     BOUND,
     UPLOADED,
     DONE,    
+    ObsSet,
+    G3tObservations,
 )
 
 from .load_smurf import (
@@ -99,6 +101,37 @@ def set_book_rebind(imprint, book, update_level2=False):
         for _, obs in obs_dict.items():
             SMURF.update_observation_files(obs, g3session, force=True)
 
+def remove_level2_obs_from_book(imprint, book, bad_obs_id):
+    """If one level2 observation is problematic, delete that book and re-register without it.
+    """
+    assert book.type == "obs", f"Book should be an 'obs' book"
+
+    # keep staged clean
+    set_book_rebind(imprint, book)
+    odic = imprint.get_g3tsmurf_obs_for_book(book)
+    obs_ids = [k for k in odic.keys()]
+    assert bad_obs_id in obs_ids, f"{bad_obs_id} not in book {book.bid}"
+    
+    new_obs_list = [o for o in obs_ids if o != bad_obs_id]
+    g3session = imprint.get_g3tsmurf_session()
+    olist = [
+        g3session.query(G3tObservations).filter(
+            G3tObservations.obs_id == o
+        ).one() for o in new_obs_list
+    ]
+    oset = ObsSet(
+        olist,
+        mode=book.type, 
+        slots=imprint.tubes[book.tel_tube]['slots'],
+        tel_tube=book.tel_tube
+    )
+    session = imprint.get_session()
+    for o in book.obs:
+        session.delete(o)
+    session.delete(book)
+    session.commit()
+    return imprint.register_book(oset, session=session)
+
 def find_overlaps(imprint, obs_id, min_ctime, max_ctime):
     """ helper function for when a level 2 observation could span multiple
     books. Creates a list of ObsSets with that obs_id, prints info to screen and
@@ -169,7 +202,7 @@ def block_fix_bad_timing(imprint):
     """Run through and try rebinding all books with bad timing"""
     failed_books = imprint.get_failed_books()
     fix_list = []
-    for book in failed_book:
+    for book in failed_books:
         if "TimingSystemOff" in book.message:
             fix_list.append(book)
     for book in fix_list:

--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -263,7 +263,6 @@ class G3tSmurf:
             g3tsmurf_db: "/path/to/g3tsmurf.db"
             g3thk_db: "/path/to/g3hk.db"
 
-
             finalization:
                 servers:
                     - smurf-suprsync: "smurf-sync-so1" ## instance-id

--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -616,7 +616,7 @@ class G3tSmurf:
                 f"Database file {db_file.name} appears already deleted on disk"
             )
         else:
-            my_logger.info(f"Deleting file {db_file.name}")
+            my_logger.debug(f"Deleting file {db_file.name}")
 
             if not dry_run:
                 os.remove(db_file.name)
@@ -625,7 +625,7 @@ class G3tSmurf:
                 base, _ = os.path.split(db_file.name)
                 if len(os.listdir(base)) == 0:
                     os.rmdir(base)
-        my_logger.info(f"Deleting database entry for {db_file.name}")
+        my_logger.debug(f"Deleting database entry for {db_file.name}")
         if not dry_run:
             session.delete(db_file)
             session.commit()
@@ -1171,6 +1171,7 @@ class G3tSmurf:
         if my_logger is None:
             my_logger = logger
 
+        my_logger.info(f"Deleting Observation {obs.obs_id}")
         ## first remove the tags
         tags = (
             session.query(Tags)
@@ -1180,7 +1181,7 @@ class G3tSmurf:
             .all()
         )
         for t in tags:
-            my_logger.info(f"Deleting Tag ({t.tag, t.obs_id}) from database")
+            my_logger.debug(f"Deleting Tag ({t.tag, t.obs_id}) from database")
             if not dry_run:
                 session.delete(t)
 
@@ -1189,7 +1190,7 @@ class G3tSmurf:
             self.delete_file(f, session, dry_run=dry_run, my_logger=my_logger)
 
         ## then remove the observation
-        my_logger.info(f"Deleting Observation {obs.obs_id} from database")
+        my_logger.debug(f"Deleting Observation {obs.obs_id} from database")
         if not dry_run:
             session.delete(obs)
             session.commit()

--- a/sotodlib/site_pipeline/update_g3tsmurf_db.py
+++ b/sotodlib/site_pipeline/update_g3tsmurf_db.py
@@ -107,6 +107,10 @@ def main(config: Optional[str] = None, update_delay: float = 2,
             raise_list_readout_ids.append(obs.obs_id)
 
     if len(raise_list_timing) > 0 or len(raise_list_readout_ids) > 0:
+        logger.info(
+            f"Found observations with bad timing or missing readout ids "
+            "checking to see if they've been manually cleared"
+        )
         if checked_file is None or not os.path.exists(checked_file):
             logger.warning(
                 f"File {checked_file} does not exist so cannot check if "

--- a/sotodlib/site_pipeline/update_g3tsmurf_db.py
+++ b/sotodlib/site_pipeline/update_g3tsmurf_db.py
@@ -18,7 +18,7 @@ from sotodlib.io.datapkg_utils import load_configs
 
 def main(config: Optional[str] = None, update_delay: float = 2, 
          from_scratch: bool = False, verbosity: int = 2,
-         index_via_actions: bool=False):
+         index_via_actions: bool=False, checked_file: Optional[str]=None):
     """
     Arguments
     ---------
@@ -36,6 +36,10 @@ def main(config: Optional[str] = None, update_delay: float = 2,
         will be necessary for data older than Oct 2022 but creates concurancy 
         issues on systems (like the site) running automatic deletion of level 2 
         data.
+    checked_file: str
+        a file name that contains a list of observations that would by default 
+        cause errors to be thrown during this script but have been manually
+        checked and dealt with
     """
     show_pb = True if verbosity > 1 else False
 
@@ -103,6 +107,20 @@ def main(config: Optional[str] = None, update_delay: float = 2,
             raise_list_readout_ids.append(obs.obs_id)
 
     if len(raise_list_timing) > 0 or len(raise_list_readout_ids) > 0:
+        if checked_file is None or not os.path.exists(checked_file):
+            logger.warning(
+                f"File {checked_file} does not exist so cannot check if "
+                "problematic observations have been manually cleared"
+            )
+            cleared = []
+        else:
+            with open(checked_file) as f:
+                cleared = [c.strip("\n") for c in f.readlines()]
+        raise_list_timing = [x for x in raise_list_timing if x not in cleared]
+        raise_list_readout_ids = [
+            x for x in raise_list_readout_ids if x not in cleared
+        ]
+    if len(raise_list_timing) > 0 or len(raise_list_readout_ids) > 0:
         raise ValueError(
             f"Found {len(raise_list_timing)} observations with bad timing"
             f" obs_ids are {raise_list_timing}.\nFound "
@@ -122,6 +140,8 @@ def get_parser(parser=None):
                         default=2, type=int)
     parser.add_argument('--index-via-actions', help="Look through action folders to create observations",
                         action="store_true")
+    parser.add_argument("--checked-file", 
+        help="Filename of file containing a list of observations that are problematic but have been manually acknowledged")
     return parser
 
 if __name__ == '__main__':


### PR DESCRIPTION
* Add autofixing for operations books with NoMountData errors (we generally don't care too strongly about the mount positions where operations take place, and/or it's find to miss the positions of some of these)
* Add option to skip the check that requires HK times to be monotonically increasing. We've seen this now around time periods where NoMountData was also getting thrown, we're going to want to be very careful about actually using this flag, (the time I saw this and I've checked that data, the mount was stationary the whole time, so I'm not worried about interpolations for that one)
* If librarian checking fails, try again (hoping that helps with caching errors at NERSC/Princeton)
* Allow over-riding ctimes for manual book making. Used once or twice when the ACU dropped out. 
* Check level 2 file size and throw errors if the files are too large. This makes it easier to flag and clear out smurf communication crashes
* Check for missing / dropped timesamples per stream_id. Throw error if more than 100 are dropped at once and report the number dropped (filled_samples) in the M_index.yaml so we can find them easier. This is all related to this discussion: https://github.com/simonsobs/daq-discussions/discussions/144 
