### PR TITLE
get_nearby_sources used stale signature of so3g...from.xieta 

### DIFF
--- a/sotodlib/coords/planets.py
+++ b/sotodlib/coords/planets.py
@@ -440,7 +440,7 @@ def get_nearby_sources(tod=None, source_list=None, distance=1.):
 
     # One central detector
     xieta0, R, _ = coords.helpers.get_focal_plane_cover(tod, 0)
-    fp = so3g.proj.FocalPlane.from_xieta(xieta0[0], xieta0[1])
+    fp = so3g.proj.FocalPlane.from_xieta([xieta0[0]], [xieta0[1]])
 
     asm = so3g.proj.Assembly.attach(sight, fp)
     p = so3g.proj.Projectionist.for_geom(shape, wcs)


### PR DESCRIPTION
get_nearby_sources used a stale signature of so3g.proj.FocalPlane.from_xieta(). From Matthew: (imperfect upgrade, 1e17035e4)