### PR TITLE
check-book/load-book: handle case where obsfiledb detset is just a bounding set

### DIFF
--- a/sotodlib/core/metadata/obsfiledb.py
+++ b/sotodlib/core/metadata/obsfiledb.py
@@ -186,11 +186,12 @@ class ObsFileDb:
         self.conn.commit()
 
     def add_detset(self, detset_name, detector_names, commit=True):
-        """Add a detset to the detsets table.
+        """Add a detset to the detsets table (by adding detectors with
+        specific names to it).
 
         Arguments:
-          detset_name (str): The (unique) name of this detset.
-          detector_names (list of str): The detectors belonging to
+          detset_name (str): The name of the detset.
+          detector_names (list of str): New detectors belonging to
             this detset.
 
         """


### PR DESCRIPTION
Two fixes needed:
- when updating obsfiledb, allow a detset to expand.
- when loading books, accept that obs might not have all the dets that listed in obsfiledb detset.

Tested on:
```
oper_1741050783_satp1_0010000
oper_1741051126_satp1_0010000
oper_1741115973_satp1_0100000
oper_1741116451_satp1_0100000
```

Resolves #1136 .  Once this is merged I can update site obsfiledb with new dets, and also add the obsfiledb index from #1127 .