### PR TITLE
update hwp qa metrics

### DIFF
--- a/sotodlib/qa/metrics.py
+++ b/sotodlib/qa/metrics.py
@@ -429,7 +429,12 @@ class HWPSolSuccess(HWPSolQA):
     _needs_encoder = True
 
     def _gen_value(self, meta):
-        return meta.hwp_solution[f"logger_{self._encoder}"] == "Angle calculation succeeded"
+        if "Angle calculation succeeded" in meta.hwp_solution[f"logger_{self._encoder}"]:
+            return True
+        elif meta.hwp_solution[f"logger_{self._encoder}"] == 'No HWP data':
+            return 'No data'
+        else:
+            return False
 
 
 class HWPSolPrimaryEncoder(HWPSolQA):
@@ -510,5 +515,84 @@ class HWPSolMeanTemplate(HWPSolQA):
     _needs_encoder = True
 
     def _gen_value(self, meta):
-        obs_time = [meta.obs_info.timestamp]
         return np.mean(np.abs(meta.hwp_solution[f"template_{self._encoder}"]))
+
+
+class HWPSolNumDroppedPacketsEncoder(HWPSolQA):
+    """ The number of dropped encoder packets."""
+
+    _influx_field = "num_dropped_packets_encoder"
+    _needs_encoder = True
+
+    def _gen_value(self, meta):
+        return meta.hwp_solution[f"num_dropped_packets_{self._encoder}"]
+
+
+class HWPSolNumDroppedPacketsIrig(HWPSolQA):
+    """ The number of dropped IRIG packets."""
+
+    _influx_field = "num_dropped_packets_irig"
+    _needs_encoder = True
+
+    def _gen_value(self, meta):
+        return meta.hwp_solution[f"num_dropped_packets_irig_{self._encoder}"]
+
+
+class HWPSolNumDataPointGlitchesEncoder(HWPSolQA):
+    """ The number of data point glitches in encoder data."""
+
+    _influx_field = "num_data_point_glitches_encoder"
+    _needs_encoder = True
+
+    def _gen_value(self, meta):
+        return meta.hwp_solution[f"num_glitches_{self._encoder}"]
+
+
+class HWPSolNumDataPointGlitchesIrig(HWPSolQA):
+    """ The number of data point glitches in IRIG data."""
+
+    _influx_field = "num_data_point_glitches_irig"
+    _needs_encoder = True
+
+    def _gen_value(self, meta):
+        return meta.hwp_solution[f"num_glitches_irig_{self._encoder}"]
+
+
+class HWPSolNumValueGlitchesEncoder(HWPSolQA):
+    """ The number of value glitches in encoder data."""
+
+    _influx_field = "num_value_glitches_encoder"
+    _needs_encoder = True
+
+    def _gen_value(self, meta):
+        return meta.hwp_solution[f"num_value_glitches_{self._encoder}"]
+
+
+class HWPSolNumValueGlitchesIrig(HWPSolQA):
+    """ The number of value glitches in IRIG data."""
+
+    _influx_field = "num_value_glitches_irig"
+    _needs_encoder = True
+
+    def _gen_value(self, meta):
+        return meta.hwp_solution[f"num_value_glitches_irig_{self._encoder}"]
+
+
+class HWPSolDeadRotations(HWPSolQA):
+    """ The number of dead rotations that failed to correct glitches."""
+
+    _influx_field = "num_dead_rots"
+    _needs_encoder = True
+
+    def _gen_value(self, meta):
+        return meta.hwp_solution[f"num_dead_rots_{self._encoder}"]
+
+
+class HWPSolDroppedSlits(HWPSolQA):
+    """ The number of dropped slits."""
+
+    _influx_field = "num_dropped_slits"
+    _needs_encoder = True
+
+    def _gen_value(self, meta):
+        return meta.hwp_solution[f"num_dropped_slits_{self._encoder}"]

--- a/sotodlib/qa/metrics.py
+++ b/sotodlib/qa/metrics.py
@@ -423,18 +423,20 @@ class HWPSolQA(QAMetric):
 
 
 class HWPSolSuccess(HWPSolQA):
-    """ Records success of the HWP angle solution calculation, for each encode."""
+    """ Records success of the HWP angle solution calculation, for each encoder.
+    0: No data, 1: Success, 2: Fail
+    """
 
-    _influx_field = "logger"
+    _influx_field = "sol_success"
     _needs_encoder = True
 
     def _gen_value(self, meta):
-        if "Angle calculation succeeded" in meta.hwp_solution[f"logger_{self._encoder}"]:
-            return True
-        elif meta.hwp_solution[f"logger_{self._encoder}"] == 'No HWP data':
-            return 'No data'
+        if meta.hwp_solution[f"logger_{self._encoder}"] == 'No HWP data':
+            return 0
+        elif meta.hwp_solution[f"logger_{self._encoder}"] == "Angle calculation succeeded":
+            return 1
         else:
-            return False
+            return 2
 
 
 class HWPSolPrimaryEncoder(HWPSolQA):


### PR DESCRIPTION
Update hwp angle solution QA metrics to include new statistics of hwp_angles_250711m.
Also update `HWPSolSucces` to distinguish "failure" and "no data" (https://github.com/simonsobs/sotodlib/issues/1210)

Tested in daq-dev.
I needed to make breaking change for `HWPSolSucces` to express more than two states.
I considered keeping `HWPSolSucces` and adding `HWPSolDataExist`  and do some kind of math in grafana instead, but I found this approach difficult. If it is actually easy, I will take this approach.