### PR TITLE
add edge_guard in filter_for_source

### DIFF
--- a/sotodlib/coords/planets.py
+++ b/sotodlib/coords/planets.py
@@ -228,7 +228,7 @@ def get_horizon_P(tod, az, el, receiver_fixed=False, **kw):
 
 def filter_for_sources(tod=None, signal=None, source_flags=None,
                        n_modes=10, low_pass=None,
-                       wrap=None):
+                       wrap=None, edge_guard=None):
     """Mask and gap-fill the signal at samples flagged by source_flags.
     Then PCA the resulting time ordered data.  Restore the flagged
     signal, remove the strongest modes from PCA.
@@ -264,6 +264,16 @@ def filter_for_sources(tod=None, signal=None, source_flags=None,
         raise ValueError("Must provide signal if tod is None")
     if signal is None:
         raise ValueError("signal somehow still None!")
+    
+    if edge_guard is not None:
+        if isinstance(edge_guard, int):
+            edgebl = np.zeros(source_flags.shape[-1], dtype=bool)
+            edgebl[edge_guard:-edge_guard] = True
+            edgerm = so3g.proj.ranges.RangesMatrix.from_mask(edgebl)
+            for iflag in source_flags:
+                iflag.intersect(edgerm)
+        else:
+            raise ValueError("edge_guard must be an int.")
 
     # Get a reasonable gap fill.
     signal_pca = signal.copy()

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -1761,6 +1761,8 @@ class FilterForSources(_Preprocess):
         process:
           n_modes: 10
           source_flags: "source_flags"
+          edge_gurd: 10 # Number of samples to make the first and last flags False
+          trim_samps: 100
 
     .. autofunction:: sotodlib.coords.planets.filter_for_sources
     """
@@ -1775,10 +1777,17 @@ class FilterForSources(_Preprocess):
         n_modes = self.process_cfgs.get('n_modes')
         signal = aman.get(self.signal)
         flags = aman.flags.get(self.process_cfgs.get('source_flags'))
+        edge_guard = self.process_cfgs.get('edge_guard')
         if aman.dets.count < n_modes:
             raise ValueError(f'The number of pca modes {n_modes} is '
                              f'larger than the number of detectors {aman.dets.count}.')
-        planets.filter_for_sources(aman, signal=signal, source_flags=flags, n_modes=n_modes)
+        planets.filter_for_sources(aman, signal=signal, source_flags=flags, n_modes=n_modes, edge_guard=edge_guard)
+        if self.process_cfgs.get("trim_samps"):
+            trim = self.process_cfgs["trim_samps"]
+            proc_aman.restrict('samps', (aman.samps.offset + trim,
+                                         aman.samps.offset + aman.samps.count - trim))
+            aman.restrict('samps', (aman.samps.offset + trim,
+                                    aman.samps.offset + aman.samps.count - trim))
 
 class PTPFlags(_Preprocess):
     """Find detectors with anomalous peak-to-peak signal.


### PR DESCRIPTION
This PR introduces edge_guard in `filter_for_source`. This optional argument is useful to avoid a problem of gapfilling based on only one side of TOD whereas it is usually based on both side of TOD.