### PR TITLE
TOAST mlmapmaker: Add support NmatUnit and NmatWhite noise model

### DIFF
--- a/sotodlib/mapmaking/noise_model.py
+++ b/sotodlib/mapmaking/noise_model.py
@@ -391,5 +391,7 @@ def read_nmat(fname):
     typ  = data.type.decode()
     if   typ == "NmatDetvecs": return NmatDetvecs.from_bunch(data)
     elif typ == "NmatUncorr":  return NmatUncorr .from_bunch(data)
+    elif typ == "NmatWhite":   return NmatWhite  .from_bunch(data)
+    elif typ == "NmatUnit":    return NmatUnit   .from_bunch(data)
     elif typ == "Nmat":        return Nmat       .from_bunch(data)
     else: raise IOError("Unrecognized noise matrix type '%s' in '%s'" % (str(typ), fname))

--- a/sotodlib/mapmaking/noise_model.py
+++ b/sotodlib/mapmaking/noise_model.py
@@ -109,7 +109,7 @@ class NmatUncorr(Nmat):
 
     @staticmethod
     def from_bunch(data):
-        return NmatUncorr(spacing=data.spacing, nbin=data.nbin, nmin=data.nmin, bins=data.bins, ips_binned=data.ips_binned, ivar=data.ivar, window=window, nwin=nwin)
+        return NmatUncorr(spacing=data.spacing, nbin=data.nbin, nmin=data.nmin, bins=data.bins, ips_binned=data.ips_binned, ivar=data.ivar, window=data.window, nwin=data.nwin)
 
 class NmatDetvecs(Nmat):
     def __init__(self, bin_edges=None, eig_lim=16, single_lim=0.55, mode_bins=[0.25,4.0,20],

--- a/sotodlib/toast/ops/mlmapmaker.py
+++ b/sotodlib/toast/ops/mlmapmaker.py
@@ -92,7 +92,7 @@ class MLMapmaker(Operator):
 
     nmat_type = Unicode(
         "NmatDetvecs",
-        help="Noise matrix type is either `NmatDetvecs`, `NmatUncorr` or `Nmat`",
+        help="Noise matrix type is either `NmatDetvecs`, `NmatUncorr`, `NmatWhite`, `NmatUnit` or `Nmat`",
     )
 
     nmat_mode = Unicode(
@@ -288,7 +288,7 @@ class MLMapmaker(Operator):
     @traitlets.validate("nmat_type")
     def _check_nmat_type(self, proposal):
         check = proposal["value"]
-        allowed = ["NmatUncorr", "NmatDetvecs", "Nmat"]
+        allowed = ["NmatUncorr", "NmatDetvecs", "NmatWhite", "NmatUnit", "Nmat"]
         if check not in allowed:
             msg = f"nmat_type must be one of {allowed}, not {check}"
             raise traitlets.TraitError(msg)


### PR DESCRIPTION
Also fix error when loading cached NmatUncorr in TOAST.