### PR TITLE
Make preprocess functions return axis managers

### DIFF
--- a/sotodlib/preprocess/pcore.py
+++ b/sotodlib/preprocess/pcore.py
@@ -58,7 +58,7 @@ class _Preprocess(object):
             Transfer Function simulations and determining which steps should be run.
         """
         if self.process_cfgs is None:
-            return
+            return aman, proc_aman
         raise NotImplementedError
         
     def calc_and_save(self, aman, proc_aman):
@@ -79,7 +79,7 @@ class _Preprocess(object):
             pipeline.
         """
         if self.calc_cfgs is None:
-            return
+            return aman, proc_aman
         raise NotImplementedError
     
     def save(self, proc_aman, *args):
@@ -496,9 +496,9 @@ class Pipeline(list):
             if sim and process.skip_on_sim:
                 continue
             self.logger.debug(f"Running {process.name}")
-            process.process(aman, proc_aman, sim)
+            aman, proc_aman = process.process(aman, proc_aman, sim)
             if run_calc:
-                process.calc_and_save(aman, proc_aman)
+                aman, proc_aman = process.calc_and_save(aman, proc_aman)
                 process.plot(aman, proc_aman, filename=os.path.join(self.plot_dir, '{ctime}/{obsid}', f'{step+1}_{{name}}.png'))
                 update_full_aman( proc_aman, full, self.wrap_valid)
             if update_plot:

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -34,6 +34,8 @@ class FFTTrim(_Preprocess):
         start_stop = tod_ops.fft_trim(aman, **self.process_cfgs)
         proc_aman.restrict(self.process_cfgs.get('axis', 'samps'), (start_stop))
 
+        return aman, proc_aman
+
 class Detrend(_Preprocess):
     """Detrend the signal. All processing configs go to `detrend_tod`
 
@@ -49,6 +51,7 @@ class Detrend(_Preprocess):
     def process(self, aman, proc_aman, sim=False):
         tod_ops.detrend_tod(aman, signal_name=self.signal,
                             **self.process_cfgs)
+        return aman, proc_aman
 
 class DetBiasFlags(_FracFlaggedMixIn, _Preprocess):
     """
@@ -64,6 +67,7 @@ class DetBiasFlags(_FracFlaggedMixIn, _Preprocess):
         dbc_aman = tod_ops.flags.get_det_bias_flags(aman, merge=False, full_output=True,
                                                     **self.calc_cfgs)
         self.save(proc_aman, dbc_aman)
+        return aman, proc_aman
     
     def save(self, proc_aman, dbc_aman):
         if self.save_cfgs is None:
@@ -131,6 +135,8 @@ class Trends(_FracFlaggedMixIn, _Preprocess):
             signal=aman[self.signal], **self.calc_cfgs)
         aman.wrap("trends", trend_aman)
         self.save(proc_aman, trend_aman)
+
+        return aman, proc_aman
     
     def save(self, proc_aman, trend_aman):
         if self.save_cfgs is None:
@@ -212,6 +218,7 @@ class GlitchDetection(_FracFlaggedMixIn, _Preprocess):
         self.save(proc_aman, glitch_aman)
         if self.calc_cfgs.get('save_plot', False):
             flag_utils.plot_glitch_stats(aman, save_path=self.calc_cfgs['save_plot'])
+        return aman, proc_aman
     
     def save(self, proc_aman, glitch_aman):
         if self.save_cfgs is None:
@@ -274,6 +281,8 @@ class FixJumps(_Preprocess):
             aman[self.signal], proc_aman[field].jump_flag.mask(),
             inplace=True, heights=proc_aman[field].jump_heights)
 
+        return aman, proc_aman
+
 
 class Jumps(_FracFlaggedMixIn, _Preprocess):
     """Run generic jump finding and fixing algorithm.
@@ -328,6 +337,8 @@ class Jumps(_FracFlaggedMixIn, _Preprocess):
                               signal=aman[self.signal], **cfgs)
         jump_aman = tod_ops.jumps.jumps_aman(aman, jumps, heights)
         self.save(proc_aman, jump_aman)
+
+        return aman, proc_aman
 
     def save(self, proc_aman, jump_aman):
         if self.save_cfgs is None:
@@ -423,6 +434,7 @@ class PSDCalc(_Preprocess):
             proc_aman["frequency_cutoffs"].wrap(self.wrap, proc_aman["frequency_cutoffs"][self.signal])
 
         self.save(proc_aman, fft_aman)
+        return aman, proc_aman
 
     def save(self, proc_aman, fft_aman):
         if not(self.save_cfgs is None):
@@ -488,6 +500,8 @@ class GetStats(_Preprocess):
             signal = _f(proc_aman)
         stats_aman = tod_ops.flags.get_stats(aman, signal, **self.calc_cfgs)
         self.save(proc_aman, stats_aman)
+
+        return aman, proc_aman
 
     def save(self, proc_aman, stats_aman):
         if not(self.save_cfgs is None):
@@ -643,6 +657,7 @@ class Noise(_Preprocess):
                 calc_aman.wrap("white_noise", wn, [(0,"dets"), (1,"subscans")])
 
         self.save(proc_aman, calc_aman)
+        return aman, proc_aman
     
     def save(self, proc_aman, noise):
         if self.save_cfgs is None:
@@ -753,6 +768,7 @@ class Calibrate(_Preprocess):
         else:
             raise ValueError(f"Entry '{self.process_cfgs['kind']}'"
                               " not understood")
+        return aman, proc_aman
 
 class EstimateHWPSS(_Preprocess):
     """
@@ -776,6 +792,8 @@ class EstimateHWPSS(_Preprocess):
     def calc_and_save(self, aman, proc_aman):
         hwpss_stats = hwp.get_hwpss(aman, **self.calc_cfgs)
         self.save(proc_aman, hwpss_stats)
+
+        return aman, proc_aman
 
     def save(self, proc_aman, hwpss_stats):
         if self.save_cfgs is None:
@@ -912,6 +930,8 @@ class SubtractHWPSS(_Preprocess):
                 subtract_name = self.process_cfgs["subtract_name"]
                 )
 
+        return aman, proc_aman
+
 class A2Stats(_Preprocess):
     """
     Calculate statistical metrics for A2, the 2f-demodulated Q and U signals.
@@ -953,6 +973,7 @@ class A2Stats(_Preprocess):
             a2stats_aman.move(sn, f"{sn}U")
 
         self.save(proc_aman, a2stats_aman)
+        return aman, proc_aman
 
     def save(self, proc_aman, a2_stats):
         if self.save_cfgs is None:
@@ -969,6 +990,7 @@ class Apodize(_Preprocess):
 
     def process(self, aman, proc_aman, sim=False):
         tod_ops.apodize.apodize_cosine(aman, **self.process_cfgs)
+        return aman, proc_aman
 
 class Demodulate(_Preprocess):
     """Demodulate the tod. All process confgis go to `demod_tod`.
@@ -1029,6 +1051,7 @@ class Demodulate(_Preprocess):
             if 'demodU' in proc_aman['frequency_cutoffs']:
                 proc_aman['frequency_cutoffs'].move('demodU', None)
             proc_aman['frequency_cutoffs'].wrap('demodU', freq_cutoff)
+        return aman, proc_aman
 
 
 class AzSS(_Preprocess):
@@ -1086,6 +1109,8 @@ class AzSS(_Preprocess):
             calc_aman, _ = tod_ops.azss.get_azss(aman, **self.calc_cfgs)
             self.save(proc_aman, calc_aman)
 
+        return aman, proc_aman
+
     def save(self, proc_aman, azss_stats):
         if self.save_cfgs is None:
             return
@@ -1097,7 +1122,7 @@ class AzSS(_Preprocess):
             raise ValueError('calc_cfgs.subtract_in_place is not allowed use process_cfgs.subtract')
         if self.process_cfgs is None:
             # This handles the case if no process configs are passed.
-            return
+            return aman, proc_aman
 
         if self.process_cfgs.get("subtract"):
             if self.calc_cfgs.get('azss_stats_name') in proc_aman:
@@ -1118,6 +1143,7 @@ class AzSS(_Preprocess):
                 tod_ops.azss.get_azss(aman, subtract_in_place=True, **self.calc_cfgs)
         else:
             tod_ops.azss.get_azss(aman, **self.calc_cfgs)
+        return aman, proc_aman
 
 
 class SubtractAzSSTemplate(_Preprocess):
@@ -1145,6 +1171,7 @@ class SubtractAzSSTemplate(_Preprocess):
         if sim:
             process_cfgs["azss"] = proc_aman.get(process_cfgs["azss"])
         tod_ops.azss.subtract_azss_template(aman, **process_cfgs)
+        return aman, proc_aman
 
 
 class GlitchFill(_Preprocess):
@@ -1186,6 +1213,7 @@ class GlitchFill(_Preprocess):
             tod_ops.gapfill.fill_glitches(
                 aman, signal=aman[self.signal],
                 **self.process_cfgs)
+        return aman, proc_aman
 
 class FlagTurnarounds(_Preprocess):
     """From the Azimuth encoder data, flag turnarounds, left-going, and right-going.
@@ -1220,6 +1248,7 @@ class FlagTurnarounds(_Preprocess):
             calc_aman.wrap('subscan_info', aman.subscan_info)
 
         self.save(proc_aman, calc_aman)
+        return aman, proc_aman
 
     def save(self, proc_aman, turn_aman):
         if self.save_cfgs is None:
@@ -1229,6 +1258,7 @@ class FlagTurnarounds(_Preprocess):
 
     def process(self, aman, proc_aman, sim=False):
         tod_ops.flags.get_turnaround_flags(aman, **self.process_cfgs)
+        return aman, proc_aman
 
 class SubPolyf(_Preprocess):
     """Fit TOD in each subscan with polynominal of given order and subtract it.
@@ -1240,6 +1270,7 @@ class SubPolyf(_Preprocess):
     
     def process(self, aman, proc_aman, sim=False):
         tod_ops.sub_polyf.subscan_polyfilter(aman, **self.process_cfgs)
+        return aman, proc_aman
 
 class SSOFootprint(_Preprocess):
     """Find nearby sources within a given distance and get SSO footprint and plot
@@ -1369,6 +1400,8 @@ class SSOFootprint(_Preprocess):
 
             sso_aman.wrap(planet, planet_aman)
         self.save(proc_aman, sso_aman)
+
+        return aman, proc_aman
         
     def save(self, proc_aman, sso_aman):
         if self.save_cfgs is None:
@@ -1410,6 +1443,7 @@ class DarkDets(_Preprocess):
         dark_aman = core.AxisManager(aman.dets, aman.samps)
         dark_aman.wrap('darks', mskdarks, [(0, 'dets'), (1, 'samps')])
         self.save(proc_aman, dark_aman)
+        return aman, proc_aman
     
     def save(self, proc_aman, dark_aman):
         if self.save_cfgs is None:
@@ -1509,6 +1543,8 @@ class SourceFlags(_Preprocess):
 
         self.save(proc_aman, source_aman)
 
+        return aman, proc_aman
+
     def save(self, proc_aman, source_aman):
         if self.save_cfgs is None:
             return
@@ -1592,14 +1628,15 @@ class HWPAngleModel(_Preprocess):
         if (not 'hwp_angle' in aman._fields) and ('hwp_angle' in proc_aman._fields):
             aman.wrap('hwp_angle', proc_aman['hwp_angle']['hwp_angle'],
                       [(0, 'samps')])
-        else:
-            return
+        return aman, proc_aman
 
     def calc_and_save(self, aman, proc_aman):
         hwp_angle_model.apply_hwp_angle_model(aman, **self.calc_cfgs)
         hwp_angle_aman = core.AxisManager(aman.samps)
         hwp_angle_aman.wrap('hwp_angle', aman.hwp_angle, [(0, 'samps')])
         self.save(proc_aman, hwp_angle_aman)
+
+        return aman, proc_aman
 
     def save(self, proc_aman, hwp_angle_aman):
         if self.save_cfgs is None:
@@ -1701,6 +1738,7 @@ class FourierFilter(_Preprocess):
                                     aman.samps.offset + aman.samps.count - trim))
             proc_aman.restrict('samps', (proc_aman.samps.offset + trim,
                                          proc_aman.samps.offset + proc_aman.samps.count - trim))
+        return aman, proc_aman
 
 
 class DetcalNanCuts(_Preprocess):
@@ -1821,6 +1859,8 @@ class PCARelCal(_Preprocess):
 
         self.save(proc_aman, rc_aman)
 
+        return aman, proc_aman
+
     def save(self, proc_aman, pca_aman):
         if self.save_cfgs is None:
             return
@@ -1894,6 +1934,7 @@ class PCAFilter(_Preprocess):
                              f'larger than the number of detectors {aman.dets.count}.')
         model = tod_ops.pca.get_pca_model(aman, signal=signal, n_modes=n_modes)
         _ = tod_ops.pca.add_model(aman, model, signal=signal, scale=-1)
+        return aman, proc_aman
 
 class GetCommonMode(_Preprocess):
     """
@@ -1917,6 +1958,7 @@ class GetCommonMode(_Preprocess):
         common_aman = core.AxisManager(aman.samps)
         common_aman.wrap(self.calc_cfgs['wrap'], common_mode, [(0, 'samps')])
         self.save(proc_aman, common_aman)
+        return aman, proc_aman
 
     def save(self, proc_aman, common_aman):
         if self.save_cfgs is None:
@@ -1963,6 +2005,7 @@ class FilterForSources(_Preprocess):
                                          aman.samps.offset + aman.samps.count - trim))
             aman.restrict('samps', (aman.samps.offset + trim,
                                     aman.samps.offset + aman.samps.count - trim))
+        return aman, proc_aman
 
 class PTPFlags(_Preprocess):
     """Find detectors with anomalous peak-to-peak signal.
@@ -1988,6 +2031,8 @@ class PTPFlags(_Preprocess):
         ptp_aman = core.AxisManager(aman.dets, aman.samps)
         ptp_aman.wrap('ptp_flags', mskptps, [(0, 'dets'), (1, 'samps')])
         self.save(proc_aman, ptp_aman)
+
+        return aman, proc_aman
 
     def save(self, proc_aman, ptp_aman):
         if self.save_cfgs is None:
@@ -2031,6 +2076,7 @@ class InvVarFlags(_Preprocess):
         inv_var_aman = core.AxisManager(aman.dets, aman.samps)
         inv_var_aman.wrap('inv_var_flags', msk, [(0, 'dets'), (1, 'samps')])
         self.save(proc_aman, inv_var_aman)
+        return aman, proc_aman
 
     def save(self, proc_aman, inv_var_aman):
         if self.save_cfgs is None:
@@ -2078,6 +2124,8 @@ class EstimateT2P(_Preprocess):
         t2p_aman = tod_ops.t2pleakage.get_t2p_coeffs(aman, **self.calc_cfgs)
         self.save(proc_aman, t2p_aman)
 
+        return aman, proc_aman
+
     def save(self, proc_aman, t2p_aman):
         if self.save_cfgs is None:
             return
@@ -2101,6 +2149,7 @@ class SubtractT2P(_Preprocess):
     def process(self, aman, proc_aman, sim=False):
         tod_ops.t2pleakage.subtract_t2p(aman, proc_aman['t2p'],
                                         **self.process_cfgs)
+        return aman, proc_aman
 
 class SplitFlags(_Preprocess):
     """Get flags used for map splitting/bundling.
@@ -2132,6 +2181,7 @@ class SplitFlags(_Preprocess):
         split_flg_aman = obs_ops.splits.get_split_flags(aman, proc_aman, split_cfg=self.calc_cfgs)
 
         self.save(proc_aman, split_flg_aman)
+        return aman, proc_aman
 
     def save(self, proc_aman, split_flg_aman):
         if self.save_cfgs is None:
@@ -2170,6 +2220,8 @@ class UnionFlags(_Preprocess):
         if self.process_cfgs['total_flags_label'] in aman['flags']:
             aman['flags'].move(self.process_cfgs['total_flags_label'], None)
         aman['flags'].wrap(self.process_cfgs['total_flags_label'], total_flags)
+
+        return aman, proc_aman
 
 class CombineFlags(_Preprocess):
     """Do the conbine of relevant flags for mapping
@@ -2220,6 +2272,7 @@ class CombineFlags(_Preprocess):
         if self.process_cfgs['total_flags_label'] in aman['flags']:
             aman['flags'].move(self.process_cfgs['total_flags_label'], None)
         aman['flags'].wrap(self.process_cfgs['total_flags_label'], total_flags)
+        return aman, proc_aman
 
 class RotateFocalPlane(_Preprocess):
     """ Interpret the boresight rotation effect as a focal plane rotation
@@ -2240,6 +2293,7 @@ class RotateFocalPlane(_Preprocess):
     def process(self, aman, proc_aman, sim=False):
         from sotodlib.coords import demod
         demod.rotate_focal_plane(aman, **self.process_cfgs)
+        return aman, proc_aman
 
 class RotateQU(_Preprocess):
     """Rotate Q and U components to/from telescope coordinates.
@@ -2259,6 +2313,7 @@ class RotateQU(_Preprocess):
     def process(self, aman, proc_aman, sim=False):
         from sotodlib.coords import demod
         demod.rotate_demodQU(aman, **self.process_cfgs)
+        return aman, proc_aman
 
 class SubtractQUCommonMode(_Preprocess):
     """Subtract Q and U common mode.
@@ -2285,6 +2340,8 @@ class SubtractQUCommonMode(_Preprocess):
         coeff_aman = get_qu_common_mode_coeffs(aman, Q_signal, U_signal, merge)
         self.save(proc_aman, aman)
 
+        return aman, proc_aman
+
     def save(self, proc_aman, aman):
         if self.save_cfgs is None:
             return
@@ -2299,6 +2356,7 @@ class SubtractQUCommonMode(_Preprocess):
         else:
             tod_ops.deproject.subtract_qu_common_mode(aman, self.signal_name_Q,
                                                       self.signal_name_U, merge=True)
+        return aman, proc_aman
 
 class FocalplaneNanFlags(_Preprocess):
     """Find additional detectors which have nans 
@@ -2324,6 +2382,7 @@ class FocalplaneNanFlags(_Preprocess):
         fp_aman = core.AxisManager(aman.dets, aman.samps)
         fp_aman.wrap('fp_nans', mskfp, [(0, 'dets'), (1, 'samps')])
         self.save(proc_aman, fp_aman)
+        return aman, proc_aman
     
     def save(self, proc_aman, fp_aman):
         if self.save_cfgs is None:
@@ -2360,6 +2419,7 @@ class PointingModel(_Preprocess):
         from sotodlib.coords import pointing_model
         if self.process_cfgs:
             pointing_model.apply_pointing_model(aman)
+        return aman, proc_aman
 
 class BadSubscanFlags(_Preprocess):
     """Identifies and flags bad subscans.
@@ -2400,6 +2460,8 @@ class BadSubscanFlags(_Preprocess):
         det_aman.wrap("valid_dets", msk_det, [(0, 'dets')])
         self.save(proc_aman, ss_aman, "noisy_subscan_flags")
         self.save(proc_aman, det_aman, "noisy_dets_flags")
+
+        return aman, proc_aman
 
     def save(self, proc_aman, calc_aman, name): 
         if self.save_cfgs is None:
@@ -2448,6 +2510,8 @@ class CorrectIIRParams(_Preprocess):
             freq_cutoff = freqs[np.min(np.where(np.array(mag < scale * np.max(mag)))[0])]
             proc_aman["frequency_cutoffs"]["signal"] = freq_cutoff
 
+        return aman, proc_aman
+
 class TrimFlagEdge(_Preprocess):
     """Trim edge until given flags of all detectors are False
     To find first and last sample id that has False (i.e., no flags applied) for all detectors.
@@ -2470,6 +2534,8 @@ class TrimFlagEdge(_Preprocess):
                                 aman.samps.offset + trimen))
         proc_aman.restrict('samps', (proc_aman.samps.offset + trimst,
                                      proc_aman.samps.offset + trimen))
+
+        return aman, proc_aman
 
 class SmurfGapsFlags(_Preprocess):
     """Expand smurfgaps flag of each stream_id to all detectors
@@ -2494,6 +2560,8 @@ class SmurfGapsFlags(_Preprocess):
         flag_aman = core.AxisManager(aman.dets, aman.samps)
         flag_aman.wrap(self.calc_cfgs['name'], smurfgaps, [(0, 'dets'), (1, 'samps')])
         self.save(proc_aman, flag_aman)
+
+        return aman, proc_aman
 
     def save(self, proc_aman, flag_aman):
         if self.save_cfgs is None:


### PR DESCRIPTION
This is intended to address #1325.  Updates `process` and `calc_and_save` to return both `aman` and `proc_aman`.  This shouldn't occur any significant additional computation time or memory based on monitoring both while running with and without this change.