### PR TITLE
Add outer main function to preprocess functions

### DIFF
--- a/sotodlib/site_pipeline/multilayer_preprocess_tod.py
+++ b/sotodlib/site_pipeline/multilayer_preprocess_tod.py
@@ -277,21 +277,21 @@ def get_parser(parser=None):
     )
     return parser
 
-def main(executor: Union["MPICommExecutor", "ProcessPoolExecutor"],
-         as_completed_callable: Callable,
-         configs_init: str,
-         configs_proc: str,
-         query: Optional[str] = None, 
-         obs_id: Optional[str] = None, 
-         overwrite: bool = False,
-         min_ctime: Optional[int] = None,
-         max_ctime: Optional[int] = None,
-         update_delay: Optional[int] = None,
-         tags: Optional[str] = None,
-         planet_obs: bool = False,
-         verbosity: Optional[int] = None,
-         nproc: Optional[int] = 4,
-         raise_error: Optional[bool] = False):
+def _main(executor: Union["MPICommExecutor", "ProcessPoolExecutor"],
+          as_completed_callable: Callable,
+          configs_init: str,
+          configs_proc: str,
+          query: Optional[str] = None,
+          obs_id: Optional[str] = None,
+          overwrite: bool = False,
+          min_ctime: Optional[int] = None,
+          max_ctime: Optional[int] = None,
+          update_delay: Optional[int] = None,
+          tags: Optional[str] = None,
+          planet_obs: bool = False,
+          verbosity: Optional[int] = None,
+          nproc: Optional[int] = 4,
+          raise_error: Optional[bool] = False):
 
     logger = pp_util.init_logger("preprocess", verbosity=verbosity)
 
@@ -383,8 +383,39 @@ def main(executor: Union["MPICommExecutor", "ProcessPoolExecutor"],
     if raise_error and n_fail > 0:
         raise RuntimeError(f"multilayer_preprocess_tod: {n_fail}/{len(run_list)} obs_ids failed")
 
-if __name__ == '__main__':
-    args = get_parser().parse_args()
-    rank, executor, as_completed_callable = get_exec_env(args.nproc)
+
+def main(configs_init: str,
+         configs_proc: str,
+         query: Optional[str] = None,
+         obs_id: Optional[str] = None,
+         overwrite: bool = False,
+         min_ctime: Optional[int] = None,
+         max_ctime: Optional[int] = None,
+         update_delay: Optional[int] = None,
+         tags: Optional[str] = None,
+         planet_obs: bool = False,
+         verbosity: Optional[int] = None,
+         nproc: Optional[int] = 4,
+         raise_error: Optional[bool] = False):
+
+    rank, executor, as_completed_callable = get_exec_env(nproc)
     if rank == 0:
-        main(executor=executor, as_completed_callable=as_completed_callable, **vars(args))
+        _main(executor=executor,
+              as_completed_callable=as_completed_callable,
+              configs_init=configs_init,
+              configs_proc=configs_proc,
+              query=query,
+              obs_id=obs_id,
+              overwrite=overwrite,
+              min_ctime=min_ctime,
+              max_ctime=max_ctime,
+              update_delay=update_delay,
+              tags=tags,
+              planet_obs=planet_obs,
+              verbosity=verbosity,
+              nproc=nproc,
+              raise_error=raise_error)
+
+
+if __name__ == '__main__':
+    sp_util.main_launcher(main, get_parser)

--- a/sotodlib/site_pipeline/preprocess_tod.py
+++ b/sotodlib/site_pipeline/preprocess_tod.py
@@ -313,20 +313,20 @@ def get_parser(parser=None):
     return parser
 
 
-def main(executor: Union["MPICommExecutor", "ProcessPoolExecutor"],
-        as_completed_callable: Callable,
-        configs: str,
-        query: Optional[str] = None,
-        obs_id: Optional[str] = None,
-        overwrite: bool = False,
-        min_ctime: Optional[int] = None,
-        max_ctime: Optional[int] = None,
-        update_delay: Optional[int] = None,
-        tags: Optional[str] = None,
-        planet_obs: bool = False,
-        verbosity: Optional[int] = None,
-        nproc: Optional[int] = 4,
-        raise_error: Optional[bool] = False):
+def _main(executor: Union["MPICommExecutor", "ProcessPoolExecutor"],
+          as_completed_callable: Callable,
+          configs: str,
+          query: Optional[str] = None,
+          obs_id: Optional[str] = None,
+          overwrite: bool = False,
+          min_ctime: Optional[int] = None,
+          max_ctime: Optional[int] = None,
+          update_delay: Optional[int] = None,
+          tags: Optional[str] = None,
+          planet_obs: bool = False,
+          verbosity: Optional[int] = None,
+          nproc: Optional[int] = 4,
+          raise_error: Optional[bool] = False):
 
     configs, context = pp_util.get_preprocess_context(configs)
     logger = sp_util.init_logger("preprocess", verbosity=verbosity)
@@ -403,8 +403,35 @@ def main(executor: Union["MPICommExecutor", "ProcessPoolExecutor"],
     if raise_error and n_fail > 0:
         raise RuntimeError(f"preprocess_tod: {n_fail}/{len(run_list)} obs_ids failed")
 
-if __name__ == '__main__':
-    args = get_parser().parse_args()
-    rank, executor, as_completed_callable = get_exec_env(args.nproc)
+def main(configs: str,
+         query: Optional[str] = None,
+         obs_id: Optional[str] = None,
+         overwrite: bool = False,
+         min_ctime: Optional[int] = None,
+         max_ctime: Optional[int] = None,
+         update_delay: Optional[int] = None,
+         tags: Optional[str] = None,
+         planet_obs: bool = False,
+         verbosity: Optional[int] = None,
+         nproc: Optional[int] = 4,
+         raise_error: Optional[bool] = False):
+
+    rank, executor, as_completed_callable = get_exec_env(nproc)
     if rank == 0:
-        main(executor=executor, as_completed_callable=as_completed_callable, **vars(args))
+        _main(executor=executor,
+              as_completed_callable=as_completed_callable,
+              configs=configs,
+              query=query,
+              obs_id=obs_id,
+              overwrite=overwrite,
+              min_ctime=min_ctime,
+              max_ctime=max_ctime,
+              update_delay=update_delay,
+              tags=tags,
+              planet_obs=planet_obs,
+              verbosity=verbosity,
+              nproc=nproc,
+              raise_error=raise_error)
+
+if __name__ == '__main__':
+    sp_util.main_launcher(main, get_parser)


### PR DESCRIPTION
In order to bypass the issue of getting the executor selection functions to run in Prefect, this branch adds a second main function that takes the input configuration parameters as they were before the executor functionality was integrated.  This `main` function sets up the executor and calls a second `_main` function that is the same as the current `main` function.