### PR TITLE
hkdb changes -- includes schema update

### DIFF
--- a/docs/hkdb.rst
+++ b/docs/hkdb.rst
@@ -148,7 +148,13 @@ a database, use the :func:`get_feed_list` function.  For example:
         ...]
 
 
-It is currently not easy to get a list of available fields.
+To get a list of all fields, use :func:`get_field_list`.  E.g.:
+
+.. code-block:: python
+
+    fields = hkdb.get_field_list(lspec, fields=['acu.*.*Az*'])
+    print(len(fields), fields[0])
+    >> 61 acu.acu_status.Azimuth_current_position
 
 
 API

--- a/tests/test_hkdb.py
+++ b/tests/test_hkdb.py
@@ -40,20 +40,36 @@ def write_hk(filepath):
     data = np.zeros(len(times), dtype=float)
     frame_idxs = (times - t0) // frame_len
 
-    prov_address = 'site.test_agent.feeds.test_feed'
-    prov_session_id = int(time.time())
+    prov1 = {
+        'addr': 'site.test_agent.feeds.test_feed',
+        'session_id': int(time.time()),
+    }
+    prov2 = {
+        'addr': 'site.weird_agent.feeds.misc_feed',
+        'session_id': int(time.time() + 5)
+    }
+
+    def hk_frame(prov, times, data, block_name='test_block'):
+        frame = hksess.data_frame(0)
+        tsmap = core.G3TimesampleMap()
+        tsmap.times = core.G3VectorTime(times * core.G3Units.s)
+        for k, v in data.items():
+            tsmap[k] = core.G3VectorDouble(v)
+        frame['block_names'] = core.G3VectorString([block_name])
+        frame['blocks'].append(tsmap)
+        frame['address'] = core.G3String(prov['addr'])
+        frame['provider_session_id'] = core.G3Int(prov['session_id'])
+        return frame
 
     for fr_idx in np.unique(frame_idxs):
         m = frame_idxs == fr_idx
-        frame = hksess.data_frame(0)
-        tsmap = core.G3TimesampleMap()
-        tsmap.times = core.G3VectorTime(times[m] * core.G3Units.s)
-        tsmap['test_field'] = core.G3VectorDouble(data[m].tolist())
-        frame['block_names'] = core.G3VectorString(['test_block'])
-        frame['blocks'].append(tsmap)
-        frame['address'] = core.G3String(prov_address)
-        frame['provider_session_id'] = core.G3Int(prov_session_id)
-        frames.append(frame)
+        frames.append(hk_frame(prov1, times[m], {'test_field': data[m]}))
+        if fr_idx % 2 == 0:
+            frames.append(hk_frame(prov2, times[m], {'field1': data[m]},
+                                   block_name='block1'))
+        else:
+            frames.append(hk_frame(prov2, times[m], {'field2': data[m]},
+                                   block_name='block2'))
 
     for f in frames:
         writer(f)
@@ -93,4 +109,12 @@ class HkDbTest(unittest.TestCase):
         self.assertEqual(len(res.test[0]), nsamp)
 
         feeds = hkdb.get_feed_list(load_spec)
-        self.assertEqual(feeds, ['test_agent.test_feed.*'])
+        self.assertEqual(list(map(str, feeds)),
+                         ['test_agent.test_feed.*', 'weird_agent.misc_feed.*'])
+
+        fields = hkdb.get_field_list(load_spec)
+        self.assertEqual(fields, ['test_agent.test_feed.test_field'])
+
+        fields = hkdb.get_field_list(load_spec, fields=['weird_agent.*.*'])
+        self.assertEqual(fields, ['weird_agent.misc_feed.field1',
+                                  'weird_agent.misc_feed.field2'])


### PR DESCRIPTION
Re-opening here, in favor of #1165.

Summary of changes:
- Adds a hash on the field names, for each frame.
  - This makes it possible to do "get_field_list" fairly efficiently.
  - The new-style database can still be consumed by older code
- Adds purge_unindexed files function.
- Declares index on a frames.file_id -- postgres doesn't do this for you.

I've updated our active databases to have this new column, so they'll just start supporting this function naturally when local code is updated.

In general though, the new code will fail when trying to query or update a database created by the prior code.  If you have a giant database you'd like to modify for use with the new code... there's sql for that, get in touch with me.  You don't need to start over.

The new schema lets you do this:
```
hkdb.get_field_list(lspec, ['timing-m1000-office-1.*.*']
>> ['timing-m1000-office-1.m1000.mbgLtNgPtpPortState_1', 'timing-m1000-office-1.m1000.mbgLtNgPtpPortState_1_description', ...]
```
and it's not even slow ...