### PR TITLE
Add boresight rotation to the pointing test

### DIFF
--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -286,6 +286,10 @@ def simulation_test_data(
     else:
         schedule = observing_schedule(telescope, mpicomm=toastcomm.comm_world)
 
+    # Add boresight rotation to one scan
+
+    schedule.scans[0].boresight_angle = 30 * u.deg
+
     sim_ground = toast.ops.SimGround(
         name="sim_ground",
         telescope=telescope,

--- a/tests/test_mapmaker_pointing.py
+++ b/tests/test_mapmaker_pointing.py
@@ -135,6 +135,7 @@ class MapmakerPointingTest(unittest.TestCase):
             comps="TQU",
             nmat_type="Nmat",
             maxiter=[3],
+            weather="typical",
             truncate_tod=False,
             write_hits=True,
             write_rhs=False,


### PR DESCRIPTION
This improvement was used to pinpoint a pointing error in TOAST when using qpoint: https://github.com/hpc4cmb/toast/pull/853