### PR TITLE
Now atomic filterbin mapmaker wont throw a non-0 error when there are…

### DIFF
--- a/sotodlib/site_pipeline/make_atomic_filterbin_map.py
+++ b/sotodlib/site_pipeline/make_atomic_filterbin_map.py
@@ -335,7 +335,7 @@ def main(
             fixed_time=args.fixed_time, mindur=args.min_dur)
     except mapmaking.NoTODFound as err:
         L.exception(err)
-        exit(1)
+        exit(0)
     L.info(f'Running {len(obslists)} maps after build_obslists')
 
     split_labels = []


### PR DESCRIPTION
… not TODs