### PR TITLE
Parallelize make_book for operations books

### DIFF
--- a/sotodlib/io/datapkg_completion.py
+++ b/sotodlib/io/datapkg_completion.py
@@ -686,7 +686,7 @@ class DataPackaging:
             for book in books_not_deleted:
                 msg += f'\t{book.bid}\n'   
             self.logger.error(msg)
-            return False, "msg"
+            return False, msg
         return True, ""
     
     def check_and_delete_timecode(

--- a/sotodlib/site_pipeline/make_book.py
+++ b/sotodlib/site_pipeline/make_book.py
@@ -36,7 +36,7 @@ def _bookbinding_helper(platform, bid ):
     return imprint._run_book_binding(bid)
 
 
-def main(config: str, parallel_oper:bool=False):
+def main(config: str, n_proc:int=1):
     """Make books based on imprinter db
     
     Parameters
@@ -53,11 +53,12 @@ def main(config: str, parallel_oper:bool=False):
     unbound_books = imprinter.get_unbound_books()
     already_failed_books = imprinter.get_failed_books()
     
-    if parallel_oper:
+    if n_proc>1:
+        multiprocessing.set_start_method('spawn')
         parallel_list = [
             book for book in unbound_books if book.type == 'oper'
         ]
-        bind_books_parallel(imprinter.daq_node, parallel_list, n_proc=4)
+        bind_books_parallel(imprinter.daq_node, parallel_list, n_proc=n_proc)
 
     unbound_books = imprinter.get_unbound_books()
     print(f"Found {len(unbound_books)} unbound books and "
@@ -104,14 +105,14 @@ def get_parser(parser=None):
         type=str, 
         help="Path to imprinter configuration file"
     )
-    #parser.add_argument('output_root', type=str, help="Root path of the books")
-    parser.add_argument("--parallel-oper", action="store_true")
+    parser.add_argument(
+        "--n-proc", type=int, default=1,
+        help="The number of processes to run for operations books"
+    )
     return parser
 
 
 if __name__ == "__main__":
-    multiprocessing.set_start_method('spawn')
-
     parser = get_parser(parser=None)
     args = parser.parse_args()
     main(**vars(args))


### PR DESCRIPTION
This update is starting a parallelization effort for book binding  with just the operation books (there's lots of them and they're small). 

* Makes a new helper function in imprinter to separate the database reads and database writes. Bookbinding involved a whole but of reads from the imprinter and g3tsmurf databases, but at the end we only write book.status and book.message. sqlite / sqlalchemy can handle multiple active sessions if only one active session is writing. 
* `imprinter.bind_book` still acts the same as it always has
* I tested this on ~3000 operation books on the LAT and the speed-up factor was basically `n_processes`. I also verified that the output books had `timestamps`, `signal` and `Z_smurf` files that were identical between the parallelly and serially written books.
  * I think 3000 should have also been enough to catch write conflicts if I missed something
* small bugfix for cleanup level 2