### PR TITLE
sqlite3: remove double-quoted string literals

### DIFF
--- a/docs/context.rst
+++ b/docs/context.rst
@@ -1545,7 +1545,7 @@ few queries::
   >>> obsdb.query('hwp_speed >= 2.')
   ResultSet<[obs_id,timestamp,hwp_speed], 1 rows>
 
-  >>> obsdb.query('hwp_speed > 1. and drift=="rising"')
+  >>> obsdb.query("hwp_speed > 1. and drift=='rising'")
   ResultSet<[obs_id,timestamp,hwp_speed], 1 rows>
 
 The object returned by obsdb.query is a :py:obj:`ResultSet`, from
@@ -1579,7 +1579,7 @@ end of some of the tag strings::
 
 Alternately, the values of tags can be used in query strings::
 
-  >>> obsdb.query('(hwp_fast==1 and drift=="rising") or (hwp_fast==0 and drift="setting")',
+  >>> obsdb.query("(hwp_fast==1 and drift=='rising') or (hwp_fast==0 and drift='setting')",
     tags=['hwp_fast'])
   ResultSet<[obs_id,timestamp,hwp_speed,drift,hwp_fast], 2 rows>
     

--- a/sotodlib/core/metadata/manifest.py
+++ b/sotodlib/core/metadata/manifest.py
@@ -828,7 +828,7 @@ def main(args=None):
         print('   ' + '-' * (len(hdr) - 3))
         for row in schema:
             if row['purpose'] == 'out':
-                count = len(db.conn.execute('select distinct "%s" from map' % row['field']).fetchall())
+                count = len(db.conn.execute('select distinct `%s` from map' % row['field']).fetchall())
                 print(fmt.format(count=count, **row))
         file_count = db.conn.execute('select count(id) from files').fetchone()[0]
         print(fmt.format(
@@ -923,8 +923,8 @@ def main(args=None):
             db = ManifestDb.from_file(args.filename, force_new_db=True)
 
         # Get all files matching this prefix ...
-        c = db.conn.execute('select id, name from files '
-                            'where name like "%s%%"' % (args.old_prefix))
+        c = db.conn.execute("select id, name from files "
+                            "where name like '%s%%'" % (args.old_prefix))
         rows = c.fetchall()
         print('Found %i records matching prefix ...'
                % len(rows))

--- a/sotodlib/core/metadata/manifest.py
+++ b/sotodlib/core/metadata/manifest.py
@@ -828,7 +828,7 @@ def main(args=None):
         print('   ' + '-' * (len(hdr) - 3))
         for row in schema:
             if row['purpose'] == 'out':
-                count = len(db.conn.execute('select distinct `%s` from map' % row['field']).fetchall())
+                count = len(db.conn.execute("select distinct `%s` from map" % row['field']).fetchall())
                 print(fmt.format(count=count, **row))
         file_count = db.conn.execute('select count(id) from files').fetchone()[0]
         print(fmt.format(

--- a/sotodlib/core/metadata/obsdb.py
+++ b/sotodlib/core/metadata/obsdb.py
@@ -117,7 +117,7 @@ class ObsDb(object):
             'timestamp float, drift str'
 
         """
-        current_cols = self.conn.execute('pragma table_info("obs")').fetchall()
+        current_cols = self.conn.execute('pragma table_info(obs)').fetchall()
         current_cols = [r[1] for r in current_cols]
         if isinstance(column_defs, str):
             column_defs = column_defs.split(',')
@@ -241,7 +241,7 @@ class ObsDb(object):
         """
         if obs_id is None:
             return self.query('1', add_prefix=add_prefix)
-        results = self.query(f'obs_id="{obs_id}"', add_prefix=add_prefix)
+        results = self.query(f"obs_id='{obs_id}'", add_prefix=add_prefix)
         if len(results) == 0:
             return None
         if len(results) > 1:
@@ -302,16 +302,16 @@ class ObsDb(object):
                     val = None
                 if val is None:
                     join_type = 'left join'
-                    extra_fields.append(f'ifnull(tt{tagi}.obs_id,"") != "" as {t}')
+                    extra_fields.append(f"ifnull(tt{tagi}.obs_id,'') != '' as {t}")
                 elif val == '0':
                     join_type = 'left join'
-                    extra_fields.append(f'ifnull(tt{tagi}.obs_id,"") != "" as {t}')
+                    extra_fields.append(f"ifnull(tt{tagi}.obs_id,'') != '' as {t}")
                     query_text += f' and {t}==0'
                 else:
                     join_type = 'join'
                     extra_fields.append(f'1 as {t}')
-                joins += (f' {join_type} (select distinct obs_id from tags where tag="{t}") as tt{tagi} on '
-                          f'obs.obs_id = tt{tagi}.obs_id')
+                joins += (f" {join_type} (select distinct obs_id from tags where tag='{t}') as tt{tagi} on "
+                          f"obs.obs_id = tt{tagi}.obs_id")
         extra_fields = ''.join([','+f for f in extra_fields])
         q = 'select obs.* %s from obs %s where %s %s' % (extra_fields, joins, query_text, sort_text)
         c = self.conn.execute(q)

--- a/sotodlib/core/metadata/obsfiledb.py
+++ b/sotodlib/core/metadata/obsfiledb.py
@@ -161,8 +161,8 @@ class ObsFileDb:
     def _get_version(self, conn=None):
         if conn is None:
             conn = self.conn
-        rows = conn.execute('select value from meta where '
-                            'param="obsfiledb_version"').fetchall()
+        rows = conn.execute("select value from meta where "
+                            "param='obsfiledb_version'").fetchall()
         if len(rows) == 0:
             return None
         return int(rows[0][0])

--- a/tests/test_obsdb.py
+++ b/tests/test_obsdb.py
@@ -38,7 +38,6 @@ class TestObsDb(unittest.TestCase):
         """Basic functionality."""
         db = get_example()
         all_obs = db.query()
-        db.get(all_obs[0])
         db.get(all_obs[0]['obs_id'])
         db.query('timestamp > 0')
         db.query('timestamp > 0', tags=['cryo_problem=1'])


### PR DESCRIPTION
This is enforced starting at sqlite3.sqlite_version 3.49.1 or so.

Resolves #1119 