### PR TITLE
Preprocess method for HWPSS A2 stats

### DIFF
--- a/sotodlib/tod_ops/flags.py
+++ b/sotodlib/tod_ops/flags.py
@@ -901,7 +901,7 @@ def get_stats(aman, signal, stat_names, split_subscans=False, mask=None, name="s
         Name of axis manager to add to aman if merge is True.
     """
     stat_names = np.atleast_1d(stat_names)
-    fn_dict = {'mean': np.mean, 'median': np.median, 'ptp': np.ptp, 'std': np.std,
+    fn_dict = {'mean': np.mean, 'median': np.median, 'ptp': np.ptp, 'std': np.std, 'var': np.var,
                      'kurtosis': stats.kurtosis, 'skew': stats.skew}
 
     if isinstance(signal, str):


### PR DESCRIPTION
Addresses #985

Use `hwp.demod_tod` to demodulate the 2nd HWP harmonic and compute statistics on the demodulated timestream.

The current implementation runs into a name conflict if `hwp.demod_tod` has previously been called, since the field names “dsT”, “demodQ”, and “demodU” are hardcoded. Short of changing that function, one possible solution might be to make a copy of the AxisManager with those fields removed, but making a copy of the data on RAM is not ideal.

Suggestions welcome.