### PR TITLE
Prevent fit failures due to warnings

### DIFF
--- a/sotodlib/tod_ops/fft_ops.py
+++ b/sotodlib/tod_ops/fft_ops.py
@@ -529,13 +529,11 @@ def noise_model(f, params, **fixed_param):
             raise ValueError('The number of fit parameters are invalid.')
     else:
         raise ValueError('"alpha" or "wn" can be a fixed parameter.')
-
     return wn**2 * (1 + (fknee / f) ** alpha)
 
 def neglnlike(params, x, y, bin_size=1, **fixed_param):
     model = noise_model(x, params, **fixed_param)
     output = np.sum((np.log(model) + y / model)*bin_size)
-
     if not np.isfinite(output):
         return 1.0e30
     return output

--- a/sotodlib/tod_ops/fft_ops.py
+++ b/sotodlib/tod_ops/fft_ops.py
@@ -835,15 +835,15 @@ def fit_noise_model(
             return
         if fixed_param == None:
             initial_params = np.array([wn_est, fknee_est, alpha_est])
-            bounds= [(0, None), (0, None), (0, 10)]
+            bounds= ((sys.float_info.min, None), (sys.float_info.min, None), (0, 10))
         if fixed_param == "wn":
             initial_params = np.array([fknee_est, alpha_est])
             fixed = wn_est
-            bounds= [(sys.float_info.min, None), (0, 10)]
+            bounds= ((sys.float_info.min, None), (0, 10))
         if fixed_param == "alpha":
             initial_params = np.array([wn_est, fknee_est])
             fixed = alpha_est
-            bounds= [(sys.float_info.min, None), (sys.float_info.min, None)]
+            bounds= ((sys.float_info.min, None), (sys.float_info.min, None))
 
         for i in range(len(pxx)):
             p = pxx[i]

--- a/sotodlib/tod_ops/fft_ops.py
+++ b/sotodlib/tod_ops/fft_ops.py
@@ -529,11 +529,13 @@ def noise_model(f, params, **fixed_param):
             raise ValueError('The number of fit parameters are invalid.')
     else:
         raise ValueError('"alpha" or "wn" can be a fixed parameter.')
+
     return wn**2 * (1 + (fknee / f) ** alpha)
 
 def neglnlike(params, x, y, bin_size=1, **fixed_param):
     model = noise_model(x, params, **fixed_param)
     output = np.sum((np.log(model) + y / model)*bin_size)
+
     if not np.isfinite(output):
         return 1.0e30
     return output
@@ -764,99 +766,97 @@ def fit_noise_model(
         into input aman.
     """
 
-    with warnings.catch_warnings():
-        warnings.filterwarnings("error")
+    if signal is None:
+        signal = aman.signal
 
-        if signal is None:
-            signal = aman.signal
-
-        if f is None or pxx is None:
-            psdargs['noverlap'] = psdargs.get('noverlap', 0)
-            f, pxx, nseg = calc_psd(
-                aman,
-                signal=signal,
-                timestamps=aman.timestamps,
-                freq_spacing=freq_spacing,
-                merge=merge_psd,
-                subscan=subscan,
-                full_output=True,
-                **psdargs,
-            )
-        if np.any(mask):
-            if isinstance(mask, np.ndarray):
-                pass
-            elif isinstance(mask, Ranges):
-                mask = ~mask.mask()
-            elif mask == True:
-                if 'psd_mask' in aman:
-                    mask = ~aman.psd_mask.mask()
-                else: # Calculate on the fly
-                    mask = ~(get_psd_mask(aman, f=f, merge=False).mask())
-            else:
-                raise ValueError("mask should be an ndarray or True")
-            f = f[mask]
-            pxx = pxx[:, mask]
-
-        if subscan:
-            fit_noise_model_kwargs = {"fknee_est": fknee_est, "wn_est": wn_est, "alpha_est": alpha_est,
-                                      "lowf": lowf, "f_max": f_max, "fixed_param": fixed_param,
-                                      "binning": binning, "unbinned_mode": unbinned_mode, "base": base,
-                                      "freq_spacing": freq_spacing}
-            fitout, covout = _fit_noise_model_subscan(aman, signal,  f, pxx, fit_noise_model_kwargs)
-            axis_map_fit = [(0, "dets"), (1, "noise_model_coeffs"), (2, aman.subscans)]
-            axis_map_cov = [(0, "dets"), (1, "noise_model_coeffs"), (2, "noise_model_coeffs"), (3, aman.subscans)]
+    if f is None or pxx is None:
+        psdargs['noverlap'] = psdargs.get('noverlap', 0)
+        f, pxx, nseg = calc_psd(
+            aman,
+            signal=signal,
+            timestamps=aman.timestamps,
+            freq_spacing=freq_spacing,
+            merge=merge_psd,
+            subscan=subscan,
+            full_output=True,
+            **psdargs,
+        )
+    if np.any(mask):
+        if isinstance(mask, np.ndarray):
+            pass
+        elif isinstance(mask, Ranges):
+            mask = ~mask.mask()
+        elif mask == True:
+            if 'psd_mask' in aman:
+                mask = ~aman.psd_mask.mask()
+            else: # Calculate on the fly
+                mask = ~(get_psd_mask(aman, f=f, merge=False).mask())
         else:
-            eix = np.argmin(np.abs(f - f_max))
-            if lowf is None:
-                six = 1
-            else:
-                six = np.argmin(np.abs(f - lowf))
-            f = f[six:eix]
-            pxx = pxx[:, six:eix]
-            bin_size = 1
-            # binning
-            if binning == True:
-                f, pxx, bin_size = get_binned_psd(aman, f=f, pxx=pxx, unbinned_mode=unbinned_mode,
-                                                  base=base, merge=False)
-            fitout = np.zeros((aman.dets.count, 3))
-            # This is equal to np.sqrt(np.diag(cov)) when doing curve_fit
-            covout = np.zeros((aman.dets.count, 3, 3))
-            if isinstance(wn_est, (int, float)):
-                wn_est = np.full(aman.dets.count, wn_est)
-            elif len(wn_est)!=aman.dets.count:
-                print('Size of wn_est must be equal to aman.dets.count or a single value.')
-                return
-            if isinstance(fknee_est, (int, float)):
-                fknee_est = np.full(aman.dets.count, fknee_est)
-            elif len(fknee_est)!=aman.dets.count:
-                print('Size of fknee_est must be equal to aman.dets.count or a single value.')
-                return
-            if isinstance(alpha_est, (int, float)):
-                alpha_est = np.full(aman.dets.count, alpha_est)
-            elif len(alpha_est)!=aman.dets.count:
-                print('Size of alpha_est must be equal to aman.dets.count or a single value.')
-                return
-            if fixed_param == None:
-                initial_params = np.array([wn_est, fknee_est, alpha_est])
-                bounds= [(sys.float_info.min, None), (sys.float_info.min, None), (0, 10)]
-            if fixed_param == "wn":
-                initial_params = np.array([fknee_est, alpha_est])
-                fixed = wn_est
-                bounds= [(sys.float_info.min, None), (0, 10)]
-            if fixed_param == "alpha":
-                initial_params = np.array([wn_est, fknee_est])
-                fixed = alpha_est
-                bounds= [(sys.float_info.min, None), (sys.float_info.min, None)]
+            raise ValueError("mask should be an ndarray or True")
+        f = f[mask]
+        pxx = pxx[:, mask]
 
-            for i in range(len(pxx)):
-                p = pxx[i]
-                p0 = initial_params.T[i]
-                _fixed = {}
-                if fixed_param != None:
-                    _fixed = {fixed_param: fixed[i]}
-                res = minimize(lambda params: neglnlike(params, f, p, bin_size=bin_size, **_fixed),
-                               p0, bounds=bounds, method="Nelder-Mead")
+    if subscan:
+        fit_noise_model_kwargs = {"fknee_est": fknee_est, "wn_est": wn_est, "alpha_est": alpha_est,
+                                  "lowf": lowf, "f_max": f_max, "fixed_param": fixed_param,
+                                  "binning": binning, "unbinned_mode": unbinned_mode, "base": base,
+                                  "freq_spacing": freq_spacing}
+        fitout, covout = _fit_noise_model_subscan(aman, signal,  f, pxx, fit_noise_model_kwargs)
+        axis_map_fit = [(0, "dets"), (1, "noise_model_coeffs"), (2, aman.subscans)]
+        axis_map_cov = [(0, "dets"), (1, "noise_model_coeffs"), (2, "noise_model_coeffs"), (3, aman.subscans)]
+    else:
+        eix = np.argmin(np.abs(f - f_max))
+        if lowf is None:
+            six = 1
+        else:
+            six = np.argmin(np.abs(f - lowf))
+        f = f[six:eix]
+        pxx = pxx[:, six:eix]
+        bin_size = 1
+        # binning
+        if binning == True:
+            f, pxx, bin_size = get_binned_psd(aman, f=f, pxx=pxx, unbinned_mode=unbinned_mode,
+                                              base=base, merge=False)
+        fitout = np.zeros((aman.dets.count, 3))
+        # This is equal to np.sqrt(np.diag(cov)) when doing curve_fit
+        covout = np.zeros((aman.dets.count, 3, 3))
+        if isinstance(wn_est, (int, float)):
+            wn_est = np.full(aman.dets.count, wn_est)
+        elif len(wn_est)!=aman.dets.count:
+            print('Size of wn_est must be equal to aman.dets.count or a single value.')
+            return
+        if isinstance(fknee_est, (int, float)):
+            fknee_est = np.full(aman.dets.count, fknee_est)
+        elif len(fknee_est)!=aman.dets.count:
+            print('Size of fknee_est must be equal to aman.dets.count or a single value.')
+            return
+        if isinstance(alpha_est, (int, float)):
+            alpha_est = np.full(aman.dets.count, alpha_est)
+        elif len(alpha_est)!=aman.dets.count:
+            print('Size of alpha_est must be equal to aman.dets.count or a single value.')
+            return
+        if fixed_param == None:
+            initial_params = np.array([wn_est, fknee_est, alpha_est])
+            bounds= [(0, None), (0, None), (0, 10)]
+        if fixed_param == "wn":
+            initial_params = np.array([fknee_est, alpha_est])
+            fixed = wn_est
+            bounds= [(sys.float_info.min, None), (0, 10)]
+        if fixed_param == "alpha":
+            initial_params = np.array([wn_est, fknee_est])
+            fixed = alpha_est
+            bounds= [(sys.float_info.min, None), (sys.float_info.min, None)]
 
+        for i in range(len(pxx)):
+            p = pxx[i]
+            p0 = initial_params.T[i]
+            _fixed = {}
+            if fixed_param != None:
+                _fixed = {fixed_param: fixed[i]}
+            res = minimize(lambda params: neglnlike(params, f, p, bin_size=bin_size, **_fixed),
+                           p0, bounds=bounds, method="Nelder-Mead")
+            with warnings.catch_warnings():
+                warnings.filterwarnings("error")
                 try:
                     Hfun = ndt.Hessian(lambda params: neglnlike(params, f, p, bin_size=bin_size, **_fixed), full_output=True)
                     hessian_ndt, _ = Hfun(res["x"])
@@ -876,36 +876,36 @@ def fit_noise_model(
                 except RuntimeWarning as e:
                     covout_i = np.full((len(p0), len(p0)), np.nan)
                     print(f'RuntimeWarning: {e}\n Hessian failed because results are: {res["x"]}, for det: {aman.dets.vals[i]}')
-                fitout_i = res.x
-                if fixed_param == "wn":
-                    covout_i = np.insert(covout_i, 0, 0, axis=0)
-                    covout_i = np.insert(covout_i, 0, 0, axis=1)
-                    covout_i[0][0] = np.nan
-                    fitout_i = np.insert(fitout_i, 0, wn_est[i])
-                elif fixed_param == "alpha":
-                    covout_i = np.insert(covout_i, 2, 0, axis=0)
-                    covout_i = np.insert(covout_i, 2, 0, axis=1)
-                    covout_i[2][2] = np.nan
-                    fitout_i = np.insert(fitout_i, 2, alpha_est[i])
-                covout[i] = covout_i
-                fitout[i] = fitout_i
-            axis_map_fit = [(0, "dets"), (1, "noise_model_coeffs")]
-            axis_map_cov = [(0, "dets"), (1, "noise_model_coeffs"), (2, "noise_model_coeffs")]
+            fitout_i = res.x
+            if fixed_param == "wn":
+                covout_i = np.insert(covout_i, 0, 0, axis=0)
+                covout_i = np.insert(covout_i, 0, 0, axis=1)
+                covout_i[0][0] = np.nan
+                fitout_i = np.insert(fitout_i, 0, wn_est[i])
+            elif fixed_param == "alpha":
+                covout_i = np.insert(covout_i, 2, 0, axis=0)
+                covout_i = np.insert(covout_i, 2, 0, axis=1)
+                covout_i[2][2] = np.nan
+                fitout_i = np.insert(fitout_i, 2, alpha_est[i])
+            covout[i] = covout_i
+            fitout[i] = fitout_i
+        axis_map_fit = [(0, "dets"), (1, "noise_model_coeffs")]
+        axis_map_cov = [(0, "dets"), (1, "noise_model_coeffs"), (2, "noise_model_coeffs")]
 
-        noise_model_coeffs = ["white_noise", "fknee", "alpha"]
+    noise_model_coeffs = ["white_noise", "fknee", "alpha"]
 
-        noise_fit_stats = core.AxisManager(
-            aman.dets,
-            core.LabelAxis(
-                name="noise_model_coeffs", vals=np.array(noise_model_coeffs, dtype="<U11")
-            ),
-        )
-        noise_fit_stats.wrap("fit", fitout, axis_map_fit)
-        noise_fit_stats.wrap("cov", covout, axis_map_cov)
+    noise_fit_stats = core.AxisManager(
+        aman.dets,
+        core.LabelAxis(
+            name="noise_model_coeffs", vals=np.array(noise_model_coeffs, dtype="<U11")
+        ),
+    )
+    noise_fit_stats.wrap("fit", fitout, axis_map_fit)
+    noise_fit_stats.wrap("cov", covout, axis_map_cov)
 
-        if merge_fit:
-            aman.wrap(merge_name, noise_fit_stats)
-        return noise_fit_stats
+    if merge_fit:
+        aman.wrap(merge_name, noise_fit_stats)
+    return noise_fit_stats
 
 def get_mask_for_hwpss(freq, hwp_freq, max_mode=10, width=((-0.4, 0.6), (-0.2, 0.2))):
     """


### PR DESCRIPTION
Previously the entire fitting function was wrapped in a warnings to error conversion scope, but this causes problems since there can sometimes be warnings inside the minimizer and that the bounds inside `scipy.minimize` can be violated on some iterations, so having the warning conversion resulted in raising errors.  This just moves it to only wrap around the Hessian calculation which is where we want to actually convert them.  Don't see any performance issue with having this in the loop.

Also, just to note that it looks like we can avoid many Hessian evaluation errors by letting `low_f` go down to `freqs[1] `(default) for Q and U as the fit is better at recovering the shallow 1/f slope of the Q and U PSDs as opposed to cutting it off at say 0.1 or 0.01.

Tested on SATP2 obs_ids that were previously failing when `binning=False`.