### PR TITLE
TOAST Scan-Synchronous Signal now requires Stokes weights

### DIFF
--- a/sotodlib/toast/workflows/sim_optical_pickup.py
+++ b/sotodlib/toast/workflows/sim_optical_pickup.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2023 Simons Observatory.
+# Copyright (c) 2023-2025 Simons Observatory.
 # Full license can be found in the top level "LICENSE" file.
 """Simulated optical pickup from various sources.
 """
@@ -47,6 +47,7 @@ def simulate_scan_synchronous_signal(job, otherargs, runargs, data):
 
     if job_ops.sim_sss.enabled:
         job_ops.sim_sss.detector_pointing = job_ops.det_pointing_azel_sim
+        job_ops.sim_sss.stokes_weights = job_ops.weights_azel
         job_ops.sim_sss.apply(data)
 
 


### PR DESCRIPTION
Tiny update to use the new polarized SSS support in TOAST: https://github.com/hpc4cmb/toast/pull/833