### PR TITLE
Fix AzSS subtract logic.

### DIFF
--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -889,21 +889,28 @@ class AzSS(_Preprocess):
             proc_aman.wrap(self.calc_cfgs["azss_stats_name"], azss_stats)
 
     def process(self, aman, proc_aman, sim=False):
-        if self.calc_cfgs.get('azss_stats_name') in proc_aman and self.process_cfgs["subtract"]:
-            if sim:
-                tod_ops.azss.get_azss(aman, **self.calc_cfgs)
+        if self.process_cfgs["subtract"]:
+            if self.calc_cfgs.get('azss_stats_name') in proc_aman:
+                if sim:
+                    tod_ops.azss.get_azss(aman, **self.calc_cfgs)
+                else:
+                    tod_ops.azss.subtract_azss(
+                        aman,
+                        proc_aman.get(self.calc_cfgs.get('azss_stats_name')),
+                        signal=self.calc_cfgs.get('signal', 'signal'),
+                        scan_flags=self.calc_cfgs.get('scan_flags'),
+                        method=self.calc_cfgs.get('method', 'interpolate'),
+                        max_mode=self.calc_cfgs.get('max_mode'),
+                        azrange=self.calc_cfgs.get('azrange'),
+                        in_place=True
+                    )
             else:
-                tod_ops.azss.subtract_azss(
-                    aman,
-                    proc_aman.get(self.calc_cfgs.get('azss_stats_name')),
-                    signal=self.calc_cfgs.get('signal', 'signal'),
-                    scan_flags=self.calc_cfgs.get('scan_flags'),
-                    method=self.calc_cfgs.get('method', 'interpolate'),
-                    max_mode=self.calc_cfgs.get('max_mode'),
-                    azrange=self.calc_cfgs.get('azrange'),
-                    in_place=True
-                )
+                cfgs = dict(copy.deepcopy(self.calc_cfgs))
+                cfgs.pop('subtract_in_place', None)
+                tod_ops.azss.get_azss(aman, subtract_in_place=True, **cfgs)
         else:
+            if self.calc_cfgs.get('subtract_in_place', 'False'):
+                raise ValueError("calc_cfgs.subtract_in_place must be False when process_cfgs.subtract is False")
             tod_ops.azss.get_azss(aman, **self.calc_cfgs)
 
 

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -890,9 +890,11 @@ class AzSS(_Preprocess):
 
     def process(self, aman, proc_aman, sim=False):
         if self.process_cfgs.get("subtract"):
+            cfgs = dict(copy.deepcopy(self.calc_cfgs))
+            cfgs.pop('subtract_in_place', None)
             if self.calc_cfgs.get('azss_stats_name') in proc_aman:
                 if sim:
-                    tod_ops.azss.get_azss(aman, **self.calc_cfgs)
+                    tod_ops.azss.get_azss(aman, subtract_in_place=True, **cfgs)
                 else:
                     tod_ops.azss.subtract_azss(
                         aman,
@@ -905,11 +907,9 @@ class AzSS(_Preprocess):
                         in_place=True
                     )
             else:
-                cfgs = dict(copy.deepcopy(self.calc_cfgs))
-                cfgs.pop('subtract_in_place', None)
                 tod_ops.azss.get_azss(aman, subtract_in_place=True, **cfgs)
         else:
-            if self.calc_cfgs.get('subtract_in_place', 'False'):
+            if self.calc_cfgs.get('subtract_in_place', False):
                 raise ValueError("calc_cfgs.subtract_in_place must be False when process_cfgs.subtract is False")
             tod_ops.azss.get_azss(aman, **self.calc_cfgs)
 

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -1,7 +1,6 @@
 import numpy as np
 from operator import attrgetter
 import copy
-import warnings
 
 from so3g.proj import Ranges, RangesMatrix
 

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -889,7 +889,7 @@ class AzSS(_Preprocess):
             proc_aman.wrap(self.calc_cfgs["azss_stats_name"], azss_stats)
 
     def process(self, aman, proc_aman, sim=False):
-        if self.process_cfgs["subtract"]:
+        if self.process_cfgs.get("subtract"):
             if self.calc_cfgs.get('azss_stats_name') in proc_aman:
                 if sim:
                     tod_ops.azss.get_azss(aman, **self.calc_cfgs)


### PR DESCRIPTION
In the current version of AzSS there's different logic for the `process` method of the `AzSS` preprocess class depending if this is the first time the pipeline is being run or a subsequent time (i.e. if `proc_aman` is being loaded back from the archive or being created for the first time in the `calc_and_save` method). Currently if `process_cfgs` is set to `subtract = True` it will only subtract if the `proc_aman` is loaded from the archive (i.e. the 2nd+ time the pipeline is run) since its checking for `self.calc_cfgs.get('azss_stats_name') in proc_aman` which is not added to `proc_aman` until the `calc_and_save` step which is run after the `process` step in the `Pipeline.run()` function. Here I've updated the logic so that the subtraction happens regardless of if its the first time or subsequent time. 

I suspect this impacts the ISO-v1 run since this is in the 2nd layer it was run on-the-fly with the mapmaker so unless the mapmaker was run twice for certain obsids reusing the existing preprocessing "proc" archive the subtraction step was not being called. Tagging @susannaaz, @ykyohei, and @chervias to see this. 