### PR TITLE
Catch det match failures and add to failed list

### DIFF
--- a/sotodlib/site_pipeline/update_det_match.py
+++ b/sotodlib/site_pipeline/update_det_match.py
@@ -312,10 +312,18 @@ def run_match(runner: Runner, detset: str) -> bool:
         else:
             wafer_slot = None
 
-        match = run_match_aman(runner, aman, ds, wafer_slot=wafer_slot)
-        fpath = os.path.join(runner.match_dir, f"{ds}.h5")
-        match.save(fpath)
-        logger.info(f"Saved match to file: {fpath}")
+        try:
+            match = run_match_aman(runner, aman, ds, wafer_slot=wafer_slot)
+            fpath = os.path.join(runner.match_dir, f"{ds}.h5")
+            match.save(fpath)
+            logger.info(f"Saved match to file: {fpath}")
+        except Exception as e:
+            add_to_failed_cache(
+                runner.failed_detset_cache_path, ds, "MATCH_FAILED",
+                runner.cfg
+            )
+            logger.error(f"deset {ds} failed with {e}")
+            continue
 
     return True
 


### PR DESCRIPTION
The `update_det_match` process on Prefect is failing with the error:

`State message: Flow run encountered an exception. FileNotFoundError: [Errno 2] No such file or directory: '/so/data/lati6/obs/17268/obs_1726844446_lati6_001/M_index.yaml'`

I believe this is related to some detsets failing due to only a handful of detectors having detcal.  In the `update_det_match` output, I see:

```
Loaded obs_id obs_1698366808_lati1_010. Running matches for detsets:
2025-05-15 08:53:17,925 INFO update_det_match :     - ufm_mv24_1698361003_tune
  0%|                                                                                                       | 0/27 [00:00<?, ?it/s]
2025-05-15 08:53:18,190 ERROR update_det_match : deset ufm_mv24_1698361003_tune failed with float division by zero
```

Which is one of the obsids that is failing.  This is preceded by:

`WARNING: sotodlib.core.metadata.loader: Only 4 of 1794 detectors have data for metadata specified by spec={'db': '/global/cfs/cdirs/sobs/metadata/lat/manifests//det_cal/v0/det_cal_local.sqlite', 'name': 'det_cal'}. Trimming.`

This just wraps a try and except around the match function and makes sure that the detset in question will be added to the failed list.  This doesn't directly address the problem which is older files missing but once update_det_match is re-run on `Nersc` with this it should skip these files.  It will still fail if newer obsids files are missing, which I think is the behavior we want.