### PR TITLE
update_obsdb: exclude NONE dets (fixed tones) from detsets

### DIFF
--- a/sotodlib/site_pipeline/check_book.py
+++ b/sotodlib/site_pipeline/check_book.py
@@ -118,7 +118,7 @@ def scan_book_dir(book_dir, logger, config, prep_obsfiledb=False):
     (Note this function is used by update-obsdb, as well.)
     """
     logger.info(f'Examining {book_dir}')
-    bs = check_book.BookScanner(book_dir, config)
+    bs = check_book.BookScanner(book_dir, config, logger=logger)
 
     bs.go()
     bs.report()
@@ -128,7 +128,7 @@ def scan_book_dir(book_dir, logger, config, prep_obsfiledb=False):
         return False, None
 
     if prep_obsfiledb:
-        detset_rows, file_rows = bs.prep_obsfiledb(config.get('root_path', '/'))
+        detset_rows, file_rows = bs.get_obsfiledb_info(config.get('root_path', '/'))
         return True, {
             'detset_rows': detset_rows,
             'file_rows': file_rows,


### PR DESCRIPTION
This was sort of done in io.check_book, but that code segment wasn't called from update_obsdb / site_pipeline.check_book.  Now io.check_book never releases the names of the fixed tones.  The "remove_fixed_tones" work-around setting is removed, since we just always want to remove them.