### PR TITLE
Not enough workers fix

### DIFF
--- a/sotodlib/utils/procs_pool.py
+++ b/sotodlib/utils/procs_pool.py
@@ -34,7 +34,7 @@ def _get_mpi_comm() -> (
             MPICommExecutor(comm, root=0, max_workers=max_workers).__enter__(),
             as_completed,
         )
-    except (NameError, ImportError):
+    except (NameError, ImportError, ValueError):
         return False, 0, None, None
 
 


### PR DESCRIPTION
This is to provide a process pool executor when MPI has only one process and fails to launch, essentially moving forward with:
```
Traceback (most recent call last):
  File "/global/homes/m/mmccrack/so_home/repos/sotodlib/20250407_mpi/sotodlib/sotodlib/site_pipeline/preprocess_tod.py", line 391, in <module>
    rank, executor, as_completed_callable = get_exec_env(args.nproc)
                                            ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/global/homes/m/mmccrack/so_home/repos/sotodlib/20250407_mpi/sotodlib/sotodlib/utils/procs_pool.py", line 133, in get_exec_env
    _get_mpi_comm()
  File "/global/homes/m/mmccrack/so_home/repos/sotodlib/20250407_mpi/sotodlib/sotodlib/utils/procs_pool.py", line 34, in _get_mpi_comm
    MPICommExecutor(comm, root=0, max_workers=max_workers).__enter__(),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/global/u1/m/mmccrack/so_home/env/soconda_20240903_0.1.4/lib/python3.11/site-packages/mpi4py/futures/pool.py", line 348, in __enter__
    executor = MPIPoolExecutor(**options)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/global/u1/m/mmccrack/so_home/env/soconda_20240903_0.1.4/lib/python3.11/site-packages/mpi4py/futures/pool.py", line 51, in __init__
    raise ValueError("max_workers must be greater than 0")
ValueError: max_workers must be greater than 0
```