### PR TITLE
add functions for making detector-centered coordinate system.

### DIFF
--- a/sotodlib/coords/planets.py
+++ b/sotodlib/coords/planets.py
@@ -247,8 +247,7 @@ def get_each_detcen_P(tod, az, el, sight=None, boresight_centered=False, **kw):
         sight = so3g.proj.CelestialSightLine.for_horizon(tod.timestamps, tod.boresight.az, tod.boresight.el, roll= tod.boresight.roll)
     pq = so3g.proj.quat.rotation_lonlat(-az, el)
 
-    # xieta quaternion for a given detector
-    xieta_gamma0 = so3g.proj.quat.rotation_xieta(tod.focal_plane.xi[0],tod.focal_plane.eta[0],0) # assumed axis manager include one detector
+    xieta_gamma0 = so3g.proj.quat.rotation_xieta(tod.focal_plane.xi[0],tod.focal_plane.eta[0],0) # assumed axis manager include one detector.
     if boresight_centered:
         detQ = ~sight.Q * pq # fixed Boresight center instead of detector center
     else:


### PR DESCRIPTION
This PR adds functions for making maps in detector-centered coordinate system that is useful for beam characterization.
I confirmed `get_each_detcen_P ` and `calc_detcen_coadd_maps` woking properly with Jupiter observation (after pre-process applied).
Current version need to execute `get_each_detcen_P` every single detector and then coadded them.
In addition, prior to `get_each_detcen_P` planet az/el needs to be calculated.
It took roughly 3min for 148 detectors with map size of 2deg and map resolution of 2arcmin.