### PR TITLE
Fix downsampling comparison

### DIFF
--- a/sotodlib/site_pipeline/make_ml_map.py
+++ b/sotodlib/site_pipeline/make_ml_map.py
@@ -247,7 +247,7 @@ def main(**args):
                     mapmaking.inject_map(obs, map_to_inject, recenter=recenter, interpol=args.interpol)
                 utils.deslope(obs.signal, w=5, inplace=True)
 
-                if args.downsample != 1:
+                if passinfo.downsample != 1:
                     obs = mapmaking.downsample_obs(obs, passinfo.downsample)
 
                 # Maybe load precomputed noise model.


### PR DESCRIPTION
`args.downsample` is a string of comma-separated values, and this comparison will always be true. Changing it to `passinfo` checks against an integer and specifically of the current iteration