### PR TITLE
Add mean white noise QA metric

### DIFF
--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -705,8 +705,8 @@ class Noise(_Preprocess):
                 vals.append(np.nanmean(white_noise))
 
                 tags_base = {
-                        k: _get_tag(meta.det_info, k, subset[0]) for k in tag_keys if _has_tag(meta.det_info, k)
-                    }
+                    k: _get_tag(meta.det_info, k, subset[0]) for k in tag_keys if _has_tag(meta.det_info, k)
+                }
                 tags_base["telescope"] = meta.obs_info.telescope
 
                 tags.append(tag_base)

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -551,6 +551,7 @@ class Noise(_Preprocess):
 
     """
     name = "noise"
+    _influx_field = "median_white_noise"
 
     def __init__(self, step_cfgs):
         self.psd = step_cfgs.get('psd', 'psd')

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -704,12 +704,12 @@ class Noise(_Preprocess):
                 white_noise = proc_aman[noise_aman].white_noise[subset]
                 vals.append(np.nanmean(white_noise))
 
-            tags_base = {
-                    k: _get_tag(meta.det_info, k, subset[0]) for k in tag_keys if _has_tag(meta.det_info, k)
-                }
-                tags_base["telescope"] = meta.obs_info.telescope
+                tags_base = {
+                        k: _get_tag(meta.det_info, k, subset[0]) for k in tag_keys if _has_tag(meta.det_info, k)
+                    }
+                    tags_base["telescope"] = meta.obs_info.telescope
 
-            tags.append(tag_base)
+                tags.append(tag_base)
 
         obs_time = [meta.obs_info.timestamp] * len(tags)
         return {

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -710,7 +710,7 @@ class Noise(_Preprocess):
                     k: _get_tag(meta.det_info, k, subset[0]) for k in tag_keys if _has_tag(meta.det_info, k)
                 }
                 tags_base["telescope"] = meta.obs_info.telescope
-                tags.append(tag_base)
+                tags.append(tags_base)
 
         obs_time = [meta.obs_info.timestamp] * len(tags)
         return {

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -707,7 +707,7 @@ class Noise(_Preprocess):
                 tags_base = {
                         k: _get_tag(meta.det_info, k, subset[0]) for k in tag_keys if _has_tag(meta.det_info, k)
                     }
-                    tags_base["telescope"] = meta.obs_info.telescope
+                tags_base["telescope"] = meta.obs_info.telescope
 
                 tags.append(tag_base)
 

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -671,7 +671,8 @@ class Noise(_Preprocess):
 
     @classmethod
     def gen_metric(cls, meta, proc_aman, noise_aman="noise"):
-        """ Generate a QA metric for the coefficients of the white noise
+        """ Generate a QA metric for median of the detector white noise
+        values.
 
         Arguments
         ---------
@@ -702,13 +703,12 @@ class Noise(_Preprocess):
                 )[0]
 
                 white_noise = proc_aman[noise_aman].white_noise[subset]
-                vals.append(np.nanmean(white_noise))
+                vals.append(np.nanmedian(white_noise))
 
                 tags_base = {
                     k: _get_tag(meta.det_info, k, subset[0]) for k in tag_keys if _has_tag(meta.det_info, k)
                 }
                 tags_base["telescope"] = meta.obs_info.telescope
-
                 tags.append(tag_base)
 
         obs_time = [meta.obs_info.timestamp] * len(tags)

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -696,7 +696,6 @@ class Noise(_Preprocess):
         tags = []
         vals = []
         from ..qa.metrics import _get_tag, _has_tag
-        import re
         for bp in np.unique(meta.det_info.wafer.bandpass):
             for ws in np.unique(meta.det_info.wafer_slot):
                 subset = np.where(

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -668,7 +668,57 @@ class Noise(_Preprocess):
             return meta
         else:
             return keep
-    
+
+    @classmethod
+    def gen_metric(cls, meta, proc_aman, noise_aman="noise"):
+        """ Generate a QA metric for the coefficients of the white noise
+
+        Arguments
+        ---------
+        meta : AxisManager
+            The full metadata container.
+        proc_aman : AxisManager
+            The metadata containing just the output of this process.
+        noise_aman : str
+            Name of the noise axis manager in proc_aman
+
+        Returns
+        -------
+        line : dict
+            InfluxDB line entry elements to be fed to
+            `site_pipeline.monitor.Monitor.record`
+        """
+        # record one metric per wafer_slot per bandpass
+        # extract these tags for the metric
+        tag_keys = ["wafer_slot", "tel_tube", "wafer.bandpass"]
+        tags = []
+        vals = []
+        from ..qa.metrics import _get_tag, _has_tag
+        import re
+        for bp in np.unique(meta.det_info.wafer.bandpass):
+            for ws in np.unique(meta.det_info.wafer_slot):
+                subset = np.where(
+                    (meta.det_info.wafer_slot == ws) & (meta.det_info.wafer.bandpass == bp)
+                )[0]
+
+                white_noise = proc_aman[noise_aman].white_noise[subset]
+                vals.append(np.nanmean(white_noise))
+
+            tags_base = {
+                    k: _get_tag(meta.det_info, k, subset[0]) for k in tag_keys if _has_tag(meta.det_info, k)
+                }
+                tags_base["telescope"] = meta.obs_info.telescope
+
+            tags.append(tag_base)
+
+        obs_time = [meta.obs_info.timestamp] * len(tags)
+        return {
+            "field": cls._influx_field,
+            "values": vals,
+            "timestamps": obs_time,
+            "tags": tags,
+        }
+
 class Calibrate(_Preprocess):
     """Calibrate the timestreams based on some provided information.
 


### PR DESCRIPTION
Adds the median of all detector white noise values as a QA metric for `record_qa`.