### PR TITLE
Obs wafer band in obsdb

### DIFF
--- a/sotodlib/core/metadata/obsdb.py
+++ b/sotodlib/core/metadata/obsdb.py
@@ -80,6 +80,9 @@ class ObsDb(object):
             if map_file is None:
                 map_file = ':memory:'
             self.conn = sqlite3.connect(map_file)
+        
+        global TABLE_DEFS
+        global TABLE_DEFS_OWB
         if obs_wafer_band:
             TABLE_DEFS = TABLE_DEFS_OWB
 


### PR DESCRIPTION
This is an update to obsdb to allow storing information keyed by obs-wafer-band without breaking the current obs-id primary key behavior and allowing us to retrieve common entries for an obs-id between 2 databases that could be keyed by obs-wafer-band or obsid.