### PR TITLE
fix _apply_inverse_weights_map

### DIFF
--- a/sotodlib/coords/helpers.py
+++ b/sotodlib/coords/helpers.py
@@ -600,8 +600,10 @@ def _apply_inverse_weights_map(inverse_weights, target, out=None):
 
     """
     if out is None:
-        out = enmap.ndmap(np.empty(inverse_weights.shape[1:],
-                          dtype=target.dtype), target.wcs)
+        out = np.empty(inverse_weights.shape[1:],
+                       dtype=target.dtype)
+        if isinstance(target, enmap.ndmap):
+            out = enmap.ndmap(out, target.wcs)
     # Recall matmul(a, b) operates on the last two axes of (a, b). So
     # move axes, and create a second one in target; re-order at end.
     iw = np.moveaxis(inverse_weights, (0,1), (-2,-1))

--- a/sotodlib/coords/helpers.py
+++ b/sotodlib/coords/helpers.py
@@ -600,8 +600,8 @@ def _apply_inverse_weights_map(inverse_weights, target, out=None):
 
     """
     if out is None:
-        out = np.empty(inverse_weights.shape[1:],
-                       dtype=target.dtype)
+        out = enmap.ndmap(np.empty(inverse_weights.shape[1:],
+                          dtype=target.dtype), target.wcs)
     # Recall matmul(a, b) operates on the last two axes of (a, b). So
     # move axes, and create a second one in target; re-order at end.
     iw = np.moveaxis(inverse_weights, (0,1), (-2,-1))


### PR DESCRIPTION
https://github.com/simonsobs/sotodlib/pull/1033 changed the return type of _apply_inverse_weights_map to numpy.ndarray with default arguments. This PR changes it back to pixell.enmap.ndmap.