### PR TITLE
Add option to raise errors at end of preprocessing if obsids failed

### DIFF
--- a/sotodlib/site_pipeline/multilayer_preprocess_tod.py
+++ b/sotodlib/site_pipeline/multilayer_preprocess_tod.py
@@ -269,6 +269,12 @@ def get_parser(parser=None):
         type=int,
         default=4
     )
+    parser.add_argument(
+        '--raise-error',
+        help="Raise an error upon completion if any obsids or groups fail.",
+        type=bool,
+        default=False
+    )
     return parser
 
 def main(executor: Union["MPICommExecutor", "ProcessPoolExecutor"],
@@ -284,7 +290,8 @@ def main(executor: Union["MPICommExecutor", "ProcessPoolExecutor"],
          tags: Optional[str] = None,
          planet_obs: bool = False,
          verbosity: Optional[int] = None,
-         nproc: Optional[int] = 4):
+         nproc: Optional[int] = 4,
+         raise_error: Optional[bool] = False):
 
     logger = pp_util.init_logger("preprocess", verbosity=verbosity)
 
@@ -332,6 +339,8 @@ def main(executor: Union["MPICommExecutor", "ProcessPoolExecutor"],
 
     logger.info(f'Run list created with {len(run_list)} obsids')
 
+    n_fail = 0
+
     # run write_block obs-ids in parallel at once then write all to the sqlite db.
     futures = [executor.submit(multilayer_preprocess_tod, obs_id=r[0]['obs_id'],
                 group_list=r[1], verbosity=verbosity,
@@ -342,6 +351,8 @@ def main(executor: Union["MPICommExecutor", "ProcessPoolExecutor"],
         logger.info('New future as_completed result')
         try:
             err, db_datasets_init, db_datasets_proc = future.result()
+            if err is not None:
+                n_fail += 1
         except Exception as e:
             errmsg = f'{type(e)}: {e}'
             tb = ''.join(traceback.format_tb(e.__traceback__))
@@ -349,6 +360,7 @@ def main(executor: Union["MPICommExecutor", "ProcessPoolExecutor"],
             f = open(errlog, 'a')
             f.write(f'\n{time.time()}, future.result() error\n{errmsg}\n{tb}\n')
             f.close()
+            n_fail += 1
             continue
         futures.remove(future)
 
@@ -367,6 +379,9 @@ def main(executor: Union["MPICommExecutor", "ProcessPoolExecutor"],
                     pp_util.cleanup_mandb(err, db_dataset, configs_proc, logger, overwrite)
             else:
                 pp_util.cleanup_mandb(err, db_datasets_proc, configs_proc, logger, overwrite)
+
+    if raise_error and n_fail > 0:
+        raise RuntimeError(f"multilayer_preprocess_tod: {n_fail}/{len(run_list)} obs_ids failed")
 
 if __name__ == '__main__':
     args = get_parser().parse_args()


### PR DESCRIPTION
Separates part of #1156 as a standalone PR.  This will raise an error if any obs_ids either have `error` is not `None` or cannot be extracted from the future result for `preprocess_tod.py` and `multilayer_preprocess_tod.py`