### PR TITLE
preprocess_obs: filter obs list for LAT formatted obs_ids

### DIFF
--- a/sotodlib/site_pipeline/preprocess_obs.py
+++ b/sotodlib/site_pipeline/preprocess_obs.py
@@ -17,7 +17,8 @@ def preprocess_obs(
     obs_id, 
     configs,  
     overwrite=False, 
-    logger=None
+    logger=None,
+    obs_group=None
 ):
     """Meant to be run as part of a batched script, this function calls the
     preprocessing pipeline a specific Observation ID and saves the results in
@@ -33,6 +34,8 @@ def preprocess_obs(
         if True, overwrite existing entries in ManifestDb
     logger: logging instance
         the logger to print to
+    obs_group: list of strings
+        List of obs_ids within group
     """
 
     if logger is None: 
@@ -53,6 +56,8 @@ def preprocess_obs(
         scheme = core.metadata.ManifestScheme()
         scheme.add_exact_match('obs:obs_id')
         scheme.add_data_field('dataset')
+        if obs_group:
+            scheme.add_data_field('obs_group')
         db = core.metadata.ManifestDb(
             configs['archive']['index'],
             scheme=scheme
@@ -75,6 +80,9 @@ def preprocess_obs(
     # Update the index.
     db_data = {'obs:obs_id': obs_id,
                 'dataset': dest_dataset}
+    
+    if obs_group:
+        db_data['obs_group'] = ','.join(obs_group)
     
     logger.info(f"Saving to database under {db_data}")
     if len(db.inspect(db_data)) == 0:
@@ -180,6 +188,8 @@ def main(
         time_tolerance = 10
         kept = []
         seen_ctimes = []
+        obs_groups = []
+        current_group = []
 
         for s in obs_list:
             try:
@@ -191,26 +201,45 @@ def main(
             is_close = any(abs(ctime - seen) <= time_tolerance for seen in seen_ctimes)
 
             if not is_close:
+                if current_group:
+                    obs_groups.append(current_group)
+                current_group = [s['obs_id']]
                 kept.append(s)
+                seen_ctimes = [ctime]
+            else:
+                current_group.append(s['obs_id'])
                 seen_ctimes.append(ctime)
-                
+
+        if current_group:
+            obs_groups.append(current_group)
+
         obs_list = kept
+    else:
+        obs_groups = None
 
     if overwrite or not os.path.exists(configs['archive']['index']):
         #run on all if database doesn't exist
         run_list = [o for o in obs_list]
     else:
+        mask = []
         db = core.metadata.ManifestDb(configs['archive']['index'])
         for obs in obs_list:
             x = db.inspect({'obs:obs_id': obs["obs_id"]})
             if x is None or len(x) == 0:
                 run_list.append(obs)
+                mask.append(True)
+            else:
+                mask.append(False)
+        
+        if obs_groups:
+            obs_groups = [group for keep, group in zip(mask, obs_groups) if keep]
 
     logger.info(f"Beginning to run preprocessing on {len(run_list)} observations")
-    for obs in run_list:
-        logger.info(f"Processing obs_id: {obs_id}")
+    for i, obs in enumerate(run_list):
+        logger.info(f"Processing obs_id: {obs['obs_id']}")
         try:
-            preprocess_obs(obs["obs_id"], configs, overwrite=overwrite, logger=logger)
+            preprocess_obs(obs["obs_id"], configs, overwrite=overwrite, logger=logger, 
+                           obs_group=None if obs_groups is None else obs_groups[i])
         except Exception as e:
             logger.info(f"{type(e)}: {e}")
             logger.info(''.join(traceback.format_tb(e.__traceback__)))

--- a/sotodlib/site_pipeline/preprocess_obs.py
+++ b/sotodlib/site_pipeline/preprocess_obs.py
@@ -175,23 +175,13 @@ def main(
     if len(obs_list)==0:
         logger.warning(f"No observations returned from query: {query}")
     run_list = []
-
-    if overwrite or not os.path.exists(configs['archive']['index']):
-        #run on all if database doesn't exist
-        run_list = [o for o in obs_list]
-    else:
-        db = core.metadata.ManifestDb(configs['archive']['index'])
-        for obs in obs_list:
-            x = db.inspect({'obs:obs_id': obs["obs_id"]})
-            if x is None or len(x) == 0:
-                run_list.append(obs)
-                
+    
     if lat:
         time_tolerance = 10
         kept = []
         seen_ctimes = []
 
-        for s in run_list:
+        for s in obs_list:
             try:
                 ctime_str = s['obs_id'].split('_')[1]
                 ctime = int(ctime_str)
@@ -204,7 +194,17 @@ def main(
                 kept.append(s)
                 seen_ctimes.append(ctime)
                 
-        run_list = kept
+        obs_list = kept
+
+    if overwrite or not os.path.exists(configs['archive']['index']):
+        #run on all if database doesn't exist
+        run_list = [o for o in obs_list]
+    else:
+        db = core.metadata.ManifestDb(configs['archive']['index'])
+        for obs in obs_list:
+            x = db.inspect({'obs:obs_id': obs["obs_id"]})
+            if x is None or len(x) == 0:
+                run_list.append(obs)
 
     logger.info(f"Beginning to run preprocessing on {len(run_list)} observations")
     for obs in run_list:


### PR DESCRIPTION
Adds bool argument to `preprocess_obs.py` for LAT observations. Since LAT obs_ids are split by optics tubes with timestamps within about 10 seconds of each other, we only need to run `preprocess_obs` on one of them since it loads the entire aman with no signal. Without this, `preprocess_obs` runs redundant processes.