### PR TITLE
add scan_flags to azss modules

### DIFF
--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -828,7 +828,12 @@ class EstimateAzSS(_Preprocess):
           subtract: True
 
     If we estimate and subtract azss in left going scans only,
-    make union of gltich_flags and scan_flags first then
+    make union of gltich_flags and scan_flags first
+
+      - name : "union_flags"
+        process:
+          flag_labels: ['glitches.glitch_flags', 'turnaround_flags.right_scan']
+          total_flags_label: 'glitch_flags_left'
 
       - name: "estimate_azss"
         calc:
@@ -836,7 +841,7 @@ class EstimateAzSS(_Preprocess):
           azss_stats_name: 'azss_statsQ_left'
           range: [-1.57079, 7.85398]
           bins: 1080
-          flags: 'union of glitch_flags and right_scan (~left_scan)'
+          flags: 'glitch_flags_left'
           scan_flags: 'left_scan'
           merge_stats: False
           merge_model: False

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -873,6 +873,7 @@ class EstimateAzSS(_Preprocess):
                     scan_flags=self.calc_cfgs.get('scan_flags'),
                     method=self.calc_cfgs.get('method'),
                     max_mode=self.calc_cfgs.get('max_mode'),
+                    range=self.calc_cfgs.get('range'),
                     in_place=True
                 )
         else:

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -827,7 +827,8 @@ class EstimateAzSS(_Preprocess):
         process:
           subtract: True
 
-    If we estimate and subtract azss in left going scans only
+    If we estimate and subtract azss in left going scans only,
+    make union of gltich_flags and scan_flags first then
 
       - name: "estimate_azss"
         calc:

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -820,8 +820,24 @@ class EstimateAzSS(_Preprocess):
           azss_stats_name: 'azss_statsQ'
           range: [-1.57079, 7.85398]
           bins: 1080
+          flags: 'glitch_flags'
           merge_stats: False
           merge_model: False
+        save: True
+
+    If we estimate and subtract azss in left going scans only
+
+      - name: "estimate_azss"
+        calc:
+          signal: 'demodQ'
+          azss_stats_name: 'azss_statsQ_left'
+          range: [-1.57079, 7.85398]
+          bins: 1080
+          flags: 'union of glitch_flags and right_scan (~left_scan)'
+          scan_flags: 'left_scan'
+          merge_stats: False
+          merge_model: False
+          subtract_in_place: True
         save: True
 
     .. autofunction:: sotodlib.tod_ops.azss.get_azss
@@ -831,7 +847,7 @@ class EstimateAzSS(_Preprocess):
     def calc_and_save(self, aman, proc_aman):
         calc_aman, _ = tod_ops.azss.get_azss(aman, **self.calc_cfgs)
         self.save(proc_aman, calc_aman)
-    
+
     def save(self, proc_aman, azss_stats):
         if self.save_cfgs is None:
             return

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -823,6 +823,7 @@ class EstimateAzSS(_Preprocess):
           flags: 'glitch_flags'
           merge_stats: False
           merge_model: False
+          subtract_in_place: True
         save: True
         process:
           subtract: True
@@ -875,9 +876,9 @@ class EstimateAzSS(_Preprocess):
                 tod_ops.azss.subtract_azss(
                     aman,
                     proc_aman.get(self.calc_cfgs.get('azss_stats_name')),
-                    signal=self.calc_cfgs.get('signal'),
+                    signal=self.calc_cfgs.get('signal', 'signal'),
                     scan_flags=self.calc_cfgs.get('scan_flags'),
-                    method=self.calc_cfgs.get('method'),
+                    method=self.calc_cfgs.get('method', 'interpolation'),
                     max_mode=self.calc_cfgs.get('max_mode'),
                     range=self.calc_cfgs.get('range'),
                     in_place=True

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -868,12 +868,14 @@ class EstimateAzSS(_Preprocess):
             else:
                 scan_flags = self.calc_cfgs.get('scan_flags')
                 method = self.calc_cfgs.get('method')
+                method = self.calc_cfgs.get('max_mode')
                 tod_ops.azss.subtract_azss(
                     aman,
                     proc_aman.get(self.calc_cfgs.get('azss_stats_name')),
                     signal = self.calc_cfgs.get('signal'),
                     scan_flags=scan_flags,
                     method=method,
+                    max_mode=max_mode,
                     in_place=True
                 )
         else:

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -866,16 +866,13 @@ class EstimateAzSS(_Preprocess):
             if sim:
                 tod_ops.azss.get_azss(aman, **self.calc_cfgs)
             else:
-                scan_flags = self.calc_cfgs.get('scan_flags')
-                method = self.calc_cfgs.get('method')
-                method = self.calc_cfgs.get('max_mode')
                 tod_ops.azss.subtract_azss(
                     aman,
                     proc_aman.get(self.calc_cfgs.get('azss_stats_name')),
-                    signal = self.calc_cfgs.get('signal'),
-                    scan_flags=scan_flags,
-                    method=method,
-                    max_mode=max_mode,
+                    signal=self.calc_cfgs.get('signal'),
+                    scan_flags=self.calc_cfgs.get('scan_flags'),
+                    method=self.calc_cfgs.get('method'),
+                    max_mode=self.calc_cfgs.get('max_mode'),
                     in_place=True
                 )
         else:

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -806,15 +806,16 @@ class Demodulate(_Preprocess):
                                     aman.samps.offset + aman.samps.count - trim))
 
 
-class EstimateAzSS(_Preprocess):
-    """Estimates Azimuth Synchronous Signal (AzSS) by binning signal by azimuth of boresight.
-    All process confgis go to `get_azss`. If `method` is 'interpolate', no fitting applied 
+class AzSS(_Preprocess):
+    """Estimates Azimuth Synchronous Signal (AzSS) by binning signal by azimuth of boresight and subtract.
+    All process confgis go to `get_azss`. If `method` is 'interpolate', no fitting applied
     and binned signal is directly used as AzSS model. If `method` is 'fit', Legendre polynominal
-    fitting will be applied and used as AzSS model.
+    fitting will be applied and used as AzSS model. If `subtract_in_place` is True, subtract AzSS model
+    from signal in place.
 
     Example configuration block::
 
-      - name: "estimate_azss"
+      - name: "azss"
         calc:
           signal: 'demodQ'
           azss_stats_name: 'azss_statsQ'
@@ -836,7 +837,7 @@ class EstimateAzSS(_Preprocess):
           flag_labels: ['glitches.glitch_flags', 'turnaround_flags.right_scan']
           total_flags_label: 'glitch_flags_left'
 
-      - name: "estimate_azss"
+      - name: "azss"
         calc:
           signal: 'demodQ'
           azss_stats_name: 'azss_statsQ_left'
@@ -853,7 +854,7 @@ class EstimateAzSS(_Preprocess):
 
     .. autofunction:: sotodlib.tod_ops.azss.get_azss
     """
-    name = "estimate_azss"
+    name = "azss"
 
     def calc_and_save(self, aman, proc_aman):
         if self.process_cfgs:
@@ -878,7 +879,7 @@ class EstimateAzSS(_Preprocess):
                     proc_aman.get(self.calc_cfgs.get('azss_stats_name')),
                     signal=self.calc_cfgs.get('signal', 'signal'),
                     scan_flags=self.calc_cfgs.get('scan_flags'),
-                    method=self.calc_cfgs.get('method', 'interpolation'),
+                    method=self.calc_cfgs.get('method', 'interpolate'),
                     max_mode=self.calc_cfgs.get('max_mode'),
                     range=self.calc_cfgs.get('range'),
                     in_place=True
@@ -1781,7 +1782,7 @@ _Preprocess.register(EstimateHWPSS)
 _Preprocess.register(SubtractHWPSS)
 _Preprocess.register(Apodize)
 _Preprocess.register(Demodulate)
-_Preprocess.register(EstimateAzSS)
+_Preprocess.register(AzSS)
 _Preprocess.register(GlitchFill)
 _Preprocess.register(FlagTurnarounds)
 _Preprocess.register(SubPolyf)

--- a/sotodlib/tod_ops/azss.py
+++ b/sotodlib/tod_ops/azss.py
@@ -269,7 +269,7 @@ def get_azss(aman, signal='signal', az=None, range=None, bins=100, flags=None, s
     azss_stats.wrap('binned_signal_sigma', binned_signal_sigma, [(0, 'dets'), (1, 'bin_az_samps')])
     azss_stats.wrap('uniform_binned_signal_sigma', uniform_binned_signal_sigma, [(0, 'dets')])
 
-    model_sig_tod = get_model_sig_tod(aman, azss_stats, az, method)
+    model_sig_tod = get_model_sig_tod(aman, azss_stats, az, method, max_mode)
 
     if merge_stats:
         aman.wrap(azss_stats_name, azss_stats)
@@ -280,7 +280,7 @@ def get_azss(aman, signal='signal', az=None, range=None, bins=100, flags=None, s
     return azss_stats, model_sig_tod
 
 
-def get_model_sig_tod(aman, azss_stats, az=None, method='interpolate'):
+def get_model_sig_tod(aman, azss_stats, az=None, method='interpolate', max_mode=None):
     """
     Function to return the azss template for subtraction given the azss_stats AxisManager
     """
@@ -288,14 +288,14 @@ def get_model_sig_tod(aman, azss_stats, az=None, method='interpolate'):
         az = aman.boresight.az
 
     if method == 'fit':
-        if type(azss_stats.max_mode) is not int:
+        if type(max_mode) is not int:
             raise ValueError('max_mode is not provided as integer')
         if 'frange_min' in azss_stats:
             frange = (azss_stats.frange_min, azss_stats.frange_max)
         else:
             frange = None
         azss_stats, model = fit_azss(az=az, azss_stats=azss_stats,
-                                     max_mode=azss_stats.max_mode,
+                                     max_mode=max_mode,
                                      fit_range=frange)
     if method == 'interpolate':
         # mask az bins that has no data and extrapolate
@@ -305,7 +305,7 @@ def get_model_sig_tod(aman, azss_stats, az=None, method='interpolate'):
     return model
 
 
-def subtract_azss(aman, azss_stats, signal='signal', method='interpolate', scan_flags=None,
+def subtract_azss(aman, azss_stats, signal='signal', method='interpolate', max_mode=None, scan_flags=None,
                   subtract_name='azss_remove', in_place=False, remove_template=False):
     """
     Subtract the scan synchronous signal (azss) template from the
@@ -322,6 +322,8 @@ def subtract_azss(aman, azss_stats, signal='signal', method='interpolate', scan_
         Defaults to 'signal'.
     method: str
         The method to use for azss modeling. Options are 'interpolate' and 'fit'.
+    max_mode: integer, optinal
+        The number of Legendre modes to use for azss when method is 'fit'. Required when method is 'fit'.
     scan_flags: str or Ranges, optional
         Subtract in the scan/time region specified by flags.
         Typically `flags.left_scan` or `flags.right_scan` will be used.
@@ -349,7 +351,7 @@ def subtract_azss(aman, azss_stats, signal='signal', method='interpolate', scan_
     else:
         raise TypeError("Signal must be None, str, or ndarray")
 
-    model = get_model_sig_tod(aman, azss_stats, method=method)
+    model = get_model_sig_tod(aman, azss_stats, method=method, max_mode=max_mode)
 
     if scan_flags is None:
         scan_flags = np.ones(aman.samps.count, dtype=bool)

--- a/sotodlib/tod_ops/azss.py
+++ b/sotodlib/tod_ops/azss.py
@@ -106,8 +106,6 @@ def fit_azss(az, azss_stats, max_mode, fit_range=None):
 
     Returns
     -------
-    azss_stats: AxisManager
-        Returns updated azss_stats with added fit information
     model_sig_tod: array-like
         Model fit for each detector size ndets x n_samps
     """
@@ -141,7 +139,7 @@ def fit_azss(az, azss_stats, max_mode, fit_range=None):
     azss_stats.wrap('coeffs', coeffs, [(0, 'dets'), (1, 'azss_modes')])
     azss_stats.wrap('redchi2s', redchi2s, [(0, 'dets')])
 
-    return azss_stats, L.legval(x_legendre, coeffs.T)
+    return L.legval(x_legendre, coeffs.T)
 
 
 def get_azss(aman, signal='signal', az=None, range=None, bins=100, flags=None, scan_flags=None,
@@ -289,9 +287,8 @@ def get_azss_model(aman, azss_stats, az=None, method='interpolate', max_mode=Non
     if method == 'fit':
         if not isinstance(max_mode, int):
             raise ValueError('max_mode is not provided as integer')
-        azss_stats, model = fit_azss(az=az, azss_stats=azss_stats,
-                                     max_mode=max_mode,
-                                     fit_range=range)
+        model = fit_azss(az=az, azss_stats=azss_stats, max_mode=max_mode, fit_range=range)
+
     if method == 'interpolate':
         # mask az bins that has no data and extrapolate
         mask = ~np.any(np.isnan(azss_stats.binned_signal), axis=0)

--- a/sotodlib/tod_ops/azss.py
+++ b/sotodlib/tod_ops/azss.py
@@ -115,31 +115,30 @@ def fit_azss(az, azss_stats, max_mode, fit_range=None):
     m = ~np.isnan(azss_stats.binned_signal[0]) # masks bins without counts
     if np.count_nonzero(m) < max_mode + 1:
         raise ValueError('Number of valid bins is smaller than mode of Legendre function')
-    
+
     if fit_range==None:
-        az_min = np.min(azss_stats.binned_az[m]) - bin_width/2
-        az_max = np.max(azss_stats.binned_az[m]) + bin_width/2
+        az_min = np.min(azss_stats.binned_az[m]) - bin_width / 2
+        az_max = np.max(azss_stats.binned_az[m]) + bin_width / 2
     else:
         az_min, az_max = fit_range[0], fit_range[1]
-    
-    x_legendre = ( 2*az - (az_min+az_max) ) / (az_max - az_min)
-    x_legendre_bin_centers = ( 2*azss_stats.binned_az - (az_min+az_max) ) / (az_max - az_min)
+
+    x_legendre = (2 * az - (az_min+az_max)) / (az_max - az_min)
+    x_legendre_bin_centers = (2 * azss_stats.binned_az - (az_min+az_max)) / (az_max - az_min)
     x_legendre_bin_centers = np.where(~m, np.nan, x_legendre_bin_centers)
-    
-    mode_names = []
-    for mode in range(max_mode+1):
-        mode_names.append(f'legendre{mode}')
-    
+
     coeffs = L.legfit(x_legendre_bin_centers[m], azss_stats.binned_signal[:, m].T, max_mode)
     coeffs = coeffs.T
     binned_model = L.legval(x_legendre_bin_centers, coeffs.T)
     binned_model = np.where(~m, np.nan, binned_model)
-    sum_of_squares = np.sum(((azss_stats.binned_signal[:, m] - binned_model[:,m])**2), axis=-1)
-    redchi2s = sum_of_squares/azss_stats.uniform_binned_signal_sigma**2 / ( len(x_legendre_bin_centers[m]) - max_mode - 1)
-    
+    sum_of_squares = np.sum(((azss_stats.binned_signal[:, m] - binned_model[:, m])**2), axis=-1)
+    redchi2s = sum_of_squares/azss_stats.uniform_binned_signal_sigma**2 / (len(x_legendre_bin_centers[m]) - max_mode - 1)
+
+    mode_names = np.array([f'legendre{mode}' for mode in range(max_mode + 1)], dtype='<U10')
+    modes_axis = core.LabelAxis(name='azss_modes', vals=mode_names)
+    azss_stats.add_axis(modes_axis)
     azss_stats.wrap('binned_model', binned_model, [(0, 'dets'), (1, 'bin_az_samps')])
     azss_stats.wrap('x_legendre_bin_centers', x_legendre_bin_centers, [(0, 'bin_az_samps')])
-    azss_stats.wrap('coeffs', coeffs, [(0, 'dets'), (1, core.LabelAxis(name='modes', vals=np.array(mode_names, dtype='<U10')))])
+    azss_stats.wrap('coeffs', coeffs, [(0, 'dets'), (1, 'azss_modes')])
     azss_stats.wrap('redchi2s', redchi2s, [(0, 'dets')])
 
     return azss_stats, L.legval(x_legendre, coeffs.T)
@@ -269,7 +268,7 @@ def get_azss(aman, signal='signal', az=None, range=None, bins=100, flags=None, s
     azss_stats.wrap('binned_signal_sigma', binned_signal_sigma, [(0, 'dets'), (1, 'bin_az_samps')])
     azss_stats.wrap('uniform_binned_signal_sigma', uniform_binned_signal_sigma, [(0, 'dets')])
 
-    model_sig_tod = get_model_sig_tod(aman, azss_stats, az, method, max_mode, range)
+    model_sig_tod = get_azss_model(aman, azss_stats, az, method, max_mode, range)
 
     if merge_stats:
         aman.wrap(azss_stats_name, azss_stats)
@@ -280,7 +279,7 @@ def get_azss(aman, signal='signal', az=None, range=None, bins=100, flags=None, s
     return azss_stats, model_sig_tod
 
 
-def get_model_sig_tod(aman, azss_stats, az=None, method='interpolate', max_mode=None, range=None):
+def get_azss_model(aman, azss_stats, az=None, method='interpolate', max_mode=None, range=None):
     """
     Function to return the azss template for subtraction given the azss_stats AxisManager
     """
@@ -288,7 +287,7 @@ def get_model_sig_tod(aman, azss_stats, az=None, method='interpolate', max_mode=
         az = aman.boresight.az
 
     if method == 'fit':
-        if type(max_mode) is not int:
+        if not isinstance(max_mode, int):
             raise ValueError('max_mode is not provided as integer')
         azss_stats, model = fit_azss(az=az, azss_stats=azss_stats,
                                      max_mode=max_mode,
@@ -349,7 +348,7 @@ def subtract_azss(aman, azss_stats, signal='signal', method='interpolate', max_m
     else:
         raise TypeError("Signal must be None, str, or ndarray")
 
-    model = get_model_sig_tod(aman, azss_stats, method=method, max_mode=max_mode, fit_range=range)
+    model = get_azss_model(aman, azss_stats, method=method, max_mode=max_mode, range=range)
 
     if scan_flags is None:
         scan_flags = np.ones(aman.samps.count, dtype=bool)


### PR DESCRIPTION
I propose this way of estimation and subtraction of azss in left_going scans and right_going scans separately.
Also fixed the azss extrapolation at the boundaries of subscans. This resolves the glitches near turnarounds induced by azss subtraction.
I tested updated individual functions and a proprocess module.