### PR TITLE
Adding subscan HWPSS subtraction function to sotodlib.hwp.hwp

### DIFF
--- a/sotodlib/hwp/hwp.py
+++ b/sotodlib/hwp/hwp.py
@@ -2,6 +2,7 @@ import numpy as np
 from scipy.optimize import curve_fit
 from sotodlib import core, tod_ops
 from sotodlib.tod_ops import bin_signal, filters, apodize
+from so3g.proj import RangesMatrix
 import logging
 
 logger = logging.getLogger(__name__)
@@ -649,3 +650,114 @@ def demod_tod(aman, signal=None, demod_mode=4,
     aman['demodU'] = demod.imag
     aman['demodU'] = tod_ops.fourier_filter(
         aman, lpf, signal_name='demodU', detrend=None) * 2.
+
+
+def subscan_subtraction(aman, flags=None, merge_model=False, in_place=False):
+    '''
+    Function to fit and subtract HWPSS by subscan. 
+    Assumes that turnaround flags and subscan flags have already been calculated and wrapped. 
+    Also note that the bin size for the final subscan subtraction is set to 90, which roughly matches the increment size of the HWP
+    angle per sample at 200 Hz
+
+    Arguments:
+    aman: Axis Manager
+    flags: flags object: flagged samples for the HWPSS fitting function to avoid, e.g. aman.flags.custom_glitch_flag. If None,
+            flagged samples will be a union of turnaround flags and hwpss_glitches, the result of iterative glitch finding done in this function.
+    merge_model: boolean: If True, will merge hwpss subtracted model into aman. Default is False.
+    in_place: boolean: If True, will re-assign the result of the hwpss subscan subtraction into aman.signal. Default is False.
+
+    Returns:
+        None. Either re-assigns aman.signal to the hwpss subscan subtracted signal, or wraps an axis "hwpss_subscan_remove" into aman.
+    '''
+
+    #refine glitch finding
+    logger.info('first round glitch finding, then filling')
+    tod_ops.flags.get_glitch_flags(aman, signal_name='signal', merge=True, name='hwpss_glitches_1',overwrite=True)
+
+    logger.info('subtracting hwpss from full tod for better glitch detection')
+    get_hwpss(aman, flags=aman.flags.hwpss_glitches_1, merge_stats=False)
+    subtract_hwpss(aman, in_place=False,remove_template=True)
+
+    logger.info('glitch finding post full tod hwpss subtraction')
+    tod_ops.flags.get_glitch_flags(aman, signal_name='hwpss_remove', merge=True, name='hwpss_glitches_2',overwrite=True)
+
+    #delete hwpss_remove
+    aman.move('hwpss_remove',None)
+
+    aman.flags.reduce(flags=['hwpss_glitches_1', 'hwpss_glitches_2'], method='union', wrap=True,
+                      new_flag='hwpss_glitches', remove_reduced=True)
+    
+    logger.info('subtract hwpss by subscan')
+    #define hwpss_avoid flags for mask to avoid in hwpss estimation
+    if 'hwpss_avoid' in aman.flags._assignments.keys():
+        aman.flags.move('hwpss_avoid',None)
+
+    aman.flags.reduce(flags=['hwpss_glitches', 'turnarounds'], method='union', wrap=True,
+                      new_flag='hwpss_avoid', remove_reduced=False)   
+
+    #prepare arrays for subscan subtracted signal and model
+    num_subscans = aman.subscan_info.subscan_flags.shape[0]
+    subtracted_sig = np.zeros_like(aman.signal)
+    hwpssmodel = np.zeros_like(aman.signal)
+
+    for j in range(num_subscans):
+        i = aman.subscan_info.subscan_flags[j].ranges()[0]
+
+        sub_aman = aman.restrict('samps',(i[0]+aman.samps.offset, i[1]+aman.samps.offset),in_place=False)
+        if flags is None:
+            sub_flag = sub_aman.flags.hwpss_avoid
+        else:
+            sub_flag = RangesMatrix.from_mask(flags.mask()[:,i[0]:i[1],])
+        
+        # clear sub axis manager of hwp axes so can populate new model
+        if 'hwpss_stats' in sub_aman._assignments.keys():
+            sub_aman.move('hwpss_stats',None)
+
+        if 'hwpss_model' in sub_aman._assignments.keys():
+            sub_aman.move('hwpss_model',None)
+
+        get_hwpss(sub_aman, signal=None, hwp_angle=None, bin_signal=True, bins=90,
+          lin_reg=True, modes=[1, 2, 3, 4, 5, 6, 7, 8], apply_prefilt=True,
+          prefilt_cfg=None, prefilt_detrend='linear', flags=sub_flag,
+          apodize_edges=True, apodize_edges_samps=1600, 
+          apodize_flags=True, apodize_flags_samps=200,
+          merge_stats=True, hwpss_stats_name='hwpss_stats',
+          merge_model=True, hwpss_model_name='hwpss_model')
+
+        #Append sub axis manager signal and model
+        subtract_hwpss(sub_aman,in_place=True,remove_template=False)
+        subtracted_sig[:,i[0]:i[1],] += sub_aman.signal
+        hwpssmodel[:,i[0]:i[1],] += sub_aman.hwpss_model
+
+        del sub_aman
+
+    #temporarily wrap hwpss subtracted signal into 'hwpss_subscan_remove'
+    aman.wrap('hwpss_subscan_remove', subtracted_sig, [(0, 'dets'), (1, 'samps')])
+    
+    tod_ops.flags.get_glitch_flags(aman, signal_name='hwpss_subscan_remove', merge=True, name='hwpss_glitches_3',overwrite=True)
+
+    #wrap all 3 glitch finding rounds into one flag 'hwpss_glitches'
+    aman.flags.reduce(flags=['hwpss_glitches_3', 'hwpss_glitches'], method='union', wrap=True,
+                      new_flag='hwpss_glitches', remove_reduced=True)
+    
+    gfilled = tod_ops.gapfill.fill_glitches(aman, nbuf=10, use_pca=False, modes=1, signal=aman.hwpss_subscan_remove,
+                                                wrap=False, glitch_flags=aman.flags.hwpss_glitches)
+    aman.move('hwpss_subscan_remove',None)
+
+    if merge_model:
+        if 'hwpss_subscan_model' in sub_aman._assignments.keys():
+            aman.move('hwpss_subscan_model', None)
+        aman.wrap('hwpss_subscan_model', hwpssmodel, [(0, 'dets'), (1, 'samps')])
+
+    if in_place:
+        aman.signal = gfilled
+    else:
+        aman.wrap('hwpss_subscan_remove', gfilled, [(0, 'dets'), (1, 'samps')])
+
+    #remove remaining by-products of the subtraction
+    aman.flags.move('hwpss_avoid',None)
+    del subtracted_sig
+    del hwpssmodel
+    del num_subscans
+
+    return None


### PR DESCRIPTION
This PR adds a function in hwp.py to complete HWPSS subtraction by subscan, accounting for amplitude and phase variation within each scan and not relying on mean subtraction post-demodulation. It has also been found that glitch detection after HWPSS subtraction is more effective for identifying glitches, and this function introduces an iterative glitch detection approach, which also reduces bias in the HWPSS fit by improving the glitch mask. 