### PR TITLE
Minor fix for logging in multilayer_load_and_preprocess

### DIFF
--- a/sotodlib/preprocess/preprocess_util.py
+++ b/sotodlib/preprocess/preprocess_util.py
@@ -988,7 +988,7 @@ def check_cfg_match(ref, loaded, logger=None):
                 return False
             else:
                 if type(ref[ri]) is core.AxisManager:
-                    check_cfg_match(ref[ri], loaded[li])
+                    check_cfg_match(ref[ri], loaded[li], logger)
                 elif ref[ri] == loaded[li]:
                     continue
                 else:


### PR DESCRIPTION
Minor fix to logger when running `multilayer_load_and_preprocess`.  The logging level would previously get reset due to the recursive call of `check_cfg_match`.