### PR TITLE
Allow flags str for easy iterative glitch removal via preprocess

### DIFF
--- a/sotodlib/hwp/hwp.py
+++ b/sotodlib/hwp/hwp.py
@@ -48,8 +48,9 @@ def get_hwpss(aman, signal=None, hwp_angle=None, bin_signal=True, bins=360,
     prefilt_detrend: str or None
         Method of detrending when you apply prefilter. Default is `linear`. If data is already detrended or you do not want to detrend,
         set it to `None`.
-    flags : RangesMatrix, optional
+    flags : str or RangesMatrix or Ranges, optional
         Flags to be masked out before extracting HWPSS. If Default is None, and no mask will be applied.
+        If provided by a string, `aman.flags.get(flags)` is used for the flags.
     merge_stats : bool, optional
         Whether to add the extracted HWPSS statistics to `aman` as new axes. Default is `True`.
     hwpss_stats_name : str, optional
@@ -162,6 +163,9 @@ def get_hwpss(aman, signal=None, hwp_angle=None, bin_signal=True, bins=360,
     else:
         if flags is None:
             m = np.ones([aman.dets.count, aman.samps.count], dtype=bool)
+        if isinstance(flags, str):
+            flags = aman.flags.get(flags)
+            m = ~flags.mask()
         else:
             m = ~flags.mask()
 
@@ -206,8 +210,9 @@ def get_binned_hwpss(aman, signal=None, hwp_angle=None,
         The name of the timestream of hwp_angle. Defaults to aman.hwp_angle if not specified.
     bins : int, optional
         The number of HWP angle bins to use. Default is 360.
-    flags : None or RangesMatrix
+    flags : str or RangesMatrix or Ranges. optional
         Flag indicating whether to exclude flagged samples when binning the signal.
+        If provided by a string, `aman.flags.get(flags)` is used for the flags.
         Default is no mask applied.
     apodize_edges : bool, optional
         If True, applies an apodization window to the edges of the signal. Defaults to True.
@@ -230,9 +235,11 @@ def get_binned_hwpss(aman, signal=None, hwp_angle=None,
         signal = aman.signal
     if hwp_angle is None:
         hwp_angle = aman['hwp_angle']
-        
+
     if apodize_edges:
         weight_for_signal = apodize.get_apodize_window_for_ends(aman, apodize_samps=apodize_edges_samps)
+        if isinstance(flags, str):
+            flags = aman.flags.get(flags)
         if (flags is not None) and apodize_flags:
             flags_mask = flags.mask()
             if flags_mask.ndim == 1:

--- a/sotodlib/hwp/hwp.py
+++ b/sotodlib/hwp/hwp.py
@@ -161,11 +161,10 @@ def get_hwpss(aman, signal=None, hwp_angle=None, bin_signal=True, bins=360,
         hwpss_stats.wrap('redchi2s', redchi2s, [(0, 'dets')])
 
     else:
-        if flags is None:
-            m = np.ones([aman.dets.count, aman.samps.count], dtype=bool)
         if isinstance(flags, str):
             flags = aman.flags.get(flags)
-            m = ~flags.mask()
+        if flags is None:
+            m = np.ones([aman.dets.count, aman.samps.count], dtype=bool)
         else:
             m = ~flags.mask()
 

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -860,16 +860,22 @@ class GlitchFill(_Preprocess):
 
     def __init__(self, step_cfgs):
         self.signal = step_cfgs.get('signal', 'signal')
-        self.flag_aman = step_cfgs.get('flag_aman', 'glitches')
-        self.flag = step_cfgs.get('flag', 'glitch_flags')
+        self.flag_aman = step_cfgs.get('flag_aman')
+        self.flag = step_cfgs.get('flag')
 
         super().__init__(step_cfgs)
 
     def process(self, aman, proc_aman):
-        tod_ops.gapfill.fill_glitches(
-            aman, signal=aman[self.signal],
-            glitch_flags=proc_aman[self.flag_aman][self.flag],
-            **self.process_cfgs)
+        if (self.flag_aman is not None) and (self.flag is not None):
+            glitch_flags=proc_aman[self.flag_aman][self.flag]
+            tod_ops.gapfill.fill_glitches(
+                aman, signal=aman[self.signal],
+                glitch_flags=glitch_flags,
+                **self.process_cfgs)
+        else:
+            tod_ops.gapfill.fill_glitches(
+                aman, signal=aman[self.signal],
+                **self.process_cfgs)
 
 class FlagTurnarounds(_Preprocess):
     """From the Azimuth encoder data, flag turnarounds, left-going, and right-going.

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -840,18 +840,20 @@ class EstimateAzSS(_Preprocess):
 
 class GlitchFill(_Preprocess):
     """Fill glitches. All process configs go to `fill_glitches`.
+    Notes on flags. If flags are provided as step_cfgs, `proc_aman.get(flags)` is used.
+    If provided as process_cfgs, `aman.get(glitch_flags)` is used instead.
 
     Example configuration block::
 
       - name: "glitchfill"
         signal: "hwpss_remove"
-        flag_aman: "jumps_2pi"
-        flag: "jump_flag"
+        flags: "glitches.glitch_flags" # optional
         process:
           nbuf: 10
           use_pca: False
           modes: 1
           in_place: True
+          glitch_flags: "glitch_flags"
           wrap: None
 
     .. autofunction:: sotodlib.tod_ops.gapfill.fill_glitches
@@ -860,14 +862,13 @@ class GlitchFill(_Preprocess):
 
     def __init__(self, step_cfgs):
         self.signal = step_cfgs.get('signal', 'signal')
-        self.flag_aman = step_cfgs.get('flag_aman')
-        self.flag = step_cfgs.get('flag')
+        self.flags = step_cfgs.get('flags')
 
         super().__init__(step_cfgs)
 
     def process(self, aman, proc_aman):
-        if (self.flag_aman is not None) and (self.flag is not None):
-            glitch_flags=proc_aman[self.flag_aman][self.flag]
+        if self.flags is not None:
+            glitch_flags=proc_aman.get(self.flags)
             tod_ops.gapfill.fill_glitches(
                 aman, signal=aman[self.signal],
                 glitch_flags=glitch_flags,

--- a/sotodlib/tod_ops/azss.py
+++ b/sotodlib/tod_ops/azss.py
@@ -30,8 +30,9 @@ def bin_by_az(aman, signal=None, az=None, range=None, bins=100, flags=None,
         If bins is an int, it defines the number of equal-width bins in the given range (100, by default).
         If bins is a sequence, it defines the bin edges, including the rightmost edge, allowing for non-uniform bin widths.
         If ``bins`` is a sequence, ``bins`` overwrite ``range``.
-    flags: RangesMatrix, optional
+    flags: str or RangesMatrix or Ranges, optional
         Flag indicating whether to exclude flagged samples when binning the signal.
+        If provided by a string, `aman.flags.get(flags)` is used for the flags.
         Default is no mask applied.
     apodize_edges : bool, optional
         If True, applies an apodization window to the edges of the signal. Defaults to True.

--- a/sotodlib/tod_ops/azss.py
+++ b/sotodlib/tod_ops/azss.py
@@ -54,6 +54,8 @@ def bin_by_az(aman, signal=None, az=None, range=None, bins=100, flags=None,
     """
     if apodize_edges:
         weight_for_signal = apodize.get_apodize_window_for_ends(aman, apodize_samps=apodize_edges_samps)
+        if isinstance(flags, str):
+            flags = aman.flags.get(flags)
         if (flags is not None) and apodize_flags:
             flags_mask = flags.mask()
             # check the flags dimension
@@ -66,7 +68,7 @@ def bin_by_az(aman, signal=None, az=None, range=None, bins=100, flags=None,
                     flags_mask = flags_mask[0]
                 else:
                     flag_is_1d = False
-                    
+
             if flag_is_1d:
                 weight_for_signal = weight_for_signal * apodize.get_apodize_window_from_flags(aman, 
                                                                                               flags=flags,
@@ -81,7 +83,7 @@ def bin_by_az(aman, signal=None, az=None, range=None, bins=100, flags=None,
         else:
             weight_for_signal = None
     binning_dict = bin_signal(aman, bin_by=az, signal=signal,
-                               range=range, bins=bins, flags=flags, weight_for_signal=weight_for_signal)
+                              range=range, bins=bins, flags=flags, weight_for_signal=weight_for_signal)
     return binning_dict
 
 def fit_azss(az, azss_stats, max_mode, fit_range=None):

--- a/sotodlib/tod_ops/binning.py
+++ b/sotodlib/tod_ops/binning.py
@@ -3,8 +3,8 @@ import logging
 logger = logging.getLogger(__name__)
 
 def bin_signal(aman, bin_by, signal=None,
-                   range=None, bins=100, flags=None,
-                   weight_for_signal=None):
+               range=None, bins=100, flags=None,
+               weight_for_signal=None):
     """
     Bin time-ordered data by the ``bin_by`` and return the binned signal and its standard deviation.
 
@@ -23,8 +23,9 @@ def bin_signal(aman, bin_by, signal=None,
         If bins is an int, it defines the number of equal-width bins in the given range (100, by default).
         If bins is a sequence, it defines the bin edges, including the rightmost edge, allowing for non-uniform bin widths.
         If `bins` is a sequence, `bins` overwrite `range`.
-    flags : RangesMatrix, optional
+    flags : (str or RangesMatrix or Ranges), optional
         Flag indicating whether to exclude flagged samples when binning the signal.
+        If provided by a string, `aman.flags.get(flags)` is used for the flags.
         Default is no mask applied.
     weight_for_signal : array-like, optional
         Array of weights for the signal values. If None, all weights are assumed to be 1. You can get a apodizing window by
@@ -75,10 +76,11 @@ def bin_signal(aman, bin_by, signal=None,
         binned_signal_sigma[:, mcnts] = np.sqrt(np.abs(binned_signal_squared_mean[:,mcnts] - binned_signal[:,mcnts]**2)
                                       ) / np.sqrt(bin_counts[mcnts])
         bin_counts_dets = np.tile(bin_counts, (aman.dets.count, 1))
-            
+
     else:
         bin_counts_dets = np.full([aman.dets.count, nbins], np.nan)
-
+        if isinstance(flags, str):
+            flags = aman.flags.get(flags)
         if flags.shape == (aman.dets.count, aman.samps.count):
             flag_is_2d = True
             m_2d = ~flags.mask()
@@ -91,7 +93,7 @@ def bin_signal(aman, bin_by, signal=None,
         for i, dets in enumerate(aman.dets.vals):
             if flag_is_2d:
                 m = m_2d[i]
-                
+
             if weight_for_signal.shape == (aman.dets.count, aman.samps.count):
                 weight_for_signal_det = weight_for_signal[i]
             elif weight_for_signal.shape == (aman.samps.count, ):

--- a/sotodlib/tod_ops/gapfill.py
+++ b/sotodlib/tod_ops/gapfill.py
@@ -404,8 +404,9 @@ def fill_glitches(aman, nbuf=10, use_pca=False, modes=3, signal=None,
     signal : ndarray or None
         Array of data to fill glitches in. If None then uses ``aman.signal``.
         Default is None.
-    glitch_flags : RangesMatrix or None
-        RangesMatrix containing flags to use for gap filling. If None then
+    glitch_flags : str or RangesMatrix or None
+        RangesMatrix containing flags to use for gap filling. If provided by
+        a string, ``aman.flags.get(flags)`` is used for the flags. If None then
         uses ``aman.flags.glitches``.
     in_place : bool
         If False it makes a copy of signal before gap filling and returns
@@ -429,9 +430,11 @@ def fill_glitches(aman, nbuf=10, use_pca=False, modes=3, signal=None,
             sig = signal
         else:
             sig = np.copy(signal)
-    
+
     if glitch_flags is None:
         glitch_flags = aman.flags.glitches
+    if isinstance(glitch_flags, str):
+        glitch_flags = aman.flags.get(glitch_flags)
 
     # Polyfill
     gaps = get_gap_fill(aman, nbuf=nbuf, flags=glitch_flags,


### PR DESCRIPTION
These changes make it possible to perform iterative glitch removal and HWPSS removal via the preprocessing module, as follows. I think the changes of default behaviors of GlitchFill can break previous preprocess.yaml which was relying on default parameters, but it should be easy to fix.
```
    - name: "union_flags"
      process:
        flag_labels: ['jumps_2pi.jump_flag', 'glitches.glitch_flags', 'jumps_slow.jump_flag']
        total_flags_label: 'exclude'

    - name: "estimate_hwpss"
      signal: "hwpss_remove"
      calc:
        hwpss_stats_name: "hwpss_stats"
        flags: "exclude"
      save: True

    - name: "subtract_hwpss"
      signal: "signal"
      process:
        subtract_name: "signal"

    - name: "glitchfill"
      signal: "signal"
      skip_on_sim: True  # updated
      process:
        nbuf: 10
        use_pca: False
        modes: 1
        glitch_flags: "exclude"
        wrap: "signal"
```