### PR TITLE
Fix frequency cutoffs bug

### DIFF
--- a/sotodlib/preprocess/pcore.py
+++ b/sotodlib/preprocess/pcore.py
@@ -512,7 +512,11 @@ class Pipeline(list):
             if aman.dets.count == 0:
                 success = process.name
                 break
-        
+
+        # copy updated frequency cutoffs to full
+        full.move("frequency_cutoffs", None)
+        full.wrap("frequency_cutoffs", proc_aman["frequency_cutoffs"])
+
         return full, success
         
 


### PR DESCRIPTION
Solves problem with trying to access `frequency_cutoffs` in the second layer.  The function `update_full_aman` only copies new axis managers into `full` and therefore does not propagate the new keys added into `proc_aman["frequency_cutoffs"]` as it runs through the first layer since it copied it after the first process.  This just copies it again at the end of `pipe.run()` into `full`.

Probably will want a more general solution to this type of thing at some point though.

Tested with a first layer config containing demodulate (so `demodQ` and `demodU` get added to `frequency_cutoffs`) and with a second layer that contains a PSD calculation using `demodQ` and confirmed it now runs after the change.  Also checked the contents of `full[frequency_cutoffs]` and see that it is now properly populated.