### PR TITLE
Removing the polarization angle dependency in the h_n maps computation

### DIFF
--- a/sotodlib/toast/ops/h_n.py
+++ b/sotodlib/toast/ops/h_n.py
@@ -87,6 +87,11 @@ class Hn(Operator):
         False, help="If True, do not clear detector pointing matrices after use"
     )
 
+    include_pol_angle = Bool(
+        False,
+        help="If True, include the polarization angle in the angle used to compute h_n",
+    )
+
     nmin = Int(1, help="Minimum `n` to evaluate.")
     nmax = Int(4, help="Maximum `n` to evaluate.")
 
@@ -152,16 +157,18 @@ class Hn(Operator):
                     self.sin_n_name,
                 ]:
                     obs.detdata.ensure(name, detectors=[det])
-                # FIXME: temporary hack until instrument classes are also pre-staged
-                # to GPU -- taken from derivatives_and_beams toast3 branch 
-                focalplane = obs.telescope.focalplane
-                focalplane.detector_data
+                
                 # Compute detector quaternions
                 obs_data = data.select(obs_uid=obs.uid)
                 self.pixel_pointing.detector_pointing.apply(obs_data, detectors=[det])
                 quats = obs.detdata[self.pixel_pointing.detector_pointing.quats][det]
                 theta, phi, psi = qa.to_iso_angles(quats)
-                psi -= focalplane[det]["pol_angle"].value # Removing the polarization angle
+                if not self.include_pol_angle:
+                    # FIXME: temporary hack until instrument classes are also pre-staged
+                    # to GPU -- taken from derivatives_and_beams toast3 branch 
+                    focalplane = obs.telescope.focalplane
+                    focalplane.detector_data
+                    psi -= focalplane[det]["pol_angle"].value # Removing the polarization angle
                 cos_n_new = np.cos(psi)
                 sin_n_new = np.sin(psi)
                 obs.detdata[self.cos_1_name][det] = cos_n_new


### PR DESCRIPTION
In the same spirit as what it done here https://github.com/hpc4cmb/toast/blob/8cb36a922508d268554bde32b3ce7416d5efe6fe/src/toast/ops/derivatives_weights.py#L205 for the TOD template approach, I propose that the $h_n$ maps are generated without the polarization angle. Instead, the polarization angle could be added by the user instead. 

It would be more convenient in the pixel-based mapmaking processes as well.

If you need more details on the equations behind, I would be happy to provide them!