### PR TITLE
update_det_cal: refactor multiprocessing logic to use concurrent.futures

### DIFF
--- a/sotodlib/site_pipeline/update_det_cal.py
+++ b/sotodlib/site_pipeline/update_det_cal.py
@@ -304,8 +304,6 @@ class ObsInfo:
     ------------
     obs_id: str
         Obs id.
-    am: AxisManager
-        AxisManager containing metadata for the given observation.
     iv_obsids: dict
         Dict mapping detset to iv obs-id.
     bs_obsids: dict

--- a/sotodlib/site_pipeline/update_det_cal.py
+++ b/sotodlib/site_pipeline/update_det_cal.py
@@ -14,15 +14,17 @@ from dataclasses import dataclass, astuple, fields
 import numpy as np
 from tqdm.auto import tqdm
 import logging
-from typing import Optional, Union, Dict, List, Any, Tuple, Literal
+from typing import Optional, Union, Dict, List, Any, Tuple, Literal, Callable
 from queue import Queue
 import argparse
 
 from sotodlib import core
 from sotodlib.io.metadata import write_dataset, ResultSet
 from sotodlib.io.load_book import get_cal_obsids
+from sotodlib.utils.procs_pool import get_exec_env
 import sotodlib.site_pipeline.util as sp_util
 import multiprocessing as mp
+from concurrent.futures import ProcessPoolExecutor, as_completed, Future
 import sodetlib.tes_param_correction as tpc
 from sodetlib.operations.iv import IVAnalysis
 from sodetlib.operations.bias_steps import BiasStepAnalysis
@@ -312,16 +314,28 @@ class ObsInfo:
         Dict mapping detset to IV analysis file path.
     bsa_files: dict
         Dict mapping detset to bias step analysis file path.
+    det_info: dict
+        Dict which contains det readout id, band, channel, stream id, detset.
+    bias_lines: list
+        List which stores bias lines
+    biases: ndarray
+        Array of detector biases for each bias line
+    tube_flavor: str
+        Type of optics tube (MF, LF, or UHF)
     """
 
     obs_id: str
-    am: core.AxisManager
 
     iv_obsids: Dict[str, str]
     bs_obsids: Dict[str, str]
 
     iva_files: Dict[str, str]
     bsa_files: Dict[str, str]
+
+    det_info: Dict[str, List[str]]
+    bias_lines: List[str]
+    biases: np.ndarray
+    tube_flavor: str
 
 
 @dataclass
@@ -404,9 +418,19 @@ def get_obs_info(cfg: DetCalCfg, obs_id: str) -> ObsInfoResult:
         if pA_per_phi0 is None:
             pA_per_phi0 = DEFAULT_pA_per_phi0
 
+        # Pass through specific fields from our axismanager so that the result
+        # is Picklable.
         res.obs_info = ObsInfo(
             obs_id=obs_id,
-            am=am,
+            det_info ={"stream_id": am.det_info.stream_id,
+                       "detset": am.det_info.detset,
+                       "readout_id": am.det_info.readout_id,
+                       "band": am.det_info.smurf.band,
+                       "channel": am.det_info.smurf.channel,},
+            bias_lines=am.bias_lines.vals,
+            biases=am.biases,
+            tube_flavor=am.obs_info.tube_flavor,
+
             iv_obsids=iv_obsids,
             bs_obsids=bias_step_obsids,
             iva_files=iva_files,
@@ -435,7 +459,8 @@ class CalRessetResult:
     result_set: Optional[np.ndarray] = None
 
 
-def get_cal_resset(cfg: DetCalCfg, obs_info: ObsInfo, pool=None) -> CalRessetResult:
+def get_cal_resset(cfg: DetCalCfg, obs_info: ObsInfo,
+                   executor=None, as_completed_callable=None) -> CalRessetResult:
     """
     Returns calibration ResultSet for a given ObsId. This pulls IV and bias step
     data for each detset in the observation, and uses that to compute CalInfo
@@ -462,7 +487,6 @@ def get_cal_resset(cfg: DetCalCfg, obs_info: ObsInfo, pool=None) -> CalRessetRes
         ch.setLevel(getattr(logging, cfg.log_level.upper()))
 
     try:
-        am = obs_info.am
 
         ivas = {
             dset: IVAnalysis.load(iva_file)
@@ -484,15 +508,15 @@ def get_cal_resset(cfg: DetCalCfg, obs_info: ObsInfo, pool=None) -> CalRessetRes
         iva = list(ivas.values())[0]
         rtm_bit_to_volt = iva.meta["rtm_bit_to_volt"]
         pA_per_phi0 = iva.meta["pA_per_phi0"]
-        cals = [CalInfo(rid) for rid in am.det_info.readout_id]
+        cals = [CalInfo(rid) for rid in obs_info.det_info["readout_id"]]
         if len(cals) == 0:
             raise ValueError(f"No detectors found for {obs_id}")
 
         # Add IV info
         for i, cal in enumerate(cals):
-            band = am.det_info.smurf.band[i]
-            chan = am.det_info.smurf.channel[i]
-            detset = am.det_info.detset[i]
+            band = obs_info.det_info["band"][i]
+            chan = obs_info.det_info["channel"][i]
+            detset = obs_info.det_info["detset"][i]
             iva = ivas[detset]
 
             if iva is None:  # No IV analysis for this detset
@@ -509,7 +533,7 @@ def get_cal_resset(cfg: DetCalCfg, obs_info: ObsInfo, pool=None) -> CalRessetRes
             cal.p_sat = iva.p_sat[ridx]  # type: ignore
 
         obs_biases = dict(
-            zip(am.bias_lines.vals, am.biases[:, 0] * 2 * rtm_bit_to_volt)
+            zip(obs_info.bias_lines, obs_info.biases[:, 0] * 2 * rtm_bit_to_volt)
         )
         bias_line_is_valid = {k: True for k in obs_biases.keys()}
 
@@ -540,7 +564,7 @@ def get_cal_resset(cfg: DetCalCfg, obs_info: ObsInfo, pool=None) -> CalRessetRes
             for dset in bsas:
                 # logger.debug(f"Applying correction for {dset}")
                 rs = []
-                if pool is None:
+                if executor is None:
                     for b, c in zip(ivas[dset].bands, ivas[dset].channels):
                         chdata = tpc.RpFitChanData.from_data(
                             ivas[dset], bsas[dset], b, c
@@ -550,8 +574,8 @@ def get_cal_resset(cfg: DetCalCfg, obs_info: ObsInfo, pool=None) -> CalRessetRes
                         )
                 else:
                     rs = tpc.run_corrections_parallel(
-                        ivas[dset], bsas[dset], cfg.param_correction_config, pool=pool
-                    )
+                        ivas[dset], bsas[dset], cfg.param_correction_config, executor=executor,
+                        as_completed_callable=as_completed_callable)
                 correction_results[dset] = rs
         res.correction_results = correction_results
 
@@ -562,10 +586,10 @@ def get_cal_resset(cfg: DetCalCfg, obs_info: ObsInfo, pool=None) -> CalRessetRes
             return None
 
         for i, cal in enumerate(cals):
-            band = am.det_info.smurf.band[i]
-            chan = am.det_info.smurf.channel[i]
-            detset = am.det_info.detset[i]
-            stream_id = am.det_info.stream_id[i]
+            band = obs_info.det_info["band"][i]
+            chan = obs_info.det_info["channel"][i]
+            detset = obs_info.det_info["detset"][i]
+            stream_id = obs_info.det_info["stream_id"][i]
             bg = cal.bg
             bsa = bsas[detset]
 
@@ -628,7 +652,7 @@ def get_cal_resset(cfg: DetCalCfg, obs_info: ObsInfo, pool=None) -> CalRessetRes
                 cal.phase_to_pW = pA_per_phi0 / (2 * np.pi) / cal.s_i * cal.polarity
 
             # Add bandpass informaton from bias group
-            tube_flavor = am.obs_info.tube_flavor
+            tube_flavor = obs_info.tube_flavor
             if cal.bg in BGS['lb']:
                 cal.bandpass = BAND_STR[tube_flavor]['lb']
             elif cal.bg in BGS['hb']:
@@ -711,7 +735,10 @@ def handle_result(result: CalRessetResult, cfg: DetCalCfg) -> None:
     )
 
 
-def run_update_site(cfg: DetCalCfg) -> None:
+def run_update_site(
+        cfg: DetCalCfg,
+        executor: Union["MPICommExecutor", "ProcessPoolExecutor"],
+        as_completed_callable: Callable) -> None:
     """
     Main run script for computing det-cal results at the site. This will
     loop over obs-ids and serially gather the ObsInfo from the filesystem and
@@ -733,18 +760,18 @@ def run_update_site(cfg: DetCalCfg) -> None:
 
     logger.info(f"Processing {len(obs_ids)} obsids...")
 
-    with mp.Pool(cfg.nprocs_result_set) as pool:
-        for oid in tqdm(obs_ids, disable=(not cfg.show_pb)):
-            res = get_obs_info(cfg, oid)
-            if not res.success:
-                logger.info(f"Could not get obs info for obs id: {oid}")
-                logger.error(res.traceback)
+    for oid in tqdm(obs_ids, disable=(not cfg.show_pb)):
+        res = get_obs_info(cfg, oid)
+        if not res.success:
+            logger.info(f"Could not get obs info for obs id: {oid}")
+            logger.error(res.traceback)
 
-            if res.obs_info is None:
-                continue
+        if res.obs_info is None:
+            continue
 
-            result_set = get_cal_resset(cfg, res.obs_info, pool=pool)
-            handle_result(result_set, cfg)
+        result_set = get_cal_resset(cfg, res.obs_info, executor=executor,
+                                    as_completed_callable=as_completed_callable)
+        handle_result(result_set, cfg)
 
 
 def run_update_nersc(cfg: DetCalCfg) -> None:
@@ -775,7 +802,8 @@ def run_update_nersc(cfg: DetCalCfg) -> None:
 
     pb = tqdm(total=len(obs_ids), disable=(not cfg.show_pb))
 
-    def callback(result: CalRessetResult):
+    def callback(fut: Future):
+        result = fut.result()
         pb.update()
         handle_result(result, cfg)
 
@@ -785,71 +813,56 @@ def run_update_nersc(cfg: DetCalCfg) -> None:
 
     # We split into multiple pools because:
     # - we don't want to overload sqlite files with too much concurrent access
-    # - we want to be able to continue getting the next obs_info data while ressets are being computed
-    pool1 = mp.Pool(cfg.nprocs_obs_info)
-    pool2 = mp.Pool(cfg.nprocs_result_set)
+    # - we want to be able to continue getting the next obs_info data while
+    # ressets are being computed
+    executor1 = ProcessPoolExecutor(max_workers=cfg.nprocs_obs_info)
+    executor2 = ProcessPoolExecutor(max_workers=cfg.nprocs_result_set)
 
-    resset_async_results: Queue = Queue()
-    obsinfo_async_results: Queue = Queue()
+    resset_futures: list[Future] = []
+    obsinfo_futures: list[Future] = []
 
-    def get_obs_info_callback(result: ObsInfoResult):
-        if result.success:
-            r = pool2.apply_async(
-                get_cal_resset,
-                args=(cfg, result.obs_info),
-                callback=callback,
-                error_callback=errback,
-            )
-            resset_async_results.put(r)
-        else:
-            pb.update()
-            add_to_failed_cache(cfg, result.obs_id, result.traceback)
-            logger.error(
-                f"Failed to get obs_info for {result.obs_id}:\n{result.traceback}"
-            )
+
+    def get_obs_info_callback(fut: Future):
+        try:
+            result = fut.result()
+            if result.success:
+                future = executor2.submit(get_cal_resset, cfg, result.obs_info)
+                future.add_done_callback(callback)
+                resset_futures.append(future)
+            else:
+                pb.update()
+                add_to_failed_cache(cfg, result.obs_id, result.traceback)
+                logger.error(f"Failed to get obs_info for {result.obs_id}:\n{result.traceback}")
+        except Exception as e:
+            errback(e)
 
     try:
         for obs_id in obs_ids:
-            a = pool1.apply_async(
-                get_obs_info,
-                args=(cfg, obs_id),
-                callback=get_obs_info_callback,
-                error_callback=errback,
-            )
-            obsinfo_async_results.put(a)
+            future = executor1.submit(get_obs_info, cfg, obs_id)
+            future.add_done_callback(get_obs_info_callback)
+            obsinfo_futures.append(future)
 
-        while not obsinfo_async_results.empty():
-            obsinfo_async_results.get().wait()
-        while not resset_async_results.empty():
-            resset_async_results.get().wait()
+        # Wait for all obsinfo tasks to complete
+        for fut in as_completed(obsinfo_futures):
+            pass  # results handled in callback
+
+        # Wait for all resset tasks to complete
+        for fut in as_completed(resset_futures):
+            try:
+                fut.result()  # Force exceptions to be raised here if any
+            except Exception as e:
+                errback(e)
 
     finally:
-        pool1.terminate()
-        pool1.join()
-        pool2.terminate()
-        pool2.join()
+        executor1.shutdown(wait=True, cancel_futures=True)
+        executor2.shutdown(wait=True, cancel_futures=True)
+
     pb.close()
     logger.info("Finished updates")
 
 
-def main(config_file: str) -> None:
-    """
-    Run update function. This will chose the correct method to run based on
-    ``cfg.run_method``.
-    """
-    cfg = DetCalCfg.from_yaml(config_file)
-
-    if cfg.run_method == "site":
-        run_update_site(cfg)
-    elif cfg.run_method == "nersc":
-        run_update_nersc(cfg)
-    else:
-        raise ValueError(f"Unknown run_method: {cfg.run_method}")
-
-
 def get_parser(
-    parser: Optional[argparse.ArgumentParser] = None,
-) -> argparse.ArgumentParser:
+    parser: Optional[argparse.ArgumentParser] = None,) -> argparse.ArgumentParser:
     if parser is None:
         p = argparse.ArgumentParser()
     else:
@@ -860,11 +873,30 @@ def get_parser(
     return p
 
 
+def _main(
+    cfg: DetCalCfg,
+    executor: Union["MPICommExecutor", "ProcessPoolExecutor"],
+    as_completed_callable: Callable) -> None:
+    """
+    Run update function. This will chose the correct method to run based on
+    ``cfg.run_method``.
+    """
+
+    if cfg.run_method == "site":
+        run_update_site(cfg, executor, as_completed_callable)
+    elif cfg.run_method == "nersc":
+        # Instantiate our own separate pools when running on NERSC.
+        executor.shutdown(wait=True)
+        run_update_nersc(cfg)
+    else:
+        raise ValueError(f"Unknown run_method: {cfg.run_method}")
+
+
+def main(config_file: str):
+    cfg = DetCalCfg.from_yaml(config_file)
+    rank, executor, as_completed_callable = get_exec_env(cfg.nprocs_result_set)
+    if rank == 0:
+        _main(cfg, executor, as_completed_callable)
+
 if __name__ == "__main__":
-    parser = get_parser()
-    args = parser.parse_args()
-    cfg = DetCalCfg.from_yaml(args.config_file)
-    # This needs to be run here in __main__ or else this will throw a "context
-    # has already been set" RuntimeError
-    mp.set_start_method(cfg.multiprocess_start_method)
-    main(config_file=args.config_file)
+    sp_util.main_launcher(main, get_parser)


### PR DESCRIPTION
- Replace multiprocessing.Pool with executor objects
- Switched from apply_async + callback model to submit + as_completed
- Avoid passing non-pickleable axismanager to subprocesses


I believe these updates will fix the hanging update_det_cal flows on prefect. Separate note that [sodetlib PR#468](https://github.com/simonsobs/sodetlib/pull/468) which similarly updates the multiprocessing code inside `tes_param_correction.py` is required to be merged as well to make these changes work.