### PR TITLE
Fix error of hwp angle sign

### DIFF
--- a/sotodlib/hwp/__init__.py
+++ b/sotodlib/hwp/__init__.py
@@ -7,6 +7,7 @@ This module contains code for HWP analysis tools
 """
 from .g3thwp import G3tHWP
 from .hwp import (get_hwpss, subtract_hwpss, demod_tod, get_hwp_freq)
+from .hwp_angle_model import apply_hwp_angle_model
 from .sim_hwp import I_to_P_param
 from .sim_hwp import sim_hwpss
 from .sim_hwp import sim_hwpss_2f4f

--- a/sotodlib/hwp/hwp_angle_model.py
+++ b/sotodlib/hwp/hwp_angle_model.py
@@ -40,30 +40,6 @@ def default_model(telescope):
     return model
 
 
-def correct_sign(tod, telescope):
-    """
-    correct hwp angle sign which is known to be wrong.
-
-    Args:
-        tod: hwp_solution AxisManager
-        telescope: name of telescope
-    """
-    if telescope == 'satp1':
-        # start time, stop time, sign to correct
-        correction = [
-            # pid direction was wrong due to the bug of hwp-pid agent
-            [1717446106, 1717706400, 'pid'],
-            # satp1 SCR6 has unusual offcentering
-            # stop time needs to be updated later
-            [1751000000, 2000000000, 'offcenter'],
-        ]
-        for t0, t1, method in correction:
-            if (t0 <= tod.timestamps[0]) and (tod.timestamps[-1] <= t1):
-                tod[method + '_direction'] *= -1
-                logger.info('This observation has known to have wrong sign'
-                            f' of {method}. Apply correction.')
-
-
 def apply_hwp_angle_model(tod, on_sign_ambiguous='fail'):
     """
     Applies `hwp_angle_model` to the `hwp_solution` and construct hwp angle
@@ -97,7 +73,6 @@ def apply_hwp_angle_model(tod, on_sign_ambiguous='fail'):
         model = default_model(telescope)
 
     assert model.model_version == 'v2'
-    correct_sign(hwp, telescope)
     # construct sign
     methods = model.sign_matrix.keys()
     if on_sign_ambiguous in methods:
@@ -108,9 +83,9 @@ def apply_hwp_angle_model(tod, on_sign_ambiguous='fail'):
     elif on_sign_ambiguous == 'fail':
         available_signs = []
         for method in methods:
-            _sign = hwp[method + '_direction']
-            if _sign != 0:
-                available_signs.append(_sign*model.sign_matrix[method])
+            _sign = hwp[method + '_direction'] * model.sign_matrix[method]
+            if _sign:
+                available_signs.append(_sign)
 
         # check agreements of available estimation methods
         if len(available_signs) == 0:


### PR DESCRIPTION
Apply special correction to hwp angle sign.
`apply_hwp_angle_model(aman, on_sign_ambiguous='fail')` had `ValueError: hwp rotation direction is ambiguous` in following observations, This PR will fix it

The first pid sign error was casued by bug of hwp-pid agent, we fixed the agent to not cause same problam anymore but we haven't applied fix to data. https://github.com/simonsobs/chwp-discussions/discussions/24

The second offcenter sign error is  because satp1 SCR6 has unusual offcentering of hwp. This estimation method depends on the sign of hwp offcentering and this had same sign in all the platforms and cooldowns so far. But this is different in satp1 SCR6 and we need to correct it.

