### PR TITLE
update preproc config checker types

### DIFF
--- a/sotodlib/preprocess/preprocess_util.py
+++ b/sotodlib/preprocess/preprocess_util.py
@@ -1204,7 +1204,7 @@ def check_cfg_match(ref, loaded, logger=None):
                 logger.warning('Config check fails due to ordered pipeline element names not matching.')
                 return False
             else:
-                if type(ref[ri]) is core.AxisManager:
+                if type(ref[ri]) is core.AxisManager and type(loaded[li]) is core.AxisManager:
                     check_cfg_match(ref[ri], loaded[li], logger)
                 elif ref[ri] == loaded[li]:
                     continue


### PR DESCRIPTION
Adds a check for the type of both the reference and loaded axis managers in multilayer preprocessing.  Note this will allow failed checks to pass (as they already do in some cases due to recursion), which will need to be fixed later.