### PR TITLE
site_pipeline: check_book funcs for update_obsdb use

### DIFF
--- a/sotodlib/site_pipeline/check_book.py
+++ b/sotodlib/site_pipeline/check_book.py
@@ -104,16 +104,19 @@ def get_parser(parser=None):
     return parser
 
 
-def main(book_dir, config=None, add=None, overwrite=None):
-    logger = util.init_logger(__name__, 'check_book: ')
+def scan_book_dir(book_dir, logger, config, prep_obsfiledb=False):
+    """Run the BookScanner on book_dir.
 
+    Returns:
+      ok : bool
+        True only if the book passed the checks.
+      obsfiledb_info : dict or None
+        If prep_obsfiledb, and ok, then this dict has the info needed
+        for updating obsfiledb (see add_to_obsfiledb).
+
+    (Note this function is used by update-obsdb, as well.)
+    """
     logger.info(f'Examining {book_dir}')
-
-    if config is not None:
-        logger.debug(f'Loading config from {config}')
-        config = yaml.safe_load(open(config, 'rb'))
-    else:
-        config = {}
     bs = check_book.BookScanner(book_dir, config)
 
     bs.go()
@@ -121,13 +124,24 @@ def main(book_dir, config=None, add=None, overwrite=None):
 
     if len(bs.results['errors']):
         logger.error('Cannot register this obs due to errors.')
-        sys.exit(1)
+        return False, None
 
-    if not add:
-        sys.exit(0)
+    if prep_obsfiledb:
+        detset_rows, file_rows = bs.prep_obsfiledb(config.get('root_path', '/'))
+        return True, {
+            'detset_rows': detset_rows,
+            'file_rows': file_rows,
+        }
+    return True, None
 
-    detset_rows, file_rows = bs.prep_obsfiledb(config.get('root_path', '/'))
+def add_to_obsfiledb(info, logger, config, overwrite=False):
+    """Add observation info to the obsfiledb specified in config.  The
+    "info" dict is the one returned by scan_book_dir.  If overwrite,
+    then file entries in the obsfiledb, for this obs_id, will be
+    replaced.
 
+    (Note this function is used by update-obsdb, as well.)
+    """
     # Write to obsfiledb
     obsfiledb_file = config.get('obsfiledb', 'obsfiledb.sqlite')
     logger.debug('Updating %s ...' % obsfiledb_file)
@@ -137,17 +151,35 @@ def main(book_dir, config=None, add=None, overwrite=None):
         # Note this only drops the obs ... if detsets need to be
         # rewritten, you'd better start over entirely.
         logger.debug(' -- removing any existing references.')
-        db.drop_obs(file_rows[0]['obs_id'])
+        db.drop_obs(info['file_rows'][0]['obs_id'])
 
     logger.debug(
-        ' -- adding %i detsets and %i file refs' % (len(detset_rows), 
-        len(file_rows))
+        ' -- adding %i detsets and %i file refs' % (len(info['detset_rows']), 
+        len(info['file_rows']))
     )
-    for name, dets in detset_rows:
+    for name, dets in info['detset_rows']:
         if len(db.get_dets(name)) == 0:
             db.add_detset(name, dets)
-    for row in file_rows:
+    for row in info['file_rows']:
         db.add_obsfile(**row)
+
+
+def main(book_dir, config=None, add=None, overwrite=None):
+    logger = util.init_logger(__name__, 'check_book: ')
+
+    if config is not None:
+        logger.debug(f'Loading config from {config}')
+        config = yaml.safe_load(open(config, 'rb'))
+    else:
+        config = {}
+
+    ok, info = scan_book_dir(book_dir, logger, config, prep_obsfiledb=add)
+    if not ok:
+        logger.error('Cannot register this obs due to errors.')
+        sys.exit(1)
+
+    if add:
+        add_to_obsfiledb(info, logger, config, overwrite=overwrite)
 
 
 if __name__ == '__main__':

--- a/sotodlib/site_pipeline/update_obsdb.py
+++ b/sotodlib/site_pipeline/update_obsdb.py
@@ -33,7 +33,7 @@ The config file could be of the form:
 
 from sotodlib.core.metadata import ObsDb
 from sotodlib.core import Context 
-from sotodlib.site_pipeline.check_book import main as checkbook
+from sotodlib.site_pipeline import check_book
 from sotodlib.io import load_book
 import os
 import glob
@@ -198,7 +198,12 @@ def main(config: str,
             logger.info(f"Examining book at {bookpath}")
             try:
                 #obsfiledb creation
-                checkbook(bookpath, config, add=True, overwrite=True)
+                ok, obsfiledb_info = check_book.scan_book_dir(
+                    bookpath, logger, config_dict, prep_obsfiledb=True)
+                if not ok:
+                    raise RuntimeError("check_book found fatal errors, not adding.")
+                check_book.add_to_obsfiledb(
+                    obsfiledb_info, logger, config_dict, overwrite=True)
                 logger.info(f"Ran check_book in {time.time()-t1} s")
             except Exception as e:
                 if config_dict["skip_bad_books"]:


### PR DESCRIPTION
This resolves issue where update_obsdb would sys.exit when a book check failed.

So now update_obsdb doesn't call main, it calls two other functions.

@AERAdler  I have not tested the update_obsdb changes!  Please do so to confirm they behave as we want.  In particular this should raise an informative error, not exit, when it encounters a bad book.

The logging will change slightly, because the update_obsdb logger is passed into the check_book functions.