### PR TITLE
Fix broken pior support

### DIFF
--- a/sotodlib/mapmaking/ml_mapmaker.py
+++ b/sotodlib/mapmaking/ml_mapmaker.py
@@ -189,6 +189,7 @@ class MLEvaluator:
     """Helper for MLMapmaker that represents the action of P in the model d = Px+n."""
     def __init__(self, x_zip, signals, dof, dtype=np.float32):
         self.signals = signals
+        self.x_zip   = x_zip
         self.x       = dof.unzip(x_zip)
         self.dof     = dof
         self.dtype   = dtype
@@ -213,7 +214,8 @@ class MLAccumulator:
     def finish(self):
         """Return the full P'd based on the previous accumulation"""
         self.x = [signal.from_work(w) for signal, w in zip(self.signals, self.owork)]
-        return self.dof.zip(*self.x)
+        self.x_zip = self.dof.zip(*self.x)
+        return self.x_zip
 
 class Signal:
     """This class represents a thing we want to solve for, e.g. the sky, ground, cut samples, etc."""


### PR DESCRIPTION
This fixes the broken or incomplete support for priors in the maximum-likelhood mapmaker. This must have worked before, but has broken at some point, so the prior was not being taken into account at all. This is needed when doing source sub-sampling. Without the prior, the equation system becomes degenerate, and the mapmaker does not converge properly. This pull requests restores the missing functionality. I've tested it with a case that used to not work (a LAT scan of the galaxy), and confirmed that it now converges. The test was done on a branch with some more features for reading in LAT data, but I've isolated the actual fix in this pull request.