### PR TITLE
Also trim on proc_aman in fft_trim

### DIFF
--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -28,7 +28,8 @@ class FFTTrim(_Preprocess):
     """
     name = "fft_trim"
     def process(self, aman, proc_aman, sim=False):
-        tod_ops.fft_trim(aman, **self.process_cfgs)
+        start_stop = tod_ops.fft_trim(aman, **self.process_cfgs)
+        proc_aman.restrict(self.process_cfgs.get('axis', 'samps'), (start_stop))
 
 class Detrend(_Preprocess):
     """Detrend the signal. All processing configs go to `detrend_tod`


### PR DESCRIPTION
The `fft_trim` function only trimmed the axis on `aman` and not `proc_aman`, leading to a miss matched samples error later in the processing stages. 