### PR TITLE
update_obsdb uses book edit time instead of book_id for recency check

### DIFF
--- a/sotodlib/site_pipeline/update_obsdb.py
+++ b/sotodlib/site_pipeline/update_obsdb.py
@@ -185,9 +185,9 @@ def main(config: str,
                 if book_id in config_dict["known_bad_books"]:
                     logger.debug(f"{book_id} known to be bad, skipping it")
                     continue
-                found_timestamp = re.search(r"\d{10}", book_id)#Find the rough timestamp
-                if found_timestamp and int(found_timestamp.group())>tback:
-                    #Looks like a book folder and young enough
+                edit_time = os.path.getmtime(dirpath)
+                if edit_time > tback:
+                    #Looks like a book folder and edited recently enough
                     bookcart.append(dirpath)
     
     logger.info(f"Found {len(bookcart)} new books in {time.time()-tnow} s")


### PR DESCRIPTION
I went back and edited a line that looked at a book's timestamp instead of its edit time (which is what we want to look for) Now that there's the fastwalk option the line was redundent, so I replaced it with something actually useful. 