### PR TITLE
removing the open of file on the fly in context

### DIFF
--- a/sotodlib/core/context.py
+++ b/sotodlib/core/context.py
@@ -550,8 +550,7 @@ def _read_cfg(filename=None, envvar=None, default=None):
         return False, filename, odict()
     with open(filename, 'r') as file:
         yaml_file = yaml.safe_load(file)
-        file.close()
-        return True, filename, yaml_file
+    return True, filename, yaml_file
 
 
 def obsloader_template(db, obs_id, dets=None, prefix=None, samples=None,


### PR DESCRIPTION
Newer versions of python are giving a very annoying warning for opening files on the fly without closing them, like so
`Exception ignored in: <_io.FileIO name='/home/ccaimapo/SimonsObs/iso-sat/v2/contexts/satp1/use_this_local_250516.yaml' mode='rb' closefd=True>
Traceback (most recent call last):
  File "/home/ccaimapo/.local/soconda_v0.6.3/lib/python3.11/site-packages/sotodlib/core/context.py", line 551, in _read_cfg
    return True, filename, yaml.safe_load(open(filename, 'r'))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/ccaimapo/SimonsObs/iso-sat/v2/contexts/satp1/use_this_local_250516.yaml' mode='r' encoding='UTF-8'>`