### PR TITLE
Pointing model quat.deconstruct_lonlat issue

### DIFF
--- a/sotodlib/coords/pointing_model.py
+++ b/sotodlib/coords/pointing_model.py
@@ -196,13 +196,11 @@ def model_sat_v1(params, az, el, roll):
             * q_fp_offset * ~q_fp_rot * quat.euler(2, roll) * q_fp_rot)
 
     neg_az, el, roll = quat.decompose_lonlat(q_hs)
-    
-    if np.any((-neg_az - az_orig) > 2*np.pi):
-        new_az = -neg_az - 2*np.pi
-    elif np.any((-neg_az - az_orig) < -2*np.pi):
-        new_az = -neg_az + 2*np.pi
-    else:
-        new_az = -neg_az
+
+    # Make corrected az as close as possible to the input az.
+    change = ((-neg_az - az_orig) + np.pi) % (2 * np.pi) - np.pi
+    new_az = az_orig + change
+
     return new_az, el, roll
 
 

--- a/sotodlib/coords/pointing_model.py
+++ b/sotodlib/coords/pointing_model.py
@@ -175,7 +175,7 @@ def model_sat_v1(params, az, el, roll):
             raise ValueError(f'Handling of model param "{k}" is not implemented.')
 
     # Construct offsetted encoders.
-    az_spot_test = az.copy()
+    az_orig = az.copy()
     az_twist = params['az_rot'] * (el + params['enc_offset_el'])
     az = az + params['enc_offset_az'] + az_twist
     el = el + params['enc_offset_el'] 
@@ -197,10 +197,10 @@ def model_sat_v1(params, az, el, roll):
 
     neg_az, el, roll = quat.decompose_lonlat(q_hs)
     
-    if np.any((-1*neg_az - az_spot_test) > 2*np.pi):
-        new_az = -1 * neg_az - 2*np.pi
-    elif np.any((-1*neg_az - az_spot_test) < -2*np.pi):
-        new_az = -1 * neg_az + 2*np.pi
+    if np.any((-neg_az - az_orig) > 2*np.pi):
+        new_az = -neg_az - 2*np.pi
+    elif np.any((-neg_az - az_orig) < -2*np.pi):
+        new_az = -neg_az + 2*np.pi
     else:
         new_az = -neg_az
     return new_az, el, roll

--- a/sotodlib/coords/pointing_model.py
+++ b/sotodlib/coords/pointing_model.py
@@ -175,6 +175,7 @@ def model_sat_v1(params, az, el, roll):
             raise ValueError(f'Handling of model param "{k}" is not implemented.')
 
     # Construct offsetted encoders.
+    az_spot_test = az.copy()
     az_twist = params['az_rot'] * (el + params['enc_offset_el'])
     az = az + params['enc_offset_az'] + az_twist
     el = el + params['enc_offset_el'] 
@@ -195,7 +196,14 @@ def model_sat_v1(params, az, el, roll):
             * q_fp_offset * ~q_fp_rot * quat.euler(2, roll) * q_fp_rot)
 
     neg_az, el, roll = quat.decompose_lonlat(q_hs)
-    return -neg_az, el, roll
+    
+    if np.any((-1*neg_az - az_spot_test) > 2*np.pi):
+        new_az = -1 * neg_az - 2*np.pi
+    elif np.any((-1*neg_az - az_spot_test) < -2*np.pi):
+        new_az = -1 * neg_az + 2*np.pi
+    else:
+        new_az = -neg_az
+    return new_az, el, roll
 
 
 # Support functions


### PR DESCRIPTION
I am making this PR in response to issue #1158 raised by Kyohei. I have added the following to the end of the pointing_model.model_sat_v1 function to add or subtract 2 pi from the azimuth values if any of them are off by over 2pi from what is expected. However if not all of the azimuth values have the same issue, perhaps this should be changed to a np.all() or make changes to individual values instead of all the tod. 
```
    neg_az, el, roll = quat.decompose_lonlat(q_hs)
    
    if np.any((-neg_az - az_orig) > 2*np.pi):
        new_az = -neg_az - 2*np.pi
    elif np.any((-neg_az - az_orig) < -2*np.pi):
        new_az = -neg_az + 2*np.pi
    else:
        new_az = -neg_az
    return new_az, el, roll
```

