### PR TITLE
Quality of life obsdb/manifestdb/resultset fixes

### DIFF
--- a/sotodlib/core/__init__.py
+++ b/sotodlib/core/__init__.py
@@ -14,6 +14,7 @@ from .flagman import FlagManager
 
 from .hardware import Hardware
 
+from . import metadata
 from . import util
 
 from .resources import get_local_file, RESOURCE_DEFAULTS

--- a/sotodlib/core/metadata/manifest.py
+++ b/sotodlib/core/metadata/manifest.py
@@ -633,20 +633,24 @@ class ManifestDb:
             self.conn.commit()
 
     def get_entries(self, fields):
-
-        """Return list of all entry names in database
-        that are in the listed fields
+        """Return unique combinations of data fields (endpoint data) in the
+        database.
 
         Arguments
         ---------
         fields: list of strings
-            should correspond to columns in map table made through 
-            ManifestScheme.add_data_field( field_name )
+            Should correspond to columns in map table made through
+            ManifestScheme.add_data_field(field_name). (For 'range'
+            fields, include __lo or __hi.)
 
         Returns
         --------
-        ResultSet with keys equal to field names
+        ResultSet with keys equal to field names.
+
         """
+        # Make sure all fields are quoted.
+        fields = [(f if f[0] in ["`", "'", "'"] else f"`{f}`")
+                  for f in fields]
         if not isinstance(fields, list):
             raise ValueError("fields must be a list")
         q = f"select distinct {','.join(fields)} from map"

--- a/sotodlib/core/metadata/manifest.py
+++ b/sotodlib/core/metadata/manifest.py
@@ -649,7 +649,7 @@ class ManifestDb:
 
         """
         # Make sure all fields are quoted.
-        fields = [(f if f[0] in ["`", "'", "'"] else f"`{f}`")
+        fields = [(f if f[0] in ["`", "'", '"'] else f"`{f}`")
                   for f in fields]
         if not isinstance(fields, list):
             raise ValueError("fields must be a list")

--- a/sotodlib/core/metadata/obsdb.py
+++ b/sotodlib/core/metadata/obsdb.py
@@ -1,6 +1,7 @@
 import sqlite3
 import os
 import numpy as np
+import warnings
 
 from .resultset import ResultSet
 from . import common
@@ -302,6 +303,11 @@ class ObsDb(object):
         sort_text = ''
         if sort is not None and len(sort):
             sort_text = ' ORDER BY ' + ','.join(sort)
+        if '"' in query_text:
+            warnings.warn('obsdb.query text contains double quotes (") -- '
+                          'replacing with single quotes (\').')
+            query_text = query_text.replace('"', "'")
+
         joins = ''
         extra_fields = []
         if tags is not None and len(tags):

--- a/sotodlib/site_pipeline/update_obsdb.py
+++ b/sotodlib/site_pipeline/update_obsdb.py
@@ -78,7 +78,8 @@ def telescope_lookup(telescope: str):
         return {"telescope": "satp3", "telescope_flavor": "sat",
                 "tube_flavor": "mf", "detector_flavor": "tes"}
     elif telescope == "lat":
-        return {"telescope": "lat", "telescope_flavor": "lat"}
+        return {"telescope": "lat", "telescope_flavor": "lat",
+                "detector_flavor": "tes"}
     else:
         logger.error("unknown telescope type given by bookbinder")
         return {}

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -239,6 +239,10 @@ class MetadataTest(unittest.TestCase):
                          'obs:timestamp': (1300000000, 1400000001),
                          'dataset': 'early'}, filename='y')
 
+        # Does .get_entries work?
+        entries = mandb.get_entries(['obs:timestamp__lo', 'obs:timestamp__hi'])
+        print(entries)
+
         # Does .inspect work properly?
         entries = mandb.inspect({'wafer': 'A'})
         self.assertEqual(len(entries), 3)

--- a/tests/test_obsdb.py
+++ b/tests/test_obsdb.py
@@ -51,6 +51,10 @@ class TestObsDb(unittest.TestCase):
         self.assertGreater(len(r0), 0)
         self.assertEqual(len(r0) + len(r1), len(db))
 
+        # Grumbles about double quotes?
+        with self.assertWarns(UserWarning):
+            r1 = db.query('drift == "setting"')
+
     def test_tags(self):
         db = get_example()
         r0 = db.query(tags=['planet=1', 'cryo_problem', 'not_a_tag'])


### PR DESCRIPTION
- ObsDb will create indices on main tables.
- ObsDb.query will noisily replace double quotes with single quotes in
  query strings.
- update_obsdb will populate LAT "detector_flavor" (previously was
  leaving null).
- ResultSet -- if a column has a None value, some effort is made to
  cast to the type of the other data in the column.
- core imports .metadata, to give easier access to those things and
  simplify use alongside io.metadata
- ManifestDb.get_entries() will auto-quote fields, so colons in field
  names are easier to work with.

Resolves #705, #1178, #1185.
