### PR TITLE
fix t2p lmfit weight

### DIFF
--- a/sotodlib/tod_ops/t2pleakage.py
+++ b/sotodlib/tod_ops/t2pleakage.py
@@ -183,11 +183,11 @@ def t2p_joint_fit(aman, T_sig_name='dsT', Q_sig_name='demodQ', U_sig_name='demod
         yU = aman[U_sig_name][di][mask[di]][::ds_factor]
 
         try:
-            model = LmfitModel(leakage_model, independent_vars=['dT'], 
-                          weights=np.ones_like(x)/sigma_demod[di])
+            model = LmfitModel(leakage_model, independent_vars=['dT'])
             params = model.make_params(AQ=np.median(yQ), AU=np.median(yU), 
                                        lamQ=0., lamU=0.)
-            result = model.fit(yQ + 1j * yU, params, dT=x)
+            result = model.fit(yQ + 1j * yU, params, dT=x,
+                               weights=np.ones_like(x)/sigma_demod[di])
             A_Q_array[di] = result.params['AQ'].value
             A_U_array[di] = result.params['AU'].value
             lambda_Q_array[di] = result.params['lamQ'].value


### PR DESCRIPTION
Fix the weight of t2p join fit. This was messing up the reduced chi square of t2p fitting.
I'm using lmfit version '1.3.2'.
For example, in (obs_1723613525_satp3_1111111, ws2, f090), this changes `aman.t2p_stats.redchi2s` from
```
[2.19e-09, 2.45e-09, 2.03e-09, 2.53e-09, 2.03e-09, 2.47e-09,
 2.03e-09, 2.10e-09, 3.59e-09, 2.14e-09, 2.64e-09, 3.63e-09,
 2.40e-09, 2.86e-09, 2.58e-09, 4.00e-09, 2.69e-09, 2.34e-09,
 3.13e-09, 2.75e-09, 3.50e-09, 2.33e-09, 2.42e-09, 2.91e-09,
 2.82e-09, 2.45e-09, 3.20e-09, 2.64e-09, 2.12e-09, 2.84e-09,
 2.23e-09, 2.16e-09, 2.03e-09, 2.19e-09, 2.09e-09, 1.74e-09,
 1.69e-09, 2.12e-09, 2.36e-09, 2.26e-09, 2.96e-09, 2.33e-09,
 2.57e-09, 2.27e-09, 2.49e-09, 2.50e-09, 2.46e-09, 2.17e-09]
```
to
```
[0.99 0.97 0.95 0.95 0.95 0.94 0.95 0.99 0.96 0.98 0.95 0.97 0.95 0.95
 0.96 0.97 0.93 0.98 1.01 0.92 0.91 0.97 0.95 1.02 1.06 0.97 1.03 0.92
 0.97 0.99 0.98 0.98 1.   0.93 0.93 0.99 0.95 0.92 0.96 0.93 0.93 1.
 0.93 0.94 0.98 0.97 0.98 0.98]
```