### PR TITLE
Fix for Source Flags

### DIFF
--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -1082,10 +1082,18 @@ class SourceFlags(_Preprocess):
         else:
             source_flags = proc_aman.source_flags
 
-        for source in source_flags._fields:
-            keep = ~has_all_cut(source_flags[source])
-            meta.restrict("dets", meta.dets.vals[keep])
-            source_flags.restrict("dets", source_flags.dets.vals[keep])
+        source_list = np.atleast_1d(self.calc_cfgs.get('center_on', 'planet'))
+        if source_list == ['planet']:
+            from sotodlib.coords.planets import SOURCE_LIST
+            source_list = [x for x in aman.tags if x in SOURCE_LIST]
+            if len(source_list) == 0:
+                raise ValueError("No tags match source list")
+
+        for source in source_list:
+            if source in source_flags._fields:
+                keep = ~has_all_cut(source_flags[source])
+                meta.restrict("dets", meta.dets.vals[keep])
+                source_flags.restrict("dets", source_flags.dets.vals[keep])
         return meta
 
 class HWPAngleModel(_Preprocess):


### PR DESCRIPTION
This branch is to fix a problem that arose when loading data back in that was introduced from the Source Flags preprocessing module.  Since fields are added into the axis manager, all detectors are cut when non-source entries are added.  For now, I copied the source list generation and use the fields that match sources in the source_flags axis manager.  We could alternatively just exclude "valid," but might not be future proof.