### PR TITLE
numpy 2 compatibility fixes

### DIFF
--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -2036,7 +2036,7 @@ def make_DetDb_single_obs(obsfiledb, obs_id):
         len(ch_list),
         dtype=[
             ("idx", int),
-            ("rchannel", np.unicode_, 30),
+            ("rchannel", np.str_, 30),
             ("band", int),
             ("channel", int),
             ("freqs", float),
@@ -2755,7 +2755,7 @@ def get_channel_info(
         len(ch_list),
         dtype=[
             ("idx", int),
-            ("rchannel", np.unicode_, 30),
+            ("rchannel", np.str_, 30),
             ("band", int),
             ("channel", int),
             ("freqs", float),

--- a/sotodlib/preprocess/preprocess_plot.py
+++ b/sotodlib/preprocess/preprocess_plot.py
@@ -154,7 +154,7 @@ def plot_hwpss_fit_status(aman, hwpss_stats, plot_dets=None, plot_num_dets=3,
         plot_dets_idx = np.arange(0, hwpss_stats.dets.count, plot_step).astype(int)
         plot_dets = hwpss_stats.dets.vals[plot_dets_idx]
     else:
-        plot_dets_idx = np.where(np.in1d(hwpss_stats.dets.vals, plot_dets))[0]
+        plot_dets_idx = np.where(np.isin(hwpss_stats.dets.vals, plot_dets))[0]
 
     for i, det_idx in enumerate(plot_dets_idx):
         ax[0].errorbar(hwpss_stats.binned_angle, hwpss_stats.binned_signal[det_idx], yerr=hwpss_stats.sigma_bin[det_idx],


### PR DESCRIPTION
These are numpy 2 compatibility issues:

https://numpy.org/doc/stable/reference/generated/numpy.in1d.html



The `unicode_` is deprecated and removed. Numpy says to use `str_` instead.