### PR TITLE
Also search for label key in get_preprocess_context

### DIFF
--- a/sotodlib/preprocess/preprocess_util.py
+++ b/sotodlib/preprocess/preprocess_util.py
@@ -165,7 +165,7 @@ def get_preprocess_context(configs, context=None):
         context["metadata"] = []
 
     for key in context.get("metadata"):
-        if key.get("name") == "preprocess":
+        if key.get("name") == "preprocess" or key.get("label") == "preprocess":
             found=True
             break
     if not found:


### PR DESCRIPTION
Searches for `label` in addition to `name` in the `get_preprocess_context` function to prevent duplicate entries.