### PR TITLE
Check if frequency cutoffs are in full aman

### DIFF
--- a/sotodlib/preprocess/pcore.py
+++ b/sotodlib/preprocess/pcore.py
@@ -514,7 +514,8 @@ class Pipeline(list):
                 break
 
         # copy updated frequency cutoffs to full
-        full.move("frequency_cutoffs", None)
+        if "frequency_cutoffs" in full:
+            full.move("frequency_cutoffs", None)
         full.wrap("frequency_cutoffs", proc_aman["frequency_cutoffs"])
 
         return full, success


### PR DESCRIPTION
When loading, `update_full_aman` is not called, so it will not contain `frequency_cutoffs` since it is added later.  Adds a check to the `frequency_cutoffs` move to make sure it won't fail.