### PR TITLE
Fix signal reference in demod

### DIFF
--- a/sotodlib/hwp/hwp.py
+++ b/sotodlib/hwp/hwp.py
@@ -678,7 +678,7 @@ def demod_tod(aman, signal=None, demod_mode=4,
     # Filter the demodulated signal
     demod_aman = core.AxisManager(aman.dets, aman.samps)
     demod_aman.wrap("timestamps", aman.timestamps, axis_map=[(0, 'samps')])
-    demod_aman.wrap("dsT", aman[signal_name], axis_map=[(0, 'dets'), (1, 'samps')])
+    demod_aman.wrap("dsT", aman[signal_name].copy(), axis_map=[(0, 'dets'), (1, 'samps')])
     demod_aman["dsT"][:] = tod_ops.fourier_filter(demod_aman, lpf, signal_name='dsT', detrend=None, rfft=rfft)
     demod_aman.wrap("demodQ", demod.real, axis_map=[(0, 'dets'), (1, 'samps')])
     demod_aman["demodQ"][:] = tod_ops.fourier_filter(demod_aman, lpf, signal_name="demodQ", detrend=None, rfft=rfft)


### PR DESCRIPTION
Addresses #1336.  Makes an explicit copy of `signal` when making `dsT` in `demod_aman` otherwise it is a reference and is modified in place with the new FFT setup.  `DemodQ` and `demodU` should be fine since `demodQ` only modifies `demod.real `and does not touch `demod.imag`.