### PR TITLE
Remove extra deslopes

### DIFF
--- a/sotodlib/site_pipeline/make_ml_map.py
+++ b/sotodlib/site_pipeline/make_ml_map.py
@@ -192,7 +192,6 @@ def main(**args):
                 # Desolope to make it periodic. This should be done *before*
                 # dropping to single precision, to avoid unnecessary loss of precision due
                 # to potential high offses in the raw tod.
-                utils.deslope(obs.signal, w=5, inplace=True)
                 obs.signal = obs.signal.astype(dtype_tod)
 
                 if "flags" not in obs:
@@ -245,7 +244,6 @@ def main(**args):
                 # the main mapmaking.
                 if args.inject:
                     mapmaking.inject_map(obs, map_to_inject, recenter=recenter, interpol=args.interpol)
-                utils.deslope(obs.signal, w=5, inplace=True)
 
                 if passinfo.downsample != 1:
                     obs = mapmaking.downsample_obs(obs, passinfo.downsample)


### PR DESCRIPTION
These deslopes are probably unnecessary, based on a discussion with @amaurea , @chervias , and @keskitalo. The mapmaker `add_obs` also does a deslope.

However based on the comment on line 192, we may have to keep it.