### PR TITLE
Update per-band array handling for relcal

### DIFF
--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -1420,18 +1420,19 @@ class PCARelCal(_Preprocess):
             bands = np.unique(aman.det_info.wafer.bandpass)
             bands = bands[bands != 'NC']
             for band in bands:
-                pca_aman = aman.restrict('dets', aman.dets.vals[proc_aman[self.run_name][f'{band}_idx']], in_place=False)
-                if self.calc_cfgs.get("lpf") is not None:
-                    trim = self.calc_cfgs["trim_samps"]
-                    pca_aman.restrict('samps', (pca_aman.samps.offset + trim,
-                                                pca_aman.samps.offset + pca_aman.samps.count - trim))
-                band_aman = proc_aman[self.run_name].restrict('dets', aman.dets.vals[proc_aman[self.run_name][f'{band}_idx']], in_place=False)
-                plot_pcabounds(pca_aman, band_aman, filename=filename.replace('{name}', f'{ufm}_{band}_pca'), signal=self.plot_signal, band=band, plot_ds_factor=self.plot_cfgs.get('plot_ds_factor', 20))
-                proc_aman[self.run_name].move(f'{band}_idx', None)
-                proc_aman[self.run_name].move(f'{band}_pca_mode0', None)
-                proc_aman[self.run_name].move(f'{band}_xbounds', None)
-                proc_aman[self.run_name].move(f'{band}_ybounds', None)
-                proc_aman[self.run_name].move(f'{band}_median', None)
+                if f'{band}_pca_mode0' in proc_aman[self.run_name]:
+                    pca_aman = aman.restrict('dets', aman.dets.vals[proc_aman[self.run_name][f'{band}_idx']], in_place=False)
+                    if self.calc_cfgs.get("lpf") is not None:
+                        trim = self.calc_cfgs["trim_samps"]
+                        pca_aman.restrict('samps', (pca_aman.samps.offset + trim,
+                                                    pca_aman.samps.offset + pca_aman.samps.count - trim))
+                    band_aman = proc_aman[self.run_name].restrict('dets', aman.dets.vals[proc_aman[self.run_name][f'{band}_idx']], in_place=False)
+                    plot_pcabounds(pca_aman, band_aman, filename=filename.replace('{name}', f'{ufm}_{band}_pca'), signal=self.plot_signal, band=band, plot_ds_factor=self.plot_cfgs.get('plot_ds_factor', 20))
+                    proc_aman[self.run_name].move(f'{band}_idx', None)
+                    proc_aman[self.run_name].move(f'{band}_pca_mode0', None)
+                    proc_aman[self.run_name].move(f'{band}_xbounds', None)
+                    proc_aman[self.run_name].move(f'{band}_ybounds', None)
+                    proc_aman[self.run_name].move(f'{band}_median', None)
 
 class PCAFilter(_Preprocess):
     """


### PR DESCRIPTION
The PCA relcal function wrapped in arrays that included the bandpasses in their names, which breaks when trying to load in multiple bandpasses from an existing preprocessing database.  Those arrays were only used in the PCA plotting, so this branch changes things such that they are only made when plotting is enabled and are deleted once that band's plots have been made.  While it might be useful to have these values available, it is currently more or less impossible to store per-band information (unless they are per-detector indexed) in the preprocessing axis manager and be able to load it back due to restrictions from the axis manager loading/concatenation functions.  This requires changes at a deeper level in the axis manager classes.

Made a slight change to the plotting which was broken.  Since `aman` is not trimmed after the lowpass filter, I added a trim to the restricted copy of `aman` in the plotting function if lowpassing.

Tested by preprocessing two band independently and running `get_meta(obsid)` with both plotting disabled and enabled.

Confirmation that these parameters are not used elsewhere other than plotting:
https://github.com/search?q=repo%3Asimonsobs%2Fsotodlib+pca_mode0&type=code
https://github.com/search?q=repo%3Asimonsobs%2Fsotodlib+xbounds&type=code
https://github.com/search?q=repo%3Asimonsobs%2Fsotodlib+ybounds&type=code
https://github.com/search?q=repo%3Asimonsobs%2Fsotodlib+%7Bband%7D_idx&type=code