### PR TITLE
add process for smurfgaps

### DIFF
--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -2336,6 +2336,8 @@ class TrimFlagEdge(_Preprocess):
 
 class SmurfGapsFlags(_Preprocess):
     """Expand smurfgaps flag of each stream_id to all detectors
+    smurfgaps flags indicates the samples of each stream_id where the
+    lost frames are filled in the bookbinding process.
 
     Example config block::
 

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -2334,6 +2334,34 @@ class TrimFlagEdge(_Preprocess):
         proc_aman.restrict('samps', (proc_aman.samps.offset + trimst,
                                      proc_aman.samps.offset + trimen))
 
+class SmurfGapsFlags(_Preprocess):
+    """Expand smurfgaps flag of each stream_id to all detectors
+
+    Example config block::
+
+        - name: "smurfgaps_flags"
+          calc:
+            buffer: 200
+            name: "smurfgaps"
+            merge: True
+          save: True
+
+    .. autofunction:: sotodlib.tod_ops.flags.expand_smurfgaps_flags
+    """
+    name = "smurfgaps_flags"
+
+    def calc_and_save(self, aman, proc_aman):
+        smurfgaps = tod_ops.flags.expand_smurfgaps_flags(aman, **self.calc_cfgs)
+        flag_aman = core.AxisManager(aman.dets, aman.samps)
+        flag_aman.wrap(self.calc_cfgs['name'], smurfgaps, [(0, 'dets'), (1, 'samps')])
+        self.save(proc_aman, flag_aman)
+
+    def save(self, proc_aman, flag_aman):
+        if self.save_cfgs is None:
+            return
+        if self.save_cfgs:
+            proc_aman.wrap("smurfgaps", flag_aman)
+
 _Preprocess.register(SplitFlags)
 _Preprocess.register(SubtractT2P)
 _Preprocess.register(EstimateT2P)
@@ -2379,3 +2407,4 @@ _Preprocess.register(BadSubscanFlags)
 _Preprocess.register(CorrectIIRParams)
 _Preprocess.register(DetcalNanCuts)
 _Preprocess.register(TrimFlagEdge)
+_Preprocess.register(SmurfGapsFlags)

--- a/sotodlib/tod_ops/flags.py
+++ b/sotodlib/tod_ops/flags.py
@@ -1127,3 +1127,33 @@ def get_noisy_subscan_flags(aman, subscan_stats, nstd_lim=None,
         aman.flags.wrap(name, noisy_subscan_flags)
 
     return noisy_subscan_flags, ~noisy_detector_flags
+
+
+def expand_smurfgaps_flags(aman, buffer=200, name='smurfgaps', merge=True):
+    """
+    Expand smurfgaps flag of each stream_id to all detectors.
+
+    Parameters
+    ----------
+    aman: AxisManager
+        Input AxisManager
+    buffer: int
+        Amount of buffer to apply on smurfgaps
+    name: str
+        Name of flag to add to aman.flags if merge is True.
+    merge: bool
+        If true, merges the generated flag into aman.
+
+    Returns
+    -------
+    smurfgaps: RangesMatrix
+        smurfgaps flag with 'dets' and 'samps' axis
+
+    """
+
+    smurfgaps = RangesMatrix([aman.flags.get('smurfgaps_' + ufm) for ufm in aman.det_info.stream_id])
+    if buffer:
+        smurfgaps = smurfgaps.buffer(buffer)
+    if merge:
+        aman.flags.wrap('smurfgaps', smurfgaps, [(0, 'dets'), (1, 'samps')])
+    return smurfgaps

--- a/sotodlib/tod_ops/flags.py
+++ b/sotodlib/tod_ops/flags.py
@@ -1131,7 +1131,11 @@ def get_noisy_subscan_flags(aman, subscan_stats, nstd_lim=None,
 
 def expand_smurfgaps_flags(aman, buffer=200, name='smurfgaps', merge=True):
     """
-    Expand smurfgaps flag of each stream_id to all detectors.
+    smurfgaps flags indicates the samples of each stream_id where the
+    lost frames are filled in the bookbinding process.
+    See `sotodlib.io.bookbinder.bind`.
+
+    This function expands smurfgaps flags of each stream_id to all detectors.
 
     Parameters
     ----------


### PR DESCRIPTION
This flag is very useful, and we need to use more.
The default buffer value is arbitrary, I chose this based on ws2 of obs_1727642777_satp3_1111111 and obs_1727991085_satp3_1111111

link to the presentation showing the effectiveness of this flag.
https://simonsobs.atlassian.net/wiki/spaces/PRO/pages/806846478/SAT+LAT+Analysis+Section+1+telecons#26-June-2025-(B-slot-%E2%80%93-8pm-ET)