### PR TITLE
Add runtime error check in save_group_and_cleanup

### DIFF
--- a/sotodlib/preprocess/preprocess_util.py
+++ b/sotodlib/preprocess/preprocess_util.py
@@ -733,7 +733,12 @@ def save_group_and_cleanup(obs_id, configs, context=None, subdir='temp',
                 if not remove and g not in db_groups:
                     cleanup_mandb(None, outputs_grp, configs, logger)
                 else:
-                    # if we're overwriting, remove file so it will re-run
+                    # if we're overwriting
+                    if remove:
+                        logger.info(f"remove={remove}: removing {outputs_grp['temp_file']}")
+                    # if found in database already
+                    elif g in db_groups:
+                        logger.info(f"{outputs_grp['temp_file']} found in db, removing")
                     os.remove(outputs_grp['temp_file'])
             except OSError as e:
                 # remove if it can't be opened

--- a/sotodlib/preprocess/preprocess_util.py
+++ b/sotodlib/preprocess/preprocess_util.py
@@ -736,7 +736,7 @@ def save_group_and_cleanup(obs_id, configs, context=None, subdir='temp',
                     # if we're overwriting, remove file so it will re-run
                     os.remove(outputs_grp['temp_file'])
             except OSError as e:
-                # remove if it can't be opened or already exists in the db
+                # remove if it can't be opened
                 os.remove(outputs_grp['temp_file'])
     return error
 

--- a/sotodlib/preprocess/preprocess_util.py
+++ b/sotodlib/preprocess/preprocess_util.py
@@ -727,7 +727,7 @@ def save_group_and_cleanup(obs_id, configs, context=None, subdir='temp',
                 else:
                     # if we're overwriting, remove file so it will re-run
                     os.remove(outputs_grp['temp_file'])
-            except OSError as e:
+            except (OSError, RuntimeError) as e:
                 # remove if it can't be opened
                 os.remove(outputs_grp['temp_file'])
     return error

--- a/sotodlib/preprocess/preprocess_util.py
+++ b/sotodlib/preprocess/preprocess_util.py
@@ -728,7 +728,7 @@ def save_group_and_cleanup(obs_id, configs, context=None, subdir='temp',
                     # if we're overwriting, remove file so it will re-run
                     os.remove(outputs_grp['temp_file'])
             except (OSError, RuntimeError) as e:
-                # remove if it can't be opened
+                # remove if it can't be opened or already exists in the db
                 os.remove(outputs_grp['temp_file'])
     return error
 

--- a/sotodlib/preprocess/preprocess_util.py
+++ b/sotodlib/preprocess/preprocess_util.py
@@ -709,6 +709,9 @@ def save_group_and_cleanup(obs_id, configs, context=None, subdir='temp',
 
     group_by, groups, error = get_groups(obs_id, configs, context)
 
+    db = core.metadata.ManifestDb(configs['archive']['index'])
+    x = db.inspect({'obs:obs_id': obs_id})
+
     all_groups = groups.copy()
     for g in all_groups:
         if 'wafer.bandpass' in group_by:
@@ -716,18 +719,23 @@ def save_group_and_cleanup(obs_id, configs, context=None, subdir='temp',
                 groups.remove(g)
                 continue
 
+    # get groups in db
+    db_groups = []
+    if x is not None and len(x) > 0:
+        [db_groups.append([a[f'dets:{gb}'] for gb in group_by]) for a in x]
+
     for g in groups:
         dets = {gb:gg for gb, gg in zip(group_by, g)}
         outputs_grp = save_group(obs_id, configs, dets, context, subdir)
 
         if os.path.exists(outputs_grp['temp_file']):
             try:
-                if not remove:
+                if not remove and g not in db_groups:
                     cleanup_mandb(None, outputs_grp, configs, logger)
                 else:
                     # if we're overwriting, remove file so it will re-run
                     os.remove(outputs_grp['temp_file'])
-            except (OSError, RuntimeError) as e:
+            except OSError as e:
                 # remove if it can't be opened or already exists in the db
                 os.remove(outputs_grp['temp_file'])
     return error


### PR DESCRIPTION
Previously this function was set up to only find corrupted files that didn't completely write out, but an existing db entry raises a RuntimeError, so this branch adds a catch for those.  Probably will improve `cleanup_mandb` to identify existing db entries in a future update (maybe along with the features of #1156).