### PR TITLE
close ephemeris file to avoid too many open files

### DIFF
--- a/sotodlib/coords/planets.py
+++ b/sotodlib/coords/planets.py
@@ -339,6 +339,7 @@ def _get_astrometric(source_name, timestamp, site="_default"):
         datetime.datetime.fromtimestamp(timestamp, tz=skyfield_api.utc)
     )
     astrometric = observatory.at(sf_timestamp).observe(target)
+    planets.close()
     return astrometric
 
 


### PR DESCRIPTION
Found case of `[Errno 24] Too many open files` when calling this line:
https://github.com/simonsobs/sotodlib/blob/67b4aa7cb730bb30dcecdba682361570a5399c10/sotodlib/coords/planets.py#L316
This occurred when I was running a catchup `preprocess_obs` job. Each obs would already open many files due to this loop here:
https://github.com/simonsobs/sotodlib/blob/67b4aa7cb730bb30dcecdba682361570a5399c10/sotodlib/obs_ops/sources.py#L49
When running on a list of many obs, these files that are never closed continue to pile up.