### PR TITLE
Implementing units for fits maps

### DIFF
--- a/sotodlib/mapmaking/ml_mapmaker.py
+++ b/sotodlib/mapmaking/ml_mapmaker.py
@@ -445,16 +445,16 @@ class SignalMap(Signal):
             else:
                 return putils.allreduce(map, self.comm)
 
-    def write(self, prefix, tag, m):
+    def write(self, prefix, tag, m, unit='K'):
         if not self.output:
             return
         oname = self.ofmt.format(name=self.name)
         oname = "%s%s_%s.%s" % (prefix, oname, tag, self.ext)
         if self.tiled:
-            tilemap.write_map(oname, m, self.comm)
+            tilemap.write_map(oname, m, self.comm, extra={'BUNIT':unit})
         else:
             if self.comm is None or self.comm.rank == 0:
-                enmap.write_map(oname, m)
+                enmap.write_map(oname, m, extra={'BUNIT':unit})
         return oname
 
     def _checkcompat(self, other):

--- a/sotodlib/site_pipeline/make_atomic_filterbin_map.py
+++ b/sotodlib/site_pipeline/make_atomic_filterbin_map.py
@@ -84,6 +84,8 @@ class Cfg:
         Run a specific wafer
     freq: str
         Run a specific frequency band
+    unit: str
+        Unit of data. Default is K
     center_at: str
     max_dets: int
     fixed_time: int
@@ -130,7 +132,8 @@ class Cfg:
         quiet: int = 0,
         window: Optional[float] = None,
         dtype_tod: str = 'float32',
-        dtype_map: str = 'float64'
+        dtype_map: str = 'float64',
+        unit: str = 'K'
     ) -> None:
         self.context = context
         self.preprocess_config = preprocess_config
@@ -165,6 +168,7 @@ class Cfg:
         self.window = window
         self.dtype_tod = dtype_tod
         self.dtype_map = dtype_map
+        self.unit = unit
     @classmethod
     def from_yaml(cls, path) -> "Cfg":
         with open(path, "r") as f:
@@ -448,7 +452,7 @@ def main(
             verbose=verbose,
             split_labels=split_labels,
             singlestream=args.singlestream,
-            site=args.site,
+            site=args.site, unit=args.unit,
             atomic_db=args.atomic_db) for r in run_list]
     for future in as_completed_callable(futures):
         L.info('New future as_completed result')

--- a/sotodlib/site_pipeline/make_ml_map.py
+++ b/sotodlib/site_pipeline/make_ml_map.py
@@ -30,6 +30,7 @@ defaults = {"query": "1",
             "maxiter": 500,
             "tiled": 1,
             "wafer": None,
+            "unit": "K",
            }
 
 def get_parser(parser=None):
@@ -63,6 +64,7 @@ def get_parser(parser=None):
     parser.add_argument(      "--maxiter",    type=int, help="Maximum number of iterative steps")
     parser.add_argument("-T", "--tiled"  ,    type=int)
     parser.add_argument("-W", "--wafer"  ,   type=str, nargs='+', help="Detector wafer subset to map with")
+    parser.add_argument("-u", "--unit"   ,  type=str, help="Units of data. Default is K")
     return parser
 
 
@@ -288,9 +290,9 @@ def main(config_file=None, defaults=defaults, **args):
 
     L.info("Done preparing")
 
-    signal_map.write(prefix, "rhs", signal_map.rhs)
-    signal_map.write(prefix, "div", signal_map.div)
-    signal_map.write(prefix, "bin", enmap.map_mul(signal_map.idiv, signal_map.rhs))
+    signal_map.write(prefix, "rhs", signal_map.rhs, unit=args['unit']+'^-1')
+    signal_map.write(prefix, "div", signal_map.div, unit=args['unit']+'^-2')
+    signal_map.write(prefix, "bin", enmap.map_mul(signal_map.idiv, signal_map.rhs), unit=args['unit'])
 
     L.info("Wrote rhs, div, bin")
 
@@ -302,13 +304,13 @@ def main(config_file=None, defaults=defaults, **args):
         if dump:
             for signal, val in zip(signals, step.x):
                 if signal.output:
-                    signal.write(prefix, "map%04d" % step.i, val)
+                    signal.write(prefix, "map%04d" % step.i, val, unit=args['unit'])
         t1 = time.time()
 
     L.info("Done")
     for signal, val in zip(signals, step.x):
         if signal.output:
-            signal.write(prefix, "map", val)
+            signal.write(prefix, "map", val, unit=args['unit'])
     comm.Barrier()
 
 


### PR DESCRIPTION
This adds the writing of units into the fits keyword BUNIT for maps produced by the ML and atomic-filterbin mapmakers. It requires the latest branch of pixell. 