### PR TITLE
TOAST intervals are now open-ended

### DIFF
--- a/sotodlib/toast/io/load_book.py
+++ b/sotodlib/toast/io/load_book.py
@@ -525,8 +525,8 @@ def read_book(
                     weather=weather,
                 )
             except KeyError:
-                msg = f"Book {book_name} toast sim info does not have valid site "
-                msg += f" information.  Will use nominal values."
+                msg = f"Book {book_name} toast sim info does not have valid "
+                msg += f"site information.  Will use nominal values."
                 log.warning_rank(msg, comm=comm.comm_group)
                 book_session = True
         else:

--- a/sotodlib/toast/io/save_book.py
+++ b/sotodlib/toast/io/save_book.py
@@ -252,16 +252,13 @@ def export_obs_ancil(
 
     output = list()
     for ifrm, frmint in enumerate(obs.intervals[frame_intervals]):
-        slc = slice(frmint.first, frmint.last + 1, 1)
+        slc = slice(frmint.first, frmint.last, 1)
         # Construct the Scan frame
         frame = c3g.G3Frame(c3g.G3FrameType.Scan)
         frame["book_id"] = c3g.G3String(book_id)
         frame["sample_range"] = c3g.G3VectorInt(
             np.array(
-                [
-                    frmint.first,
-                    frmint.last + 1,
-                ],
+                [frmint.first, frmint.last],
                 dtype=np.int64,
             )
         )
@@ -372,7 +369,7 @@ def export_obs_data(
     output = list()
 
     for ifrm, frmint in enumerate(wafer_obs[0].intervals[frame_intervals]):
-        slc = slice(frmint.first, frmint.last + 1, 1)
+        slc = slice(frmint.first, frmint.last, 1)
 
         # Get the timestamps from the first observation
         g3times = t3g.to_g3_time(wafer_obs[0].shared[times].data[slc])
@@ -393,7 +390,7 @@ def export_obs_data(
         dts.quanta = np.ones(len(det_names))
         dts.options(enable=0)
         dts_temp = np.zeros(
-            (len(det_names), frmint.last - frmint.first + 1),
+            (len(det_names), frmint.last - frmint.first),
             dtype=wafer_obs[0].detdata[det_data].dtype,
         )
 
@@ -402,7 +399,7 @@ def export_obs_data(
         fts.times = g3times
         fts.options(enable=0)
         fts_temp = np.zeros(
-            (len(det_names), frmint.last - frmint.first + 1), dtype=np.int32
+            (len(det_names), frmint.last - frmint.first), dtype=np.int32
         )
 
         # Timestream units

--- a/sotodlib/toast/io/save_book.py
+++ b/sotodlib/toast/io/save_book.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023 Simons Observatory.
+# Copyright (c) 2020-2025 Simons Observatory.
 # Full license can be found in the top level "LICENSE" file.
 """Tools for saving Level-3 Book format data.
 

--- a/sotodlib/toast/ops/mlmapmaker.py
+++ b/sotodlib/toast/ops/mlmapmaker.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2024 Simons Observatory.
+# Copyright (c) 2020-2025 Simons Observatory.
 # Full license can be found in the top level "LICENSE" file.
 """Operator for interfacing with the Maximum Likelihood Mapmaker.
 
@@ -394,7 +394,7 @@ class MLMapmaker(Operator):
         ranges = so3g.proj.ranges.RangesMatrix.zeros((len(dets), nsample))
         if self.view is not None:
              view_ranges = np.array(
-                 [[x.first, min(x.last, nsample) + 1] for x in ob.intervals[self.view]]
+                 [[x.first, x.last] for x in ob.intervals[self.view]]
              )
              ranges += so3g.proj.ranges.Ranges.from_array(view_ranges, nsample)
 

--- a/sotodlib/toast/ops/save_books.py
+++ b/sotodlib/toast/ops/save_books.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2024 Simons Observatory.
+# Copyright (c) 2022-2025 Simons Observatory.
 # Full license can be found in the top level "LICENSE" file.
 
 import os
@@ -205,12 +205,8 @@ class SaveBooks(Operator):
                         local_sets = list()
                         offset = 0
                         for intr in ob.intervals[frame_intervals]:
-                            chunk = intr.last - offset + 1
-                            local_sets.append(
-                                [
-                                    chunk,
-                                ]
-                            )
+                            chunk = intr.last - offset
+                            local_sets.append([chunk])
                             offset += chunk
                         if offset != ob.n_local_samples:
                             local_sets.append([ob.n_local_samples - offset])

--- a/sotodlib/toast/ops/save_books.py
+++ b/sotodlib/toast/ops/save_books.py
@@ -186,10 +186,12 @@ class SaveBooks(Operator):
                     n_set = ob.dist.samp_sets[ob.comm.group_rank].n_elem
                     for sset in range(first_set, first_set + n_set):
                         for chunk in ob.dist.sample_sets[sset]:
+                            first = offset
+                            last = min(offset + chunk, ob.n_local_samples - 1)
                             timespans.append(
                                 (
-                                    ob.shared[self.times][offset],
-                                    ob.shared[self.times][offset + chunk - 1],
+                                    ob.shared[self.times][first],
+                                    ob.shared[self.times][last],
                                 )
                             )
                             n_frames += 1


### PR DESCRIPTION
Update all instances of TOAST `Interval` to use the new open-ended definition. The unit tests will fail until a new tag of TOAST is uploaded.