### PR TITLE
Common mode glitch

### DIFF
--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -1496,6 +1496,35 @@ class PCAFilter(_Preprocess):
         model = tod_ops.pca.get_pca_model(aman, signal=signal, n_modes=n_modes)
         _ = tod_ops.pca.add_model(aman, model, signal=signal, scale=-1)
 
+class GetCommonMode(_Preprocess):
+    """
+    Calculate common mode.
+
+    example config file entry::
+
+      - name: "get_common_mode"
+        calc:
+            signal: "signal"
+            method: "median"
+            wrap: "signal_commonmode"
+        save: True
+
+    .. autofunction:: sotodlib.tod_ops.pca.get_common_mode.
+    """
+    name = 'get_common_mode'
+
+    def calc_and_save(self, aman, proc_aman):
+        common_mode = tod_ops.pca.get_common_mode(aman, **self.calc_cfgs)
+        common_aman = fp_aman = core.AxisManager(aman.samps)
+        common_aman.wrap(self.calc_cfgs['wrap'], common_mode, [(0, 'samps')])
+        self.save(proc_aman, common_aman)
+
+    def save(self, proc_aman, common_aman):
+        if self.save_cfgs is None:
+            return
+        if self.save_cfgs:
+            proc_aman.wrap(self.calc_cfgs['wrap'], common_aman)
+
 class FilterForSources(_Preprocess):
     """
     Mask and gap-fill the signal at samples flagged by source_flags.
@@ -1978,6 +2007,7 @@ _Preprocess.register(InvVarFlags)
 _Preprocess.register(PTPFlags)
 _Preprocess.register(PCARelCal)
 _Preprocess.register(PCAFilter)
+_Preprocess.register(GetCommonMode)
 _Preprocess.register(FilterForSources)
 _Preprocess.register(FourierFilter)
 _Preprocess.register(Trends)

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -1509,13 +1509,13 @@ class GetCommonMode(_Preprocess):
             wrap: "signal_commonmode"
         save: True
 
-    .. autofunction:: sotodlib.tod_ops.pca.get_common_mode.
+    .. autofunction:: sotodlib.tod_ops.pca.get_common_mode
     """
     name = 'get_common_mode'
 
     def calc_and_save(self, aman, proc_aman):
         common_mode = tod_ops.pca.get_common_mode(aman, **self.calc_cfgs)
-        common_aman = fp_aman = core.AxisManager(aman.samps)
+        common_aman = core.AxisManager(aman.samps)
         common_aman.wrap(self.calc_cfgs['wrap'], common_mode, [(0, 'samps')])
         self.save(proc_aman, common_aman)
 

--- a/tests/test_flags.py
+++ b/tests/test_flags.py
@@ -30,6 +30,34 @@ class TestFlags(unittest.TestCase):
         self.assertTrue(np.array_equal(cut.ranges[1].ranges(), [[0, 1000]]))
         self.assertEqual(len(cut.ranges[0].ranges()), 0)
 
+    def test_get_glitch_flags(self):
+        nsamps = 100000
+        glitch_index = 50000
+        timestamps = np.arange(nsamps)
+        signal = np.random.normal(0, 1, size=(2, nsamps))
+        signal[1][glitch_index] = 100
+        dets = ["det0", "det1"]
+        aman = core.AxisManager(
+            core.LabelAxis("dets", dets), core.IndexAxis("samps", len(timestamps))
+        )
+        aman.wrap("timestamps", timestamps, [(0, "samps")])
+        aman.wrap("signal", signal, [(0, "dets"), (1, "samps")])
+        aman.wrap("flags", core.AxisManager(aman.dets, aman.samps))
+
+        # test on normal signal
+        flag = flags.get_glitch_flags(aman)
+        self.assertTupleEqual(flag.shape, (2, nsamps))
+        self.assertEqual(len(flag.ranges[1].ranges()), 1)
+        self.assertEqual(flag[1].mask()[glitch_index], True)
+        self.assertEqual(len(flag.ranges[0].ranges()), 0)
+
+        # test on 1d array such as common mode
+        aman.wrap("common_mode", signal[1], [(0, "samps")])
+        flag = flags.get_glitch_flags(aman, signal_name='common_mode', name='common_glitches')
+        self.assertTupleEqual(flag.shape, (nsamps,))
+        self.assertEqual(len(flag.ranges()), 1)
+        self.assertEqual(flag.mask()[glitch_index], True)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Modified get_glitch_flags to allow 1d array input and added preprocess for getting common mode. Also added unit test.

The motivation is to find and remove the glitch which is common among detectors. We have physical motivation for this kind of glitches. We can also do this on hwp demodulated timestreams to find the glitch induced by hwp angle.

Example preprocess config for common mode glitch.
```
    - name: "get_common_mode"
      calc:
        signal: "signal"
        method: "median"
        wrap: "signal_commonmode"
      save: True

    - name: "glitches"
      skip_on_sim: False
      glitch_name: "glitches_commonmode"
      calc:
        signal_name: 'signal_commonmode'
        t_glitch: 0.007
        buffer: 100
        hp_fc: 6.0
        n_sig: 10
      save: True
```

