### PR TITLE
Force binned values to have signal dtype

### DIFF
--- a/sotodlib/hwp/hwp.py
+++ b/sotodlib/hwp/hwp.py
@@ -356,7 +356,7 @@ def harms_func(x, modes, coeffs):
     if coeffs is None:
         return vects
     else:
-        harmonics = np.matmul(coeffs, vects)
+        harmonics = np.matmul(coeffs, vects, casting='no')
         return harmonics
 
 

--- a/sotodlib/tod_ops/binning.py
+++ b/sotodlib/tod_ops/binning.py
@@ -44,6 +44,8 @@ def bin_signal(aman, bin_by, signal=None,
         signal = aman.signal
     if range is None:
         range = (np.nanmin(bin_by), np.nanmax(bin_by))
+
+    signal_dtype = signal.dtype
     
     if weight_for_signal is None:
         weight_for_signal = np.ones(aman.samps.count)
@@ -54,9 +56,9 @@ def bin_signal(aman, bin_by, signal=None,
     nbins = len(bin_centers)
     
     # prepare binned signal array
-    binned_signal = np.full([aman.dets.count, nbins], np.nan)
-    binned_signal_squared_mean = np.full([aman.dets.count, nbins], np.nan)
-    binned_signal_sigma = np.full([aman.dets.count, nbins], np.nan)
+    binned_signal = np.full([aman.dets.count, nbins], np.nan, signal.dtype)
+    binned_signal_squared_mean = np.full([aman.dets.count, nbins], np.nan, signal.dtype)
+    binned_signal_sigma = np.full([aman.dets.count, nbins], np.nan, signal.dtype)
     
     # get bin indices
     bin_indices = np.digitize(bin_by, bin_edges) - 1


### PR DESCRIPTION
The binning code promotes the binned data to `float64` even if the input data is in `float32`, so this just forces them to be the same `dtype` as the signal.

Also, just a small change to the hwp harms function `np.matmul` call that ensures it does not promote to `float64` internally.