### PR TITLE
fix crossover split

### DIFF
--- a/sotodlib/obs_ops/splits.py
+++ b/sotodlib/obs_ops/splits.py
@@ -88,7 +88,7 @@ def get_split_flags(aman, proc_aman=None, split_cfg=None):
     '''
     # Set default set of splits
     default_cfg = {'high_gain': 0.115, 'high_tau': 1.5e-3,
-                   'det_A': 'A', 'pol_angle': 35, 'det_top': 'BL', 'right_focal_plane': 0,
+                   'det_A': 'A', 'pol_angle': 35, 'crossover': 'BL', 'right_focal_plane': 0,
                    'top_focal_plane': 0, 'central_pixels': 0.071 }
     if split_cfg is None:
         split_cfg = default_cfg
@@ -114,9 +114,9 @@ def get_split_flags(aman, proc_aman=None, split_cfg=None):
     # def pol split
     fm.wrap_dets('high_pol_angle', aman.det_info.wafer.angle > split_cfg['pol_angle'])
     fm.wrap_dets('low_pol_angle', aman.det_info.wafer.angle <= split_cfg['pol_angle'])
-    # det top/bottom split, B and L are cross over, T and R are cross under
-    fm.wrap_dets('det_type_top', [d in split_cfg['det_top'] for d in aman.det_info.wafer.crossover])
-    fm.wrap_dets('det_type_bottom', [d not in split_cfg['det_top'] for d in aman.det_info.wafer.crossover])
+    # crossover split, B and L are cross over, T and R are cross under
+    fm.wrap_dets('crossover', [d in split_cfg['crossover'] for d in aman.det_info.wafer.crossover])
+    fm.wrap_dets('crossunder', [d not in split_cfg['crossover'] for d in aman.det_info.wafer.crossover])
     # Right/left focal plane split
     fm.wrap_dets('det_right', aman.focal_plane.xi > split_cfg['right_focal_plane'])
     fm.wrap_dets('det_left', aman.focal_plane.xi <= split_cfg['right_focal_plane'])

--- a/sotodlib/obs_ops/splits.py
+++ b/sotodlib/obs_ops/splits.py
@@ -88,7 +88,7 @@ def get_split_flags(aman, proc_aman=None, split_cfg=None):
     '''
     # Set default set of splits
     default_cfg = {'high_gain': 0.115, 'high_tau': 1.5e-3,
-                   'det_A': 'A', 'pol_angle': 35, 'det_top': 'B', 'right_focal_plane': 0,
+                   'det_A': 'A', 'pol_angle': 35, 'det_top': 'BL', 'right_focal_plane': 0,
                    'top_focal_plane': 0, 'central_pixels': 0.071 }
     if split_cfg is None:
         split_cfg = default_cfg
@@ -114,9 +114,9 @@ def get_split_flags(aman, proc_aman=None, split_cfg=None):
     # def pol split
     fm.wrap_dets('high_pol_angle', aman.det_info.wafer.angle > split_cfg['pol_angle'])
     fm.wrap_dets('low_pol_angle', aman.det_info.wafer.angle <= split_cfg['pol_angle'])
-    # det top/bottom split
-    fm.wrap_dets('det_type_top', aman.det_info.wafer.crossover > split_cfg['det_top'])
-    fm.wrap_dets('det_type_bottom', aman.det_info.wafer.crossover <= split_cfg['det_top'])
+    # det top/bottom split, B and L are cross over, T and R are cross under
+    fm.wrap_dets('det_type_top', [d in split_cfg['det_top'] for d in aman.det_info.wafer.crossover])
+    fm.wrap_dets('det_type_bottom', [d not in split_cfg['det_top'] for d in aman.det_info.wafer.crossover])
     # Right/left focal plane split
     fm.wrap_dets('det_right', aman.focal_plane.xi > split_cfg['right_focal_plane'])
     fm.wrap_dets('det_left', aman.focal_plane.xi <= split_cfg['right_focal_plane'])

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -1961,7 +1961,7 @@ class SplitFlags(_Preprocess):
             high_tau: 1.5e-3
             det_A: A
             pol_angle: 35
-            det_top: B
+            crossover: BL
             high_leakage: 1.0e-3
             high_2f: 1.5e-3
             right_focal_plane: 0


### PR DESCRIPTION
This resolves https://github.com/simonsobs/sotodlib/issues/1263
Daniel confirmed by directly looking at the full wafer GDS and following traces to the labeled bond pads. because we did not find good document for this.
This split was not used in sat-iso null tests.