### PR TITLE
Allow filter chaining

### DIFF
--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -1511,8 +1511,7 @@ class FourierFilter(_Preprocess):
     def process(self, aman, proc_aman, sim=False):
         field = self.process_cfgs.get("noise_fit_array", None)
         if field:
-            _noise_fit = attrgetter(field)
-            noise_fit = _noise_fit(proc_aman)
+            noise_fit = proc_aman[field]
         else:
             noise_fit = None
 

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -1456,7 +1456,18 @@ class FourierFilter(_Preprocess):
     """
     Applies a chain of fourier filters (defined in fft_ops) to the data.
 
-    Example config file entry::
+    Example config file entry for one filter::
+
+    - name: "fourier_filter"
+      wrap_name: "lpf_sig"
+      signal_name: "signal"
+      process:
+        filt_function: "timeconst_filter"
+        filter_params:
+          timeconst: "det_cal.tau_eff"
+          invert: True
+
+    Example config file entry for two filters::
 
     - name: "fourier_filter_chain"
       wrap_name: "lpf_sig"
@@ -1464,10 +1475,10 @@ class FourierFilter(_Preprocess):
       process:
         filters:
           - name: "iir_filter"
-            params:
+            filter_params:
               invert: True
           - name: "timeconst_filter"
-            params:
+            filter_params:
               timeconst: "det_cal.tau_eff"
               invert: True
 
@@ -1480,10 +1491,10 @@ class FourierFilter(_Preprocess):
         noise_fit_array: "noiseQ_fit"
         filters:
           - name: "iir_filter"
-            params:
+            filter_params:
               invert: True
           - name: "timeconst_filter"
-            params:
+            filter_params:
               timeconst: "det_cal.tau_eff"
               invert: True
     See :ref:`fourier-filters` documentation for more details.
@@ -1509,7 +1520,7 @@ class FourierFilter(_Preprocess):
         if filt_list is None:
             filt_list = [{
                 "name": self.process_cfgs.get("filt_function", "high_pass_butter4"),
-                "params": self.process_cfgs.get("filter_params", None)
+                "filter_params": self.process_cfgs.get("filter_params", None)
             }]
 
         filters = []
@@ -1518,7 +1529,7 @@ class FourierFilter(_Preprocess):
             params = tod_ops.fft_ops.build_hpf_params_dict(
                 fname,
                 noise_fit=noise_fit,
-                filter_params=spec.get("params")
+                filter_params=spec.get("filter_params")
             )
             ffun = getattr(tod_ops.filters, fname)
             filters.append(ffun(**params))

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -1509,7 +1509,7 @@ class FourierFilter(_Preprocess):
         if filt_list is None:
             filt_list = [{
                 "name": self.process_cfgs.get("filt_function", "high_pass_butter4"),
-                "params": self.process_cfgs.get("filter_params", {})
+                "params": self.process_cfgs.get("filter_params", None)
             }]
 
         filters = []
@@ -1518,12 +1518,12 @@ class FourierFilter(_Preprocess):
             params = tod_ops.fft_ops.build_hpf_params_dict(
                 fname,
                 noise_fit=noise_fit,
-                filter_params=spec.get("params", {})
+                filter_params=spec.get("params")
             )
             ffun = getattr(tod_ops.filters, fname)
             filters.append(ffun(**params))
 
-        filt = filters[0] if len(filters) == 1 else tod_ops.filters.FilterChain(filters)
+        filt = tod_ops.filters.FilterChain(filters)
 
         filt_tod = tod_ops.filters.fourier_filter(aman, filt,
                                                   signal_name=self.signal_name)


### PR DESCRIPTION
Update `FourierFilter` to allow for filter chaining.  Old input of `filter_function` is still supported for backwards compatibility.
