### PR TITLE
Add loader and det cal functionality to load in bandpass info using bg

### DIFF
--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -1324,6 +1324,7 @@ class PCARelCal(_Preprocess):
     def __init__(self, step_cfgs):
         self.signal = step_cfgs.get('signal', 'signal')
         self.run = step_cfgs.get('pca_run', 'run1')
+        self.bandpass = step_cfgs.get('bandpass', 'wafer.bandpass')
         self.run_name = f'{self.signal}_{self.run}'
 
         super().__init__(step_cfgs)
@@ -1346,7 +1347,7 @@ class PCARelCal(_Preprocess):
             if self.plot_cfgs:
                 self.plot_signal = filt_aman[self.signal]
 
-        bands = np.unique(aman.det_info.wafer.bandpass)
+        bands = np.unique(aman.det_info[self.bandpass])
         bands = bands[bands != 'NC']
         # align samps w/ proc_aman to include samps restriction when loading back from db.
         rc_aman = core.AxisManager(proc_aman.dets, proc_aman.samps)
@@ -1354,7 +1355,7 @@ class PCARelCal(_Preprocess):
         relcal = np.zeros(aman.dets.count)
         pca_weight0 = np.zeros(aman.dets.count)
         for band in bands:
-            m0 = aman.det_info.wafer.bandpass == band
+            m0 = aman.det_info[self.bandpass] == band
             rc_aman.wrap(f'{band}_idx', m0, [(0, 'dets')])
             band_aman = aman.restrict('dets', aman.dets.vals[m0], in_place=False)
 
@@ -1408,7 +1409,7 @@ class PCARelCal(_Preprocess):
             det = aman.dets.vals[0]
             ufm = det.split('_')[2]
 
-            bands = np.unique(aman.det_info.wafer.bandpass)
+            bands = np.unique(aman.det_info[self.bandpass])
             bands = bands[bands != 'NC']
             for band in bands:
                 pca_aman = aman.restrict('dets', aman.dets.vals[proc_aman[self.run_name][f'{band}_idx']], in_place=False)
@@ -1900,9 +1901,9 @@ _Preprocess.register(SourceFlags)
 _Preprocess.register(HWPAngleModel)
 _Preprocess.register(GetStats)
 _Preprocess.register(UnionFlags)
-_Preprocess.register(RotateQU) 
-_Preprocess.register(SubtractQUCommonMode) 
-_Preprocess.register(FocalplaneNanFlags) 
-_Preprocess.register(PointingModel)  
+_Preprocess.register(RotateQU)
+_Preprocess.register(SubtractQUCommonMode)
+_Preprocess.register(FocalplaneNanFlags)
+_Preprocess.register(PointingModel)
 _Preprocess.register(BadSubscanFlags)
 _Preprocess.register(CorrectIIRParams)


### PR DESCRIPTION
Adds custom functionality to be able to load in bandpass information using the `det_cal` bias group information. The pull request does a combination of:

1. Modify `update_det_cal.py` to calculate and save bandpass information inside the ManifestDB from the bias group.
2. Modify the PCARelCal module in `processes.py` to allow a fieldname for the bandpass as input rather than using the hard-coded `wafer.bandpass`
3. Add a custom metadata loader which allows input of which fields to load into a ResultSet, ignoring the rest. The loader also allows a user to modify the field names.

With the custom loader we can load up the `bandpass` field from the new `det_cal` into `aman.det_info` using e.g. a field name `dets:det_cal.bandpass`. The rest of the det cal information can be then loaded into `aman.det.cal` with a separate context entry using the same database.