### PR TITLE
hkdb updates -- note some API changes

### DIFF
--- a/docs/hkdb.rst
+++ b/docs/hkdb.rst
@@ -1,7 +1,8 @@
+.. py:module:: sotodlib.io.hkdb
 
-==============================
-Loading L3 Houskeeping Data
-==============================
+============================
+Loading L3 Housekeeping Data
+============================
 
 The ``sotodlib.io.hkdb`` module provides methods for indexing, and quickly
 loading housekeeping data from an archive.
@@ -9,7 +10,7 @@ The databases implemented store the following information:
 
 - List of all housekeeping files, with start and stop times
 - List of every frame in the file, with the start and stop times of each frame,
-  agent instance-id, and the byte-offset of the frame in the file.
+  agent instance-id, feed name, and the byte-offset of the frame in the file.
 
 To index and load housekeeping information, you will need to create a
 ``HkConfig`` object, documented in the API section below. For example, the
@@ -65,8 +66,9 @@ hk data has already been indexed.
 
 Loading Data
 ---------------
-To load data from the hk archive, you can pass a ``LoadSpec`` object to the
-``load_hk`` function, which defines the time range and fields to load.
+To load data from the hk archive, you can pass a :class:`LoadSpec`
+object to the :func:`load_hk` function, which defines the time range
+and fields to load.
 
 For example, the code below will load the focal-plane temp for the last week:
 
@@ -82,18 +84,19 @@ For example, the code below will load the focal-plane temp for the last week:
     )
     result = hkdb.load_hk(lspec, show_pb=True)
 
-The result object will be an HkResult object, where ``result.data`` contains the
-mapping from field-id to a numpy array of shape (2, nsamp), where the first
-entry are the timestamps, and the second entry are the data values.  If any of
-the requested fields have an alias defined in the ``cfg`` object, that alias
-will be set as an attribute in the HkResult object:
+The result object will be an :class:`HkResult` object, where
+``result.data`` contains the mapping from field-id to a tuple of two
+numpy arrays.  The first array is the timestamps and the second array
+is data values.  If any of the requested fields have an alias defined
+in the ``cfg`` object, that alias will be set as an attribute in the
+HkResult object:
 
 .. code-block:: python
 
-    >> print(result.data['cryo-ls372-lsa21yc.temperatures.Channel_02_T'].shape)
-    (2, 4160195)
-    >> print(result.fp_temp)  # same exact thing as above
-    (2, 4160195)
+    >> print(result.data['cryo-ls372-lsa21yc.temperatures.Channel_02_T'][0].shape)
+    (4160195)
+    >> print(result.fp_temp[0].shape)  # same exact thing as above
+    (4160195)
     >> plt.plot(*result.fp_temp)  # plots focal-plane temp
 
 The ``fields`` argument to ``LoadSpec`` is a list of field-specifications, which
@@ -129,9 +132,28 @@ For example, you can run:
     >> (2, 4157762)
 
 
+Inspecting Data
+---------------
+
+To determine what feeds (agent and feed combinations) are available in
+a database, use the :func:`get_feed_list` function.  For example:
+
+.. code-block:: python
+
+    feeds = hkdb.get_feed_list(lspec)
+    print(feeds)
+    >> [Field(agent='acu', feed='acu_error', field='*'),
+        Field(agent='acu', feed='acu_status', field='*'),
+        Field(agent='acu', feed='acu_udp_stream', field='*'),
+        ...]
+
+
+It is currently not easy to get a list of available fields.
+
+
 API
 -------
 .. automodule:: sotodlib.io.hkdb
-   :members: HkConfig, HkDb, LoadSpec, load_hk, HkResult
+   :members:
    :undoc-members:
    :show-inheritance:

--- a/sotodlib/site_pipeline/update_hkdb.py
+++ b/sotodlib/site_pipeline/update_hkdb.py
@@ -2,9 +2,11 @@
 Script for calling hkdb update function with a configuration file
 """
 from sotodlib.io import hkdb
+from sotodlib.site_pipeline import util
 
 def main(cfg_file: str):
     """Updates hkdb index databases"""
+    util.init_logger('', logger=hkdb.log)
     hkdb.update_index_all(cfg_file)
 
 if __name__ == "__main__":

--- a/sotodlib/site_pipeline/util.py
+++ b/sotodlib/site_pipeline/util.py
@@ -285,13 +285,14 @@ class _ReltimeFormatter(logging.Formatter):
             datefmt = '%8.3f'
         return datefmt % (record.created - self.start_time)
 
-def init_logger(name, announce='', verbosity=2):
+def init_logger(name, announce='', verbosity=2, logger=None):
     """Configure and return a logger for site_pipeline elements.  It is
     disconnected from general sotodlib (propagate=False) and displays
     relative instead of absolute timestamps.
 
     """
-    logger = logging.getLogger(name)
+    if logger is None:
+        logger = logging.getLogger(name)
 
     if verbosity == 0:
         level = logging.ERROR

--- a/tests/test_hkdb.py
+++ b/tests/test_hkdb.py
@@ -92,3 +92,5 @@ class HkDbTest(unittest.TestCase):
 
         self.assertEqual(len(res.test[0]), nsamp)
 
+        feeds = hkdb.get_feed_list(load_spec)
+        self.assertEqual(feeds, ['test_agent.test_feed.*'])


### PR DESCRIPTION
- Each result item is a tuple of arrays, not a (2, n) array.
- Empty datasets are returned as a tuple of 0-len arrays.
- New args to load_hk for fine-tuning fields and times.
- New function get_feed_list, for inspecting db.
- "subdirs" option to make scanning hk archive subsets easier.
- Update docs for new function; add more links; more autodoc.

cf #1163 

"round2" of changes, coming later, will include a change in db schema that makes it possible to retrieve a field list without tooooo much G3 file reading.