### PR TITLE
Clarify error message when there is a detector count mismatch

### DIFF
--- a/sotodlib/core/metadata/loader.py
+++ b/sotodlib/core/metadata/loader.py
@@ -638,8 +638,7 @@ def merge_det_info(det_info, new_info, multi=True, on_missing='trim'):
 
     if len(det_info) != len(i1) and on_missing != 'trim':
         raise IncompleteMetadataError(
-            f"Mismatching detector count: "
-            f"ObsFileDb({len(det_info)}) -> Manifest({len(i1)})"
+            f"det_info had n_dets={len(det_info)}; After merge it has n_dets={len(i1)}"
         )
 
     logger.debug(f' ... updating det_info (row count '

--- a/sotodlib/core/metadata/loader.py
+++ b/sotodlib/core/metadata/loader.py
@@ -637,7 +637,10 @@ def merge_det_info(det_info, new_info, multi=True, on_missing='trim'):
                 f'in the det_id, maybe add {k} to the match_keys?')
 
     if len(det_info) != len(i1) and on_missing != 'trim':
-        raise IncompleteMetadataError('{len(det_info)} -> {len(i1)})')
+        raise IncompleteMetadataError(
+            f"Mismatching detector count: "
+            f"ObsFileDb({len(det_info)}) -> Manifest({len(i1)})"
+        )
 
     logger.debug(f' ... updating det_info (row count '
                  f'{len(det_info)} -> {len(i1)})')


### PR DESCRIPTION
Properly formats error message that occurs when there is a detector count mismatch between manifestdb and obsfiledb and adds some clarifying detail.

This error message quoted in several open issues and discussions:
- https://github.com/simonsobs/site-pipeline-configs/issues/60
- https://github.com/simonsobs/sotodlib/issues/1078