### PR TITLE
Add option to run preprocesing with cprofile

### DIFF
--- a/sotodlib/preprocess/preprocess_util.py
+++ b/sotodlib/preprocess/preprocess_util.py
@@ -18,23 +18,6 @@ from . import _Preprocess, Pipeline, processes
 
 import cProfile, pstats, io
 
-def cprofile(name):
-    """Decorator to call CProfile on a function.
-    """
-    # Reference: https://stackoverflow.com/questions/5375624/a-decorator-that-profiles-a-method-call-and-logs-the-profiling-result
-    def cprofile_func(func):
-        def wrapper(*args, **kwargs):
-            prof = cProfile.Profile()
-            retval = prof.runcall(func, *args, **kwargs)
-            s = io.StringIO()
-            sortby = 'cumulative' # time spent by function and called subfunctions
-            ps = pstats.Stats(prof, stream=s).sort_stats(sortby)
-            ps.print_stats(20) # print 10 longest calls
-            print(f"{name} {func.__name__}: {s.getvalue()}")
-            return retval
-
-        return wrapper
-    return cprofile_func
 
 
 def profile_function(func, profile_path, *args, **kwargs):

--- a/sotodlib/preprocess/preprocess_util.py
+++ b/sotodlib/preprocess/preprocess_util.py
@@ -1045,7 +1045,10 @@ def preproc_or_load_group(obs_id, configs_init, dets, configs_proc=None,
             aman = context_init.get_obs(obs_id, dets=dets)
             tags = np.array(context_init.obsdb.get(aman.obs_info.obs_id, tags=True)['tags'])
             aman.wrap('tags', tags)
-            proc_aman, success, snapshots_process, snapshots_calc = pipe_init.run(aman, run_tracemalloc=run_tracemalloc)
+            if run_tracemalloc:
+                proc_aman, success, snapshots_process, snapshots_calc = pipe_init.run(aman, run_tracemalloc=run_tracemalloc)
+            else:
+                 proc_aman, success = pipe_init.run(aman)
             aman.wrap('preprocess', proc_aman)
         except Exception as e:
             error = f'Failed to run initial pipeline: {obs_id} {dets}'

--- a/sotodlib/site_pipeline/multilayer_preprocess_tod.py
+++ b/sotodlib/site_pipeline/multilayer_preprocess_tod.py
@@ -7,6 +7,7 @@ import numpy as np
 import argparse
 import traceback
 from typing import Optional
+import cProfile, pstats, io
 from sotodlib.utils.procs_pool import get_exec_env
 import h5py
 import copy

--- a/sotodlib/site_pipeline/multilayer_preprocess_tod.py
+++ b/sotodlib/site_pipeline/multilayer_preprocess_tod.py
@@ -270,6 +270,12 @@ def get_parser(parser=None):
         default=4
     )
     parser.add_argument(
+        '--profile',
+        help="Run profiling.",
+        type=bool,
+        default=False
+    )
+    parser.add_argument(
         '--raise-error',
         help="Raise an error upon completion if any obsids or groups fail.",
         type=bool,
@@ -291,6 +297,7 @@ def _main(executor: Union["MPICommExecutor", "ProcessPoolExecutor"],
           planet_obs: bool = False,
           verbosity: Optional[int] = None,
           nproc: Optional[int] = 4,
+          run_profiling: Optional[bool] = False,
           raise_error: Optional[bool] = False):
 
     logger = pp_util.init_logger("preprocess", verbosity=verbosity)
@@ -341,8 +348,18 @@ def _main(executor: Union["MPICommExecutor", "ProcessPoolExecutor"],
 
     n_fail = 0
 
+    if run_profiling:
+        profile_dir = os.path.join(os.path.dirname(configs['archive']['policy']['filename']), 'prof')
+        if not(os.path.exists(profile_dir)):
+            os.makedirs(profile_dir)
+    else:
+        profile_dir = None
+
     # run write_block obs-ids in parallel at once then write all to the sqlite db.
-    futures = [executor.submit(multilayer_preprocess_tod, obs_id=r[0]['obs_id'],
+    futures = [executor.submit(pp_util.profile_func,
+                func=multilayer_preprocess_tod,
+                profile_path=os.path.join(profile_dir, f'{r[0]["obs_id"]}.prof') if profile_dir is not None else None,
+                obs_id=r[0]['obs_id'],
                 group_list=r[1], verbosity=verbosity,
                 configs_init=configs_init,
                 configs_proc=configs_proc,
@@ -380,6 +397,23 @@ def _main(executor: Union["MPICommExecutor", "ProcessPoolExecutor"],
             else:
                 pp_util.cleanup_mandb(err, db_datasets_proc, configs_proc, logger, overwrite)
 
+    if run_profiling:
+        combined_profile_dir = os.path.join(profile_dir, 'combined_profile.prof')
+        combined_stats = None
+        for r in run_list:
+            profile_file = os.path.join(profile_dir, f'{r[0]["obs_id"]}.prof')
+            if os.path.exists(profile_file):
+                try:
+                    stats = pstats.Stats(profile_file)
+                    if combined_stats is None:
+                        combined_stats = stats
+                    else:
+                        combined_stats.add(stats)
+                except:
+                    logger.error(f"cannot get stats for {r[0]['obs_id']}")
+        if combined_stats is not None:
+            combined_stats.dump_stats(combined_profile_dir)
+
     if raise_error and n_fail > 0:
         raise RuntimeError(f"multilayer_preprocess_tod: {n_fail}/{len(run_list)} obs_ids failed")
 
@@ -396,6 +430,7 @@ def main(configs_init: str,
          planet_obs: bool = False,
          verbosity: Optional[int] = None,
          nproc: Optional[int] = 4,
+         run_profiling: Optional[bool] = False,
          raise_error: Optional[bool] = False):
 
     rank, executor, as_completed_callable = get_exec_env(nproc)
@@ -414,6 +449,7 @@ def main(configs_init: str,
               planet_obs=planet_obs,
               verbosity=verbosity,
               nproc=nproc,
+              run_profiling=run_profiling,
               raise_error=raise_error)
 
 

--- a/sotodlib/site_pipeline/multilayer_preprocess_tod.py
+++ b/sotodlib/site_pipeline/multilayer_preprocess_tod.py
@@ -400,7 +400,10 @@ def _main(executor: Union["MPICommExecutor", "ProcessPoolExecutor"],
 
     if run_profiling:
         combined_profile_dir = os.path.join(profile_dir, 'combined_profile.prof')
-        combined_stats = None
+        if os.path.exists(combined_profile_dir):
+            combined_stats = pstats.Stats(combined_profile_dir)
+        else:
+            combined_stats = None
         for r in run_list:
             profile_file = os.path.join(profile_dir, f'{r[0]["obs_id"]}.prof')
             if os.path.exists(profile_file):

--- a/sotodlib/site_pipeline/preprocess_tod.py
+++ b/sotodlib/site_pipeline/preprocess_tod.py
@@ -386,38 +386,38 @@ def _main(executor: Union["MPICommExecutor", "ProcessPoolExecutor"],
     else:
         profile_dir = None
 
-    # # Run write_block obs-ids in parallel at once then write all to the sqlite db.
-    # futures = [executor.submit(pp_util.profile_function,
-    #                 func=preprocess_tod,
-    #                 profile_path=os.path.join(profile_dir, f'{r[0]["obs_id"]}.prof') if profile_dir is not None else None,
-    #                 obs_id=r[0]['obs_id'],
-    #                 group_list=r[1], verbosity=verbosity,
-    #                 configs=configs,
-    #                 overwrite=overwrite, run_parallel=True) for r in run_list]
-    # for future in as_completed_callable(futures):
-    #     logger.info('New future as_completed result')
-    #     try:
-    #         err, db_datasets = future.result()
-    #         if err is not None:
-    #             n_fail += 1
-    #     except Exception as e:
-    #         errmsg = f'{type(e)}: {e}'
-    #         tb = ''.join(traceback.format_tb(e.__traceback__))
-    #         logger.info(f"ERROR: future.result()\n{errmsg}\n{tb}")
-    #         f = open(errlog, 'a')
-    #         f.write(f'\n{time.time()}, future.result() error\n{errmsg}\n{tb}\n')
-    #         f.close()
-    #         n_fail+=1
-    #         continue
-    #     futures.remove(future)
+    # Run write_block obs-ids in parallel at once then write all to the sqlite db.
+    futures = [executor.submit(pp_util.profile_function,
+                    func=preprocess_tod,
+                    profile_path=os.path.join(profile_dir, f'{r[0]["obs_id"]}.prof') if profile_dir is not None else None,
+                    obs_id=r[0]['obs_id'],
+                    group_list=r[1], verbosity=verbosity,
+                    configs=configs,
+                    overwrite=overwrite, run_parallel=True) for r in run_list]
+    for future in as_completed_callable(futures):
+        logger.info('New future as_completed result')
+        try:
+            err, db_datasets = future.result()
+            if err is not None:
+                n_fail += 1
+        except Exception as e:
+            errmsg = f'{type(e)}: {e}'
+            tb = ''.join(traceback.format_tb(e.__traceback__))
+            logger.info(f"ERROR: future.result()\n{errmsg}\n{tb}")
+            f = open(errlog, 'a')
+            f.write(f'\n{time.time()}, future.result() error\n{errmsg}\n{tb}\n')
+            f.close()
+            n_fail+=1
+            continue
+        futures.remove(future)
 
-    #     if db_datasets:
-    #         if err is None:
-    #             logger.info(f'Processing future result db_dataset: {db_datasets}')
-    #             for db_dataset in db_datasets:
-    #                 pp_util.cleanup_mandb(err, db_dataset, configs, logger)
-    #         else:
-    #             pp_util.cleanup_mandb(err, db_datasets, configs, logger)
+        if db_datasets:
+            if err is None:
+                logger.info(f'Processing future result db_dataset: {db_datasets}')
+                for db_dataset in db_datasets:
+                    pp_util.cleanup_mandb(err, db_dataset, configs, logger)
+            else:
+                pp_util.cleanup_mandb(err, db_datasets, configs, logger)
 
     if run_profiling:
         combined_profile_dir = os.path.join(profile_dir, 'combined_profile.prof')

--- a/sotodlib/site_pipeline/preprocess_tod.py
+++ b/sotodlib/site_pipeline/preprocess_tod.py
@@ -156,9 +156,9 @@ def preprocess_tod(obs_id,
                         dest_dataset += "_" + gb + "_" + str(g)
                 trace_dir = os.path.join(os.path.dirname(configs['archive']['policy']['filename']), "trace")
                 for i, snap in enumerate(snapshots_process):
-                    snap[1].dump(os.path.join(trace_dir, f"{dest_dataset}_snapshot_process_{snap[0]}.pkl"))
+                    snap[1].dump(os.path.join(trace_dir, f"{dest_dataset}_snapshot_process_{snap[0]}_{i}.pkl"))
                 for i, snap in enumerate(snapshots_calc):
-                    snap[1].dump(os.path.join(trace_dir, f"{dest_dataset}_snapshot_calc_{snap[0]}.pkl"))
+                    snap[1].dump(os.path.join(trace_dir, f"{dest_dataset}_snapshot_calc_{snap[0]}_{i}.pkl"))
             else:
                 proc_aman, success = pipe.run(aman, run_tracemalloc=run_tracemalloc)
 

--- a/sotodlib/site_pipeline/preprocess_tod.py
+++ b/sotodlib/site_pipeline/preprocess_tod.py
@@ -148,14 +148,14 @@ def preprocess_tod(obs_id,
 
             aman = context.get_obs(obs_id, dets=dets)
             if run_tracemalloc:
-                snapshot = tracemalloc.take_snapshot()
+                init_snapshot = ('aman', tracemalloc.take_snapshot())
                 tracemalloc.stop()
             tags = np.array(context.obsdb.get(aman.obs_info.obs_id, tags=True)['tags'])
             aman.wrap('tags', tags)
             if run_tracemalloc:
                 proc_aman, success, snapshots_process, snapshots_calc = pipe.run(aman, run_tracemalloc=run_tracemalloc)
-                snapshots_process = [snapshots] + snapshots_process
-                snapshots_calc = [snapshots] + snapshots_calc
+                snapshots_process = [init_snapshot] + snapshots_process
+                snapshots_calc = [init_snapshot] + snapshots_calc
 
                 dest_dataset = obs_id
                 for gb, g in zip(group_by, group):

--- a/sotodlib/utils/cprofile.py
+++ b/sotodlib/utils/cprofile.py
@@ -1,0 +1,19 @@
+import cProfile, pstats, io
+
+def cprofile(name):
+    """Decorator to call CProfile on a function.
+    """
+    # Reference: https://stackoverflow.com/questions/5375624/a-decorator-that-profiles-a-method-call-and-logs-the-profiling-result
+    def cprofile_func(func):
+        def wrapper(*args, **kwargs):
+            prof = cProfile.Profile()
+            retval = prof.runcall(func, *args, **kwargs)
+            s = io.StringIO()
+            sortby = 'cumulative' # time spent by function and called subfunctions
+            ps = pstats.Stats(prof, stream=s).sort_stats(sortby)
+            ps.print_stats(20) # print 10 longest calls
+            print(f"{name} {func.__name__}: {s.getvalue()}")
+            return retval
+
+        return wrapper
+    return cprofile_func


### PR DESCRIPTION
Adds an optional call to `preprocess_tod` and `multilayer_preprocess_tod` to run with `cprofile` and output profile files.  Also adds `cprofile` decorator.

Might not merge, just adding for keeping track of profiling/benchmarking efforts and having a place for potential related discussions.