### PR TITLE
Add NET metrics to record_qa

### DIFF
--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -670,54 +670,6 @@ class Noise(_Preprocess):
         else:
             return keep
 
-    @classmethod
-    def gen_metric(cls, meta, proc_aman, noise_aman="noise"):
-        """ Generate a QA metric for median of the detector white noise
-        values.
-
-        Arguments
-        ---------
-        meta : AxisManager
-            The full metadata container.
-        proc_aman : AxisManager
-            The metadata containing just the output of this process.
-        noise_aman : str
-            Name of the noise axis manager in proc_aman
-
-        Returns
-        -------
-        line : dict
-            InfluxDB line entry elements to be fed to
-            `site_pipeline.monitor.Monitor.record`
-        """
-        # record one metric per wafer_slot per bandpass
-        # extract these tags for the metric
-        tag_keys = ["wafer_slot", "tel_tube", "wafer.bandpass"]
-        tags = []
-        vals = []
-        from ..qa.metrics import _get_tag, _has_tag
-        for bp in np.unique(meta.det_info.wafer.bandpass):
-            for ws in np.unique(meta.det_info.wafer_slot):
-                subset = np.where(
-                    (meta.det_info.wafer_slot == ws) & (meta.det_info.wafer.bandpass == bp)
-                )[0]
-
-                white_noise = proc_aman[noise_aman].white_noise[subset]
-                vals.append(np.nanmedian(white_noise))
-
-                tags_base = {
-                    k: _get_tag(meta.det_info, k, subset[0]) for k in tag_keys if _has_tag(meta.det_info, k)
-                }
-                tags_base["telescope"] = meta.obs_info.telescope
-                tags.append(tags_base)
-
-        obs_time = [meta.obs_info.timestamp] * len(tags)
-        return {
-            "field": cls._influx_field,
-            "values": vals,
-            "timestamps": obs_time,
-            "tags": tags,
-        }
 
 class Calibrate(_Preprocess):
     """Calibrate the timestreams based on some provided information.

--- a/sotodlib/qa/metrics.py
+++ b/sotodlib/qa/metrics.py
@@ -287,8 +287,10 @@ class PreprocessArrayNET(PreprocessQA):
                 )[0]
 
                 white_noise = meta.preprocess[self._noise_aman].white_noise[subset]
-                if np.any(~np.isnan(white_noise)):
-                    vals.append(np.sqrt(1.0 / np.nansum( 1.0 / (white_noise)**2)))
+                mask = (white_noise != 0) & (~np.isnan(white_noise))
+                good_indices = np.nonzero(mask)[0]
+                if good_indices.size > 0:
+                    vals.append(np.sqrt(1.0 / np.sum(1.0 / (white_noise[good_indices])**2)))
                 else:
                     vals.append(0.0)
 
@@ -354,8 +356,10 @@ class PreprocessDetNET(PreprocessQA):
                 )[0]
 
                 white_noise = meta.preprocess[self._noise_aman].white_noise[subset]
-                if np.any(~np.isnan(white_noise)):
-                    vals.append((np.sqrt(1.0 / np.nansum( 1.0 / (white_noise)**2))) * np.sqrt(len(subset)))
+                mask = (white_noise != 0) & (~np.isnan(white_noise))
+                good_indices = np.nonzero(mask)[0]
+                if good_indices.size > 0:
+                    vals.append(np.sqrt(1.0 / np.sum(1.0 / (white_noise[good_indices])**2)) * np.sqrt(len(good_indices)))
                 else:
                     vals.append(0.0)
 

--- a/sotodlib/qa/metrics.py
+++ b/sotodlib/qa/metrics.py
@@ -301,7 +301,7 @@ class PreprocessArrayNET(PreprocessQA):
 
         obs_time = [meta.obs_info.timestamp] * len(tags)
         return {
-            "field": cls._influx_field,
+            "field": self._influx_field,
             "values": vals,
             "timestamps": obs_time,
             "tags": tags,
@@ -369,7 +369,7 @@ class PreprocessDetNET(PreprocessQA):
 
         obs_time = [meta.obs_info.timestamp] * len(tags)
         return {
-            "field": cls._influx_field,
+            "field": self._influx_field,
             "values": vals,
             "timestamps": obs_time,
             "tags": tags,

--- a/sotodlib/qa/metrics.py
+++ b/sotodlib/qa/metrics.py
@@ -289,7 +289,7 @@ class PreprocessArrayNET(PreprocessQA):
                 mask = (white_noise != 0) & (~np.isnan(white_noise))
                 good_indices = np.nonzero(mask)[0]
                 if good_indices.size > 0:
-                    vals.append(np.sqrt(1.0 / np.sum(1.0 / (white_noise[good_indices])**2)))
+                    vals.append(np.sqrt(1.0 / np.nansum(1.0 / (white_noise[good_indices])**2)))
                 else:
                     vals.append(0.0)
 
@@ -357,7 +357,7 @@ class PreprocessDetNET(PreprocessQA):
                 mask = (white_noise != 0) & (~np.isnan(white_noise))
                 good_indices = np.nonzero(mask)[0]
                 if good_indices.size > 0:
-                    vals.append(np.sqrt(1.0 / np.sum(1.0 / (white_noise[good_indices])**2)) * np.sqrt(len(good_indices)))
+                    vals.append(np.sqrt(1.0 / np.nansum(1.0 / (white_noise[good_indices])**2)) * np.sqrt(len(good_indices)))
                 else:
                     vals.append(0.0)
 

--- a/sotodlib/qa/metrics.py
+++ b/sotodlib/qa/metrics.py
@@ -279,7 +279,6 @@ class PreprocessArrayNET(PreprocessQA):
         tag_keys += [t for t in self._tags if t not in tag_keys]
         tags = []
         vals = []
-        from ..qa.metrics import _get_tag, _has_tag
         for bp in np.unique(meta.det_info.wafer.bandpass):
             for ws in np.unique(meta.det_info.wafer_slot):
                 subset = np.where(
@@ -348,7 +347,6 @@ class PreprocessDetNET(PreprocessQA):
         tag_keys += [t for t in self._tags if t not in tag_keys]
         tags = []
         vals = []
-        from ..qa.metrics import _get_tag, _has_tag
         for bp in np.unique(meta.det_info.wafer.bandpass):
             for ws in np.unique(meta.det_info.wafer_slot):
                 subset = np.where(


### PR DESCRIPTION
Adds array NETs and effective per-detector NETs to `record_qa`.  Removes the median noise `gen_metric` since these should replace that.

Tested with dev `InfluxDb` and the config in this PR:
https://github.com/simonsobs/site-pipeline-configs/pull/142