### PR TITLE
Add a db check to save_group_and_cleanup

### DIFF
--- a/sotodlib/preprocess/preprocess_util.py
+++ b/sotodlib/preprocess/preprocess_util.py
@@ -709,8 +709,11 @@ def save_group_and_cleanup(obs_id, configs, context=None, subdir='temp',
 
     group_by, groups, error = get_groups(obs_id, configs, context)
 
-    db = core.metadata.ManifestDb(configs['archive']['index'])
-    x = db.inspect({'obs:obs_id': obs_id})
+    if os.path.exists(configs['archive']['index']):
+        db = core.metadata.ManifestDb(configs['archive']['index'])
+        x = db.inspect({'obs:obs_id': obs_id})
+    else:
+        x = None
 
     all_groups = groups.copy()
     for g in all_groups:


### PR DESCRIPTION
Adds a check for if the preprocessing manifest db exists in save_group_and_cleanup to make sure it works when no database exists.