### PR TITLE
add no_headers=False to load bias lines

### DIFF
--- a/sotodlib/site_pipeline/update_det_cal.py
+++ b/sotodlib/site_pipeline/update_det_cal.py
@@ -342,6 +342,7 @@ def get_obs_info(cfg: DetCalCfg, obs_id: str) -> ObsInfoResult:
             samples=(0, 1),
             ignore_missing=True,
             no_signal=True,
+            no_headers=False,
             on_missing={"det_cal": "skip"},
         )
 


### PR DESCRIPTION
Similar to the change in [this PR](https://github.com/simonsobs/sotodlib/pull/1261), allows `update_det_cal` to load in bias line information when calling get_obs. A quick solution so that this process works. 