### PR TITLE
Bug fix in get_binned_hwpss

### DIFF
--- a/sotodlib/hwp/hwp.py
+++ b/sotodlib/hwp/hwp.py
@@ -258,11 +258,11 @@ def get_binned_hwpss(aman, signal=None, hwp_angle=None,
                 weight_for_signal = weight_for_signal[np.newaxis, :] * apodize.get_apodize_window_from_flags(aman, 
                                                                                                              flags=flags, 
                                                                                                              apodize_samps=apodize_flags_samps)
+    else:
+        if (flags is not None) and apodize_flags:
+            weight_for_signal = apodize.get_apodize_window_from_flags(aman, flags=flags, apodize_samps=apodize_flags_samps)
         else:
-            if (flags is not None) and apodize_flags:
-                weight_for_signal = apodize.get_apodize_window_from_flags(aman, flags=flags, apodize_samps=apodize_flags_samps)
-            else:
-                weight_for_signal = None
+            weight_for_signal = None
     
     binning_dict = tod_ops.bin_signal(aman, bin_by=hwp_angle, range=[0, 2*np.pi],
                               bins=bins, signal=signal, flags=flags, weight_for_signal=weight_for_signal)


### PR DESCRIPTION
I suggest changing the indent from [line 261](https://github.com/simonsobs/sotodlib/blob/780191b4363bf42ca4bd29c38404b13157618d5b/sotodlib/hwp/hwp.py#L261) to line 265 in `hwp.py`. 
This `else` block should be related to the `if apodize_edges:` block, otherwise `weight_for_signal` will be never assigned.
This change is trivial since almost no one uses `get_hwpss` without the apodization, but I would be happy if someone can review this pull request.