### PR TITLE
Rework some preprocessing functions, test jobdb implementation for preprocessing

### DIFF
--- a/sotodlib/site_pipeline/multilayer_preprocess_tod.py
+++ b/sotodlib/site_pipeline/multilayer_preprocess_tod.py
@@ -10,27 +10,30 @@ from typing import Optional
 from sotodlib.utils.procs_pool import get_exec_env
 import h5py
 import copy
+from tqdm import tqdm
 from sotodlib.coords import demod as demod_mm
 from sotodlib.hwp import hwp_angle_model
 from sotodlib import core
+from sotodlib.site_pipeline.jobdb import JobManager
 from sotodlib.preprocess import _Preprocess, Pipeline, processes
 import sotodlib.preprocess.preprocess_util as pp_util
+from sotodlib.preprocess.preprocess_util import PreprocessErrors
 import sotodlib.site_pipeline.util as sp_util
+
 
 logger = pp_util.init_logger("preprocess")
 
-def multilayer_preprocess_tod(obs_id, 
+
+def multilayer_preprocess_tod(obs_id,
                               configs_init,
                               configs_proc,
+                              group,
                               verbosity=0,
-                              group_list=None, 
                               overwrite=False,
                               run_parallel=False):
-    """Meant to be run as part of a batched script. Given a single
-    Observation ID, this function uses an existing ManifestDb generated
-    from a previous runof the processing pipeline, runs the pipeline using
-    a second config, and outputs a new ManifestDb. Det groups must exist in
-    the first dB to be included in the pipeline run on the second config.
+    """Meant to be run as part of a batched script, this function calls the
+    preprocessing pipeline a specific Observation ID and group combination
+    and saves the results in the ManifestDb specified in the configs.
 
     Arguments
     ----------
@@ -40,9 +43,8 @@ def multilayer_preprocess_tod(obs_id,
         config file or loaded config directory for existing database
     configs_proc: string or dictionary
         config file or loaded config directory for processing database
-        to be output
-    group_list: None or list
-        list of groups to run if you only want to run a partial update
+    group: list
+        Group to run if you only want to run a partial update
     overwrite: bool
         if True, overwrite existing entries in ManifestDb
     verbosity: log level
@@ -51,173 +53,240 @@ def multilayer_preprocess_tod(obs_id,
         If true preprocess_tod is called in a parallel process which returns
         dB info and errors and does no sqlite writing inside the function.
     """
+    logger = sp_util.init_logger("preprocess", verbosity=verbosity)
 
-    logger = pp_util.init_logger("preprocess", verbosity=verbosity)
-
-    # list to hold error, destination file, and db data
-    outputs_init = []
-    outputs_proc = []
-
-    if type(configs_init) == str:
-        configs_init = yaml.safe_load(open(configs_init, "r"))
-    context_init = core.Context(configs_init["context_file"])
-
-    if type(configs_proc) == str:
-        configs_proc = yaml.safe_load(open(configs_proc, "r"))
-    context_proc = core.Context(configs_proc["context_file"])
-
-    group_by_init, groups_init, error_init = pp_util.get_groups(obs_id, configs_init, context_init)
-    group_by_proc, groups_proc, error_proc = pp_util.get_groups(obs_id, configs_proc, context_proc)
-
-    if error_init is not None:
-        if run_parallel:
-            return error_init[0], [None, None], [None, None]
-        else:
-            return
-
-    if error_proc is not None:
-        if run_parallel:
-            return error_proc[0], [None, None], [None, None]
-        else:
-            return
-
-    if len(groups_init) > 0 and len(groups_proc) > 0:
-        if (group_by_init != group_by_proc).any():
-            raise ValueError('init and proc groups do not match')
-
-    all_groups_proc = groups_proc.copy()
-    for g in all_groups_proc:
-        if g not in groups_init:
-            groups_proc.remove(g)
-            continue
-        if group_list is not None:
-            if g not in group_list:
-                groups_proc.remove(g)
-                continue
-        if 'wafer.bandpass' in group_by_proc:
-            if 'NC' in g:
-                groups_proc.remove(g)
-                continue
-        try:
-            meta = context_proc.get_meta(obs_id, dets = {gb:gg for gb, gg in zip(group_by_proc, g)})
-        except Exception as e:
-            errmsg = f'{type(e)}: {e}'
-            tb = ''.join(traceback.format_tb(e.__traceback__))
-            logger.info(f"ERROR: {obs_id} {g}\n{errmsg}\n{tb}")
-            groups_proc.remove(g)
-            continue
-
-        if meta.dets.count == 0:
-            groups_proc.remove(g)
-
-    if len(groups_proc) == 0:
-        logger.warning(f"group_list:{group_list} contains no overlap with "
-                       f"groups in observation: {obs_id}:{all_groups_proc}. "
-                       f"No analysis to run.")
-        error = 'no_group_overlap'
-        if run_parallel:
-            return error, [None, None], [None, None]
-        else:
-            return
-
-    if not(run_parallel):
-        db_init = pp_util.get_preprocess_db(configs_init, group_by_proc)
-        db_proc = pp_util.get_preprocess_db(configs_proc, group_by_proc)
-
-    # pipeline for init config
-    pipe_init = Pipeline(configs_init["process_pipe"],
-                         plot_dir=configs_init["plot_dir"], logger=logger)
-    # pipeline for processing config
-    pipe_proc = Pipeline(configs_proc["process_pipe"],
-                         plot_dir=configs_proc["plot_dir"], logger=logger)
-
-    if configs_proc.get("lmsi_config", None) is not None:
+    if configs_init.get("lmsi_config", None) is not None or configs_proc.get("lmsi_config", None) is not None:
         make_lmsi = True
     else:
         make_lmsi = False
 
-    # loop through and reduce each group
-    n_fail = 0
-    for group in groups_proc:
-        logger.info(f"Beginning run for {obs_id}:{group}")
-        dets = {gb:gg for gb, gg in zip(group_by_proc, group)}
-        try:
-            error, outputs_grp_init, _, aman = pp_util.preproc_or_load_group(obs_id, configs_init,
-                                                                             dets=dets, logger=logger)
-            if error is None:
-                outputs_init.append(outputs_grp_init)
-
-            init_fields = aman.preprocess._fields.copy()
-
-            outputs_grp_proc = pp_util.save_group(obs_id, configs_proc, dets,
-                                      context_proc, subdir='temp_proc')
-
-            # tags from context proc
-            tags_proc = np.array(context_proc.obsdb.get(aman.obs_info.obs_id, tags=True)['tags'])
-            if "tags" in aman._fields:
-                aman.move("tags", None)
-            aman.wrap('tags', tags_proc)
-
-            # now run the pipeline on the processed axis manager
-            logger.info(f"Beginning processing pipeline for {obs_id}:{group}")
-            proc_aman, success = pipe_proc.run(aman)
-            proc_aman.wrap('pcfg_ref', pp_util.get_pcfg_check_aman(pipe_init))
-
-            # remove fields found in aman.preprocess from proc_aman
-            for fld_init in init_fields:
-                if fld_init in proc_aman:
-                    proc_aman.move(fld_init, None)
-
-        except Exception as e:
-            errmsg = f'{type(e)}: {e}'
-            tb = ''.join(traceback.format_tb(e.__traceback__))
-            logger.info(f"ERROR: {obs_id} {group}\n{errmsg}\n{tb}")
-            n_fail += 1
-            continue
-        if success != 'end':
-            # If a single group fails we don't log anywhere just mis an entry in the db.
-            logger.info(f"ERROR: {obs_id} {group}\nFailed at step {success}") 
-            n_fail += 1
-            continue
-
-        logger.info(f"Saving data to {outputs_grp_proc['temp_file']}:{outputs_grp_proc['db_data']['dataset']}")
-        proc_aman.save(outputs_grp_proc['temp_file'], outputs_grp_proc['db_data']['dataset'], overwrite)
-
-        if run_parallel:
-            outputs_proc.append(outputs_grp_proc)
-        else:
-            logger.info(f"Saving to database under {outputs_grp_proc['db_data']}")
-            if len(db_proc.inspect(outputs_grp_proc['db_data'])) == 0:
-                h5_path = os.path.relpath(outputs_grp_proc['temp_file'],
-                        start=os.path.dirname(configs_proc['archive']['index']))
-                db_proc.add_entry(outputs_grp_proc['db_data'], h5_path)
+    group_by = np.atleast_1d(configs_proc['subobs'].get('use', 'detset'))
+    dets = {gb:gg for gb, gg in zip(group_by, group)}
+    aman, out_dict_init, out_dict_proc, error = pp_util.preproc_or_load_group(obs_id=obs_id,
+                                                                              configs_init=configs_init,
+                                                                              dets=dets,
+                                                                              configs_proc=configs_proc,
+                                                                              logger=logger,
+                                                                              overwrite=overwrite,
+                                                                              save_archive=not run_parallel)
 
     if make_lmsi:
         from pathlib import Path
         import lmsi.core as lmsi
+        for configs in [configs_init, configs_proc]:
+            new_plots = os.path.join(configs["plot_dir"],
+                                     f'{str(aman.timestamps[0])[:5]}',
+                                     aman.obs_info.obs_id)
 
-        if os.path.exists(new_plots):
-            lmsi.core([Path(x.name) for x in Path(new_plots).glob("*.png")],
-                      Path(configs1["lmsi_config"]),
-                      Path(os.path.join(new_plots, 'index.html')))
+            if os.path.exists(new_plots):
+                lmsi.core([Path(x.name) for x in Path(new_plots).glob("*.png")],
+                          Path(configs["lmsi_config"]),
+                          Path(os.path.join(new_plots, 'index.html')))
 
-    if run_parallel:
-        if n_fail == len(groups_proc):
-            # If no groups make it to the end of the processing return error.
-            logger.info(f'ERROR: all groups failed for {obs_id}')
-            error = 'all_fail'
-            return error, [obs_id, 'all groups'], [obs_id, 'all groups']
+    return out_dict_init, out_dict_proc, error
+
+
+def _main(executor: Union["MPICommExecutor", "ProcessPoolExecutor"],
+          as_completed_callable: Callable,
+          configs_init: str,
+          configs_proc: str,
+          query: Optional[str] = None,
+          obs_id: Optional[str] = None,
+          overwrite: bool = False,
+          min_ctime: Optional[int] = None,
+          max_ctime: Optional[int] = None,
+          update_delay: Optional[int] = None,
+          tags: Optional[str] = None,
+          planet_obs: bool = False,
+          verbosity: Optional[int] = None,
+          nproc: Optional[int] = 4,
+          raise_error: Optional[bool] = False):
+
+    init_temp_subdir = "temp"
+    proc_temp_subdir = "temp_proc"
+
+    configs_init, context_init = pp_util.get_preprocess_context(configs_init)
+    configs_proc, context_proc = pp_util.get_preprocess_context(configs_proc)
+
+    logger = sp_util.init_logger("preprocess", verbosity=verbosity)
+
+    os.makedirs(os.path.dirname(configs_proc['archive']['policy']['filename']),
+                exist_ok=True)
+
+    jdb = JobManager(sqlite_file=configs_proc["jobdb"])
+
+    errlog = os.path.join(os.path.dirname(configs_proc['archive']['index']),
+                          'errlog_proc.txt')
+
+    obs_list = sp_util.get_obslist(context_proc, query=query, obs_id=obs_id,
+                                   min_ctime=min_ctime, max_ctime=max_ctime,
+                                   update_delay=update_delay, tags=tags,
+                                   planet_obs=planet_obs)
+
+    if len(obs_list) == 0:
+        logger.warning(f"No observations returned from query: {query}")
+        return
+
+    # clean up lingering files from previous incomplete runs
+    init_policy_dir = os.path.join(os.path.dirname(configs_init['archive']['policy']['filename']),
+                                  init_temp_subdir)
+    proc_policy_dir = os.path.join(os.path.dirname(configs_proc['archive']['policy']['filename']),
+                                   proc_temp_subdir)
+
+    for obs in obs_list:
+        obs_id = obs['obs_id']
+        pp_util.cleanup_obs(obs_id, init_policy_dir, errlog, configs_init,
+                            context_init, subdir=init_temp_subdir, remove=overwrite)
+        pp_util.cleanup_obs(obs_id, proc_policy_dir, errlog, configs_proc,
+                            context_proc, subdir=proc_temp_subdir, remove=overwrite)
+
+    run_list = []
+
+    group_by = np.atleast_1d(configs_proc['subobs'].get('use', 'detset'))
+
+    if overwrite or not os.path.exists(configs_proc['archive']['index']):
+        db = None
+    else:
+        db = core.metadata.ManifestDb(configs_proc['archive']['index'])
+
+    futures = []
+    futures_dict = {}
+    for obs in obs_list:
+        futures.append(executor.submit(pp_util.get_groups, obs["obs_id"], configs_proc))
+
+    for obs, future in zip(obs_list, futures):
+        futures_dict[future] = obs["obs_id"]
+
+    for future in tqdm(as_completed_callable(futures), total=len(futures),
+                       desc="building run list from obs list"):
+        obs_id = futures_dict[future]
+        _, groups, _ = future.result()
+
+        if db is not None:
+            x = db.inspect({'obs:obs_id': obs_id})
+            if x is not None and len(x) != 0 and len(x) != len(groups):
+                [groups.remove([a[f'dets:{gb}'] for gb in group_by]) for a in x]
+
+        for group in groups:
+            if 'NC' not in group:
+                run_list.append((obs, group))
+
+    run_list_failed = []
+    for r in run_list:
+        jclass = r[0]['obs_id']
+        for gb, g in zip(group_by, r[1]):
+            if gb == 'detset':
+                jclass += "_" + g
+            else:
+                jclass += "_" + gb + "_" + str(g)
+        if jdb.get_jobs(jclass=jclass, jstate=["done", "failed", "ignored"]):
+            run_list_failed.append(r)
+
+    logger.info(f"skipping {len(run_list_failed)} jobs from jobdb")
+
+    run_list = [r for r in run_list if r not in run_list_failed]
+
+    jobs = []
+    for r in run_list:
+        jclass = r[0]['obs_id']
+        for gb, g in zip(group_by, r[1]):
+            if gb == 'detset':
+                jclass += "_" + g
+            else:
+                jclass += "_" + gb + "_" + str(g)
+        new_jobs = {}
+        open_jobs = jdb.get_jobs(jclass=jclass, jstate=["open"])
+
+        if open_jobs:
+            job = open_jobs[0]
         else:
-            logger.info('Returning data to futures')
-            error = None
-            return error, outputs_init, outputs_proc
+            job = jdb.create_job(jclass)
+
+        jobs.append(job)
+
+    logger.info(f'Run list created with {len(run_list)} obsid groups')
+
+    futures = []
+    futures_dict = {}
+    obs_errors = {}
+
+    run_parallel = nproc > 1
+
+    # Run write_block obs-ids in parallel at once then write all to the sqlite db.
+    for r in run_list:
+        futures.append(executor.submit(multilayer_preprocess_tod,
+                                       obs_id=r[0]['obs_id'],
+                                       configs_init=configs_init,
+                                       configs_proc=configs_proc,
+                                       group=r[1],
+                                       verbosity=verbosity,
+                                       overwrite=overwrite,
+                                       run_parallel=run_parallel))
+
+    for r, j, future in zip(run_list, jobs, futures):
+        futures_dict[future] = (r[0]['obs_id'], r[1], j)
+        if r[0]['obs_id'] not in obs_errors:
+            obs_errors[r[0]['obs_id']] = []
+
+    for future in tqdm(as_completed_callable(futures), total=len(futures),
+                           desc="multilayer_preprocess_tod"):
+        obs_id, group, job = futures_dict[future]
+        out_meta = (obs_id, group)
+        try:
+            out_dict_init, out_dict_proc, error = future.result()
+            obs_errors[obs_id].append({'group': group, 'error': error})
+            logger.info(f"{obs_id}: {group} extracted successfully")
+        except Exception as e:
+            errmsg, tb = PreprocessErrors.get_errors(e)
+            logger.error(f"Executor Future Result Error for {obs_id}: {group}:\n{errmsg}\n{tb}")
+            obs_errors[obs_id].append({'group': group, 'error': PreprocessErrors.ExecutorFutureError})
+            out_dict = None
+            error = PreprocessErrors.ExecutorFutureError
+
+            with jdb.locked(job) as j:
+                j.mark_visited()
+                j.jstate = "failed"
+
+        futures.remove(future)
+
+        if run_parallel:
+            logger.info(f"Adding future result to init db for {obs_id}: {group}")
+            pp_util.cleanup_mandb(out_dict_init, out_meta, error,
+                                  configs_init, logger)
+            logger.info(f"Adding future result to proc db for {obs_id}: {group}")
+            pp_util.cleanup_mandb(out_dict_proc, out_meta, error,
+                                  configs_proc, logger)
+
+        with jdb.locked(job) as j:
+            if j.visit_count == 0:
+                j.mark_visited()
+                j.jstate = "done"
+
+    n_obs_fail = 0
+    n_groups_fail = 0
+    for obs_id, out_meta in obs_errors.items():
+        if all(entry['error'] is not None for entry in out_meta):
+            n_obs_fail += 1
+            n_groups_fail += len(out_meta)
+        else:
+            for entry in out_meta:
+                if entry['error'] is not None:
+                    n_groups_fail += 1
+
+    logger.warn(f"{n_obs_fail}/{len(obs_errors)} observations failed entirely")
+    logger.warn(f"{n_groups_fail}/{len(run_list)} groups failed")
+
+    if raise_error:
+        raise RuntimeError("multilayer_preprocess_tod ended with failed obsids")
+    else:
+        logger.info("multilayer_preprocess_tod is done")
 
 
 def get_parser(parser=None):
     if parser is None:
         parser = argparse.ArgumentParser()
-    parser.add_argument('configs_init', help="Preprocessing Configuration File for existing database")
-    parser.add_argument('configs_proc', help="Preprocessing Configuration File for new database")
+    parser.add_argument('configs_init', help="Preprocessing Configuration File for first layer database")
+    parser.add_argument('configs_proc', help="Preprocessing Configuration File for second layer database")
     parser.add_argument(
         '--query', 
         help="Query to pass to the observation list. Use \\'string\\' to "
@@ -276,112 +345,6 @@ def get_parser(parser=None):
         default=False
     )
     return parser
-
-def _main(executor: Union["MPICommExecutor", "ProcessPoolExecutor"],
-          as_completed_callable: Callable,
-          configs_init: str,
-          configs_proc: str,
-          query: Optional[str] = None,
-          obs_id: Optional[str] = None,
-          overwrite: bool = False,
-          min_ctime: Optional[int] = None,
-          max_ctime: Optional[int] = None,
-          update_delay: Optional[int] = None,
-          tags: Optional[str] = None,
-          planet_obs: bool = False,
-          verbosity: Optional[int] = None,
-          nproc: Optional[int] = 4,
-          raise_error: Optional[bool] = False):
-
-    logger = pp_util.init_logger("preprocess", verbosity=verbosity)
-
-    configs_init, context_init = pp_util.get_preprocess_context(configs_init)
-    configs_proc, context_proc = pp_util.get_preprocess_context(configs_proc)
-
-    errlog = os.path.join(os.path.dirname(configs_proc['archive']['index']),
-                          'errlog.txt')
-
-    obs_list = sp_util.get_obslist(context_proc, query=query, obs_id=obs_id, min_ctime=min_ctime,
-                                   max_ctime=max_ctime, update_delay=update_delay, tags=tags,
-                                   planet_obs=planet_obs)
-    if len(obs_list)==0:
-        logger.warning(f"No observations returned from query: {query}")
-
-    # clean up lingering files from previous incomplete runs
-    policy_dir_init = os.path.join(os.path.dirname(configs_init['archive']['policy']['filename']), 'temp')
-    policy_dir_proc = os.path.join(os.path.dirname(configs_proc['archive']['policy']['filename']), 'temp_proc')
-    for obs in obs_list:
-        obs_id = obs['obs_id']
-        pp_util.cleanup_obs(obs_id, policy_dir_init, errlog, configs_init, context_init,
-                            subdir='temp', remove=overwrite)
-        pp_util.cleanup_obs(obs_id, policy_dir_proc, errlog, configs_proc, context_proc,
-                            subdir='temp_proc', remove=overwrite)
-
-    run_list = []
-
-    if overwrite or not os.path.exists(configs_proc['archive']['index']):
-        # run on all if database doesn't exist
-        for obs in obs_list:
-            #run on all if database doesn't exist
-            run_list = [ (o,None) for o in obs_list]
-            group_by_proc = np.atleast_1d(configs_proc['subobs'].get('use', 'detset'))
-    else:
-        db = core.metadata.ManifestDb(configs_proc['archive']['index'])
-        for obs in obs_list:
-            x = db.inspect({'obs:obs_id': obs["obs_id"]})
-            if x is None or len(x) == 0:
-                run_list.append( (obs, None) )
-            else:
-                group_by_proc, groups_proc, _ = pp_util.get_groups(obs["obs_id"], configs_proc, context_proc)
-                if len(x) != len(groups_proc):
-                    [groups_proc.remove([a[f'dets:{gb}'] for gb in group_by_proc]) for a in x]
-                    run_list.append( (obs, groups_proc) )
-
-    logger.info(f'Run list created with {len(run_list)} obsids')
-
-    n_fail = 0
-
-    # run write_block obs-ids in parallel at once then write all to the sqlite db.
-    futures = [executor.submit(multilayer_preprocess_tod, obs_id=r[0]['obs_id'],
-                group_list=r[1], verbosity=verbosity,
-                configs_init=configs_init,
-                configs_proc=configs_proc,
-                overwrite=overwrite, run_parallel=True) for r in run_list]
-    for future in as_completed_callable(futures):
-        logger.info('New future as_completed result')
-        try:
-            err, db_datasets_init, db_datasets_proc = future.result()
-            if err is not None:
-                n_fail += 1
-        except Exception as e:
-            errmsg = f'{type(e)}: {e}'
-            tb = ''.join(traceback.format_tb(e.__traceback__))
-            logger.info(f"ERROR: future.result()\n{errmsg}\n{tb}")
-            f = open(errlog, 'a')
-            f.write(f'\n{time.time()}, future.result() error\n{errmsg}\n{tb}\n')
-            f.close()
-            n_fail += 1
-            continue
-        futures.remove(future)
-
-        if db_datasets_init:
-            if err is None:
-                for db_dataset in db_datasets_init:
-                    logger.info(f'Processing future result db_dataset: {db_datasets_init}')
-                    pp_util.cleanup_mandb(err, db_dataset, configs_init, logger, overwrite)
-            else:
-                pp_util.cleanup_mandb(err, db_datasets_init, configs_init, logger, overwrite)
-
-        if db_datasets_proc:
-            if err is None:
-                logger.info(f'Processing future dependent result db_dataset: {db_datasets_proc}')
-                for db_dataset in db_datasets_proc:
-                    pp_util.cleanup_mandb(err, db_dataset, configs_proc, logger, overwrite)
-            else:
-                pp_util.cleanup_mandb(err, db_datasets_proc, configs_proc, logger, overwrite)
-
-    if raise_error and n_fail > 0:
-        raise RuntimeError(f"multilayer_preprocess_tod: {n_fail}/{len(run_list)} obs_ids failed")
 
 
 def main(configs_init: str,

--- a/sotodlib/site_pipeline/preprocess_tod.py
+++ b/sotodlib/site_pipeline/preprocess_tod.py
@@ -10,197 +10,61 @@ from typing import Optional
 from sotodlib.utils.procs_pool import get_exec_env
 import h5py
 import copy
+from tqdm import tqdm
 from sotodlib.coords import demod as demod_mm
 from sotodlib.hwp import hwp_angle_model
 from sotodlib import core
+from sotodlib.site_pipeline.jobdb import JobManager
 import sotodlib.site_pipeline.util as sp_util
 from sotodlib.preprocess import preprocess_util as pp_util
+from sotodlib.preprocess.preprocess_util import PreprocessErrors
 from sotodlib.preprocess import _Preprocess, Pipeline, processes
+
 
 logger = sp_util.init_logger("preprocess")
 
-def dummy_preproc(obs_id, group_list, logger,
-                  configs, overwrite, run_parallel):
+
+def dummy_preproc(obs_id, configs, group, verbosity=0, logger=None,
+                  overwrite=False, run_parallel=False):
     """
     Dummy function that can be put in place of preprocess_tod in the
     main function for testing issues in the processpoolexecutor
     (multiprocessing).
     """
+    temp_subdir = "temp"
+    logger = pp_util.init_logger("preprocess", verbosity=verbosity)
+    logger.info(f"Starting preprocess run of {obs_id}: {group}")
+
+    context = core.Context(configs["context_file"])
+
+    group_by = np.atleast_1d(configs['subobs'].get('use', 'detset'))
+
     error = None
-    outputs = []
-    context = core.Context(configs["context_file"])
-    group_by, groups, error = pp_util.get_groups(obs_id, configs, context)
-    pipe = Pipeline(configs["process_pipe"], plot_dir=configs["plot_dir"], logger=logger)
-    for group in groups:
-        logger.info(f"Beginning run for {obs_id}:{group}")
-        dets = {gb:gg for gb, gg in zip(group_by, group)}
-        proc_aman = core.AxisManager(core.LabelAxis('dets', ['det%i' % i for i in range(3)]),
-                                     core.OffsetAxis('samps', 1000))
-        proc_aman.wrap_new('signal', ('dets', 'samps'), dtype='float32')
-        proc_aman.wrap_new('timestamps', ('samps',))[:] = (np.arange(proc_aman.samps.count) / 200)
+    pipe = Pipeline(configs["process_pipe"], plot_dir=configs["plot_dir"],
+                    logger=logger)
+    dets = {gb:gg for gb, gg in zip(group_by, group)}
+    proc_aman = core.AxisManager(core.LabelAxis('dets', ['det%i' % i for i in range(3)]),
+                                 core.OffsetAxis('samps', 1000))
+    proc_aman.wrap_new('signal', ('dets', 'samps'), dtype='float32')
+    proc_aman.wrap_new('timestamps', ('samps',))[:] = (np.arange(proc_aman.samps.count) / 200)
 
-        outputs_grp = pp_util.save_group(obs_id, configs, dets, context, subdir='temp')
-        logger.info(f"Saving data to {outputs_grp['temp_file']}:{outputs_grp['db_data']['dataset']}")
-        proc_aman.save(outputs_grp['temp_file'], outputs_grp['db_data']['dataset'], overwrite)
+    out_dict = pp_util.save_group(obs_id, configs, dets, context,
+                                  subdir=temp_subdir)
+    logger.info(f"Saving data to {out_dict['temp_file']}:{out_dict['db_data']['dataset']}")
+    proc_aman.save(out_dict['temp_file'], out_dict['db_data']['dataset'],
+                   overwrite)
 
-        if run_parallel:
-            outputs.append(outputs_grp)
-
-    if run_parallel:
-        return error, outputs
+    return out_dict, error
 
 
-def preprocess_tod(obs_id,
-                   configs,
-                   verbosity=0,
-                   group_list=None,
-                   overwrite=False,
-                   run_parallel=False):
-    """Meant to be run as part of a batched script, this function calls the
-    preprocessing pipeline a specific Observation ID and saves the results in
-    the ManifestDb specified in the configs.
-
-    Arguments
-    ----------
-    obs_id: string or ResultSet entry
-        obs_id or obs entry that is passed to context.get_obs
-    configs: string or dictionary
-        config file or loaded config directory
-    group_list: None or list
-        list of groups to run if you only want to run a partial update
-    overwrite: bool
-        if True, overwrite existing entries in ManifestDb
-    verbosity: log level
-        0 = error, 1 = warn, 2 = info, 3 = debug
-    run_parallel: Bool
-        If true preprocess_tod is called in a parallel process which returns
-        dB info and errors and does no sqlite writing inside the function.
-    """
-
-    outputs = []
-    logger = sp_util.init_logger("preprocess", verbosity=verbosity)
-
-    if type(configs) == str:
-        configs = yaml.safe_load(open(configs, "r"))
-
-    context = core.Context(configs["context_file"])
-    group_by, groups, error = pp_util.get_groups(obs_id, configs, context)
-
-    if error is not None:
-        if run_parallel:
-            return error[0], [None, None]
-        else:
-            return
-
-    all_groups = groups.copy()
-    for g in all_groups:
-        if group_list is not None:
-            if g not in group_list:
-                groups.remove(g)
-                continue
-        if 'wafer.bandpass' in group_by:
-            if 'NC' in g:
-                groups.remove(g)
-                continue
-        try:
-            meta = context.get_meta(obs_id, dets = {gb:gg for gb, gg in zip(group_by, g)})
-        except Exception as e:
-            errmsg = f'{type(e)}: {e}'
-            tb = ''.join(traceback.format_tb(e.__traceback__))
-            logger.info(f"ERROR: {obs_id} {g}\n{errmsg}\n{tb}")
-            groups.remove(g)
-            continue
-
-        if meta.dets.count == 0:
-            groups.remove(g)
-
-    if len(groups) == 0:
-        logger.warning(f"group_list:{group_list} contains no overlap with "
-                       f"groups in observation: {obs_id}:{all_groups}. "
-                       f"No analysis to run.")
-        error = 'no_group_overlap'
-        if run_parallel:
-            return error, [None, None]
-        else:
-            return
-
-    if not(run_parallel):
-        db = pp_util.get_preprocess_db(configs, group_by)
-
-    pipe = Pipeline(configs["process_pipe"], plot_dir=configs["plot_dir"], logger=logger)
-
-    if configs.get("lmsi_config", None) is not None:
-        make_lmsi = True
-    else:
-        make_lmsi = False
-
-    n_fail = 0
-    for group in groups:
-        logger.info(f"Beginning run for {obs_id}:{group}")
-        dets = {gb:gg for gb, gg in zip(group_by, group)}
-        try:
-            aman = context.get_obs(obs_id, dets=dets)
-            tags = np.array(context.obsdb.get(aman.obs_info.obs_id, tags=True)['tags'])
-            aman.wrap('tags', tags)
-            proc_aman, success = pipe.run(aman)
-
-            if make_lmsi:
-                new_plots = os.path.join(configs["plot_dir"],
-                                         f'{str(aman.timestamps[0])[:5]}',
-                                         aman.obs_info.obs_id)
-        except Exception as e:
-            #error = f'{obs_id} {group}'
-            errmsg = f'{type(e)}: {e}'
-            tb = ''.join(traceback.format_tb(e.__traceback__))
-            logger.info(f"ERROR: {obs_id} {group}\n{errmsg}\n{tb}")
-            # return error, None, [errmsg, tb]
-            # need a better way to log if just one group fails.
-            n_fail += 1
-            continue
-        if success != 'end':
-            # If a single group fails we don't log anywhere just mis an entry in the db.
-            logger.info(f"ERROR: {obs_id} {group}\nFailed at step {success}")
-            n_fail += 1
-            continue
-
-        outputs_grp = pp_util.save_group(obs_id, configs, dets, context, subdir='temp')
-        logger.info(f"Saving data to {outputs_grp['temp_file']}:{outputs_grp['db_data']['dataset']}")
-        proc_aman.save(outputs_grp['temp_file'], outputs_grp['db_data']['dataset'], overwrite)
-
-        if run_parallel:
-            outputs.append(outputs_grp)
-        else:
-            logger.info(f"Saving to database under {outputs_grp['db_data']}")
-            if len(db.inspect(outputs_grp['db_data'])) == 0:
-                h5_path = os.path.relpath(outputs_grp['temp_file'],
-                        start=os.path.dirname(configs['archive']['index']))
-                db.add_entry(outputs_grp['db_data'], h5_path)
-
-    if make_lmsi:
-        from pathlib import Path
-        import lmsi.core as lmsi
-
-        if os.path.exists(new_plots):
-            lmsi.core([Path(x.name) for x in Path(new_plots).glob("*.png")],
-                      Path(configs["lmsi_config"]),
-                      Path(os.path.join(new_plots, 'index.html')))
-
-    if run_parallel:
-        if n_fail == len(groups):
-            # If no groups make it to the end of the processing return error.
-            logger.info(f'ERROR: all groups failed for {obs_id}')
-            error = 'all_fail'
-            return error, [obs_id, 'all groups']
-        else:
-            logger.info('Returning data to futures')
-            error = None
-            return error, outputs
-
-
-def load_preprocess_tod_sim(obs_id, sim_map,
+def load_preprocess_tod_sim(obs_id,
+                            sim_map,
                             configs="preprocess_configs.yaml",
-                            context=None, dets=None,
-                            meta=None, modulated=True, logger=logger):
+                            context=None,
+                            dets=None,
+                            meta=None,
+                            modulated=True,
+                            logger=logger):
     """Loads the saved information from the preprocessing pipeline and runs the
     processing section of the pipeline on simulated data
 
@@ -247,6 +111,242 @@ def load_preprocess_tod_sim(obs_id, sim_map,
         demod_mm.from_map(aman, sim_map, wrap=True, modulated=modulated)
         pipe.run(aman, aman.preprocess, sim=True)
         return aman
+
+
+def preprocess_tod(obs_id, configs, group, verbosity=0, overwrite=False,
+                   run_parallel=False):
+    """Meant to be run as part of a batched script, this function calls the
+    preprocessing pipeline a specific Observation ID and group combination
+    and saves the results in the ManifestDb specified in the configs.
+
+    Arguments
+    ----------
+    obs_id: string or ResultSet entry
+        obs_id or obs entry that is passed to context.get_obs
+    configs: string or dictionary
+        config file or loaded config directory
+    group: list
+        Group to run if you only want to run a partial update
+    overwrite: bool
+        if True, overwrite existing entries in ManifestDb
+    verbosity: log level
+        0 = error, 1 = warn, 2 = info, 3 = debug
+    run_parallel: Bool
+        If true preprocess_tod is called in a parallel process which returns
+        dB info and errors and does no sqlite writing inside the function.
+    """
+
+    logger = sp_util.init_logger("preprocess", verbosity=verbosity)
+
+    if configs.get("lmsi_config", None) is not None:
+        make_lmsi = True
+    else:
+        make_lmsi = False
+
+    group_by = np.atleast_1d(configs['subobs'].get('use', 'detset'))
+    dets = {gb:gg for gb, gg in zip(group_by, group)}
+    aman, out_dict, _, error = pp_util.preproc_or_load_group(obs_id=obs_id,
+                                                             configs_init=configs,
+                                                             dets=dets,
+                                                             configs_proc=None,
+                                                             logger=logger,
+                                                             overwrite=overwrite,
+                                                             save_archive=not run_parallel)
+
+    if make_lmsi:
+        new_plots = os.path.join(configs["plot_dir"],
+                                 f'{str(aman.timestamps[0])[:5]}',
+                                 aman.obs_info.obs_id)
+        from pathlib import Path
+        import lmsi.core as lmsi
+
+        if os.path.exists(new_plots):
+            lmsi.core([Path(x.name) for x in Path(new_plots).glob("*.png")],
+                      Path(configs["lmsi_config"]),
+                      Path(os.path.join(new_plots, 'index.html')))
+
+    return out_dict, error
+
+
+def _main(executor: Union["MPICommExecutor", "ProcessPoolExecutor"],
+          as_completed_callable: Callable,
+          configs: str,
+          query: Optional[str] = '',
+          obs_id: Optional[str] = None,
+          overwrite: bool = False,
+          min_ctime: Optional[int] = None,
+          max_ctime: Optional[int] = None,
+          update_delay: Optional[int] = None,
+          tags: Optional[str] = None,
+          planet_obs: bool = False,
+          verbosity: Optional[int] = None,
+          nproc: Optional[int] = 4,
+          raise_error: Optional[bool] = False):
+
+    temp_subdir = "temp"
+
+    configs, context = pp_util.get_preprocess_context(configs)
+    logger = sp_util.init_logger("preprocess", verbosity=verbosity)
+
+    os.makedirs(os.path.dirname(configs_proc['archive']['policy']['filename']),
+                exist_ok=True)
+
+    jdb = JobManager(sqlite_file=configs["jobdb"])
+
+    errlog = os.path.join(os.path.dirname(configs['archive']['index']),
+                          'errlog.txt')
+
+    obs_list = sp_util.get_obslist(context, query=query, obs_id=obs_id,
+                                   min_ctime=min_ctime, max_ctime=max_ctime,
+                                   update_delay=update_delay, tags=tags,
+                                   planet_obs=planet_obs)
+    if len(obs_list) == 0:
+        logger.warning(f"No observations returned from query: {query}")
+        return
+
+    # clean up lingering files from previous incomplete runs
+    policy_dir = os.path.join(os.path.dirname(configs['archive']['policy']['filename']),
+                              temp_subdir)
+    for obs in obs_list:
+        obs_id = obs['obs_id']
+        pp_util.cleanup_obs(obs_id, policy_dir, errlog, configs, context,
+                            subdir=temp_subdir, remove=overwrite)
+
+    run_list = []
+
+    group_by = np.atleast_1d(configs['subobs'].get('use', 'detset'))
+
+    if overwrite or not os.path.exists(configs['archive']['index']):
+        db = None
+    else:
+        db = core.metadata.ManifestDb(configs['archive']['index'])
+
+    futures = []
+    futures_dict = {}
+    for obs in obs_list:
+        futures.append(executor.submit(pp_util.get_groups, obs["obs_id"], configs))
+
+    for obs, future in zip(obs_list, futures):
+        futures_dict[future] = obs["obs_id"]
+
+    for future in tqdm(as_completed_callable(futures), total=len(futures),
+                       desc="building run list from obs list"):
+        obs_id = futures_dict[future]
+        _, groups, _ = future.result()
+
+        if db is not None:
+            x = db.inspect({'obs:obs_id': obs_id})
+            if x is not None and len(x) != 0 and len(x) != len(groups):
+                [groups.remove([a[f'dets:{gb}'] for gb in group_by]) for a in x]
+
+        for group in groups:
+            if 'NC' not in group:
+                run_list.append((obs, group))
+
+    run_list_failed = []
+    for r in run_list:
+        jclass = r[0]['obs_id']
+        for gb, g in zip(group_by, r[1]):
+            if gb == 'detset':
+                jclass += "_" + g
+            else:
+                jclass += "_" + gb + "_" + str(g)
+        if jdb.get_jobs(jclass=jclass, jstate=["done", "failed", "ignored"]):
+            run_list_failed.append(r)
+
+    logger.info(f"skipping {len(run_list_failed)} jobs from jobdb")
+
+    run_list = [r for r in run_list if r not in run_list_failed]
+
+    jobs = []
+    for r in run_list:
+        jclass = r[0]['obs_id']
+        for gb, g in zip(group_by, r[1]):
+            if gb == 'detset':
+                jclass += "_" + g
+            else:
+                jclass += "_" + gb + "_" + str(g)
+        new_jobs = {}
+        open_jobs = jdb.get_jobs(jclass=jclass, jstate=["open"])
+
+        if open_jobs:
+            job = open_jobs[0]
+        else:
+            job = jdb.create_job(jclass)
+
+        jobs.append(job)
+
+    logger.info(f'Run list created with {len(run_list)} obsid groups')
+
+    futures = []
+    futures_dict = {}
+    obs_errors = {}
+
+    run_parallel = nproc > 1
+
+    # Run write_block obs-ids in parallel at once then write all to the sqlite db.
+    for r in run_list:
+        futures.append(executor.submit(preprocess_tod,
+                                       obs_id=r[0]['obs_id'],
+                                       configs=configs,
+                                       group=r[1],
+                                       verbosity=verbosity,
+                                       overwrite=overwrite,
+                                       run_parallel=run_parallel))
+
+    for r, j, future in zip(run_list, jobs, futures):
+        futures_dict[future] = (r[0]['obs_id'], r[1], j)
+        if r[0]['obs_id'] not in obs_errors:
+            obs_errors[r[0]['obs_id']] = []
+
+    for future in tqdm(as_completed_callable(futures), total=len(futures),
+                           desc="preprocess_tod"):
+        obs_id, group, job = futures_dict[future]
+        out_meta = (obs_id, group)
+        try:
+            out_dict, error = future.result()
+            obs_errors[obs_id].append({'group': group, 'error': error})
+            logger.info(f"{obs_id}: {group} extracted successfully")
+        except Exception as e:
+            errmsg, tb = PreprocessErrors.get_errors(e)
+            logger.error(f"Executor Future Result Error for {obs_id}: {group}:\n{errmsg}\n{tb}")
+            obs_errors[obs_id].append({'group': group, 'error': PreprocessErrors.ExecutorFutureError})
+            out_dict = None
+            error = PreprocessErrors.ExecutorFutureError
+
+            with jdb.locked(job) as j:
+                j.mark_visited()
+                j.jstate = "failed"
+
+        futures.remove(future)
+
+        if run_parallel:
+            logger.info(f"Adding future result to db for {obs_id}: {group}")
+            pp_util.cleanup_mandb(out_dict, out_meta, error, configs, logger)
+
+        with jdb.locked(job) as j:
+            if j.visit_count == 0:
+                j.mark_visited()
+                j.jstate = "done"
+
+    n_obs_fail = 0
+    n_groups_fail = 0
+    for obs_id, out_meta in obs_errors.items():
+        if all(entry['error'] is not None for entry in out_meta):
+            n_obs_fail += 1
+            n_groups_fail += len(out_meta)
+        else:
+            for entry in out_meta:
+                if entry['error'] is not None:
+                    n_groups_fail += 1
+
+    logger.warn(f"{n_obs_fail}/{len(obs_errors)} observations failed entirely")
+    logger.warn(f"{n_groups_fail}/{len(run_list)} groups failed")
+
+    if raise_error:
+        raise RuntimeError("preprocess_tod ended with failed obsids")
+    else:
+        logger.info("preprocess_tod is done")
 
 
 def get_parser(parser=None):
@@ -313,98 +413,8 @@ def get_parser(parser=None):
     return parser
 
 
-def _main(executor: Union["MPICommExecutor", "ProcessPoolExecutor"],
-          as_completed_callable: Callable,
-          configs: str,
-          query: Optional[str] = None,
-          obs_id: Optional[str] = None,
-          overwrite: bool = False,
-          min_ctime: Optional[int] = None,
-          max_ctime: Optional[int] = None,
-          update_delay: Optional[int] = None,
-          tags: Optional[str] = None,
-          planet_obs: bool = False,
-          verbosity: Optional[int] = None,
-          nproc: Optional[int] = 4,
-          raise_error: Optional[bool] = False):
-
-    configs, context = pp_util.get_preprocess_context(configs)
-    logger = sp_util.init_logger("preprocess", verbosity=verbosity)
-
-    errlog = os.path.join(os.path.dirname(configs['archive']['index']),
-                          'errlog.txt')
-
-    obs_list = sp_util.get_obslist(context, query=query, obs_id=obs_id, min_ctime=min_ctime,
-                                   max_ctime=max_ctime, update_delay=update_delay, tags=tags,
-                                   planet_obs=planet_obs)
-
-    if len(obs_list)==0:
-        logger.warning(f"No observations returned from query: {query}")
-
-    # clean up lingering files from previous incomplete runs
-    policy_dir = os.path.join(os.path.dirname(configs['archive']['policy']['filename']), 'temp')
-    for obs in obs_list:
-        obs_id = obs['obs_id']
-        pp_util.cleanup_obs(obs_id, policy_dir, errlog, configs, context,
-                            subdir='temp', remove=overwrite)
-
-    run_list = []
-
-    if overwrite or not os.path.exists(configs['archive']['index']):
-        #run on all if database doesn't exist
-        run_list = [ (o,None) for o in obs_list]
-        group_by = np.atleast_1d(configs['subobs'].get('use', 'detset'))
-    else:
-        db = core.metadata.ManifestDb(configs['archive']['index'])
-        for obs in obs_list:
-            x = db.inspect({'obs:obs_id': obs["obs_id"]})
-            if x is None or len(x) == 0:
-                run_list.append( (obs, None) )
-            else:
-                group_by, groups, _ = pp_util.get_groups(obs["obs_id"], configs, context)
-                if len(x) != len(groups):
-                    [groups.remove([a[f'dets:{gb}'] for gb in group_by]) for a in x]
-                    run_list.append( (obs, groups) )
-
-    logger.info(f'Run list created with {len(run_list)} obsids')
-
-    n_fail = 0
-
-    # Run write_block obs-ids in parallel at once then write all to the sqlite db.
-    futures = [executor.submit(preprocess_tod, obs_id=r[0]['obs_id'],
-                    group_list=r[1], verbosity=verbosity,
-                    configs=configs,
-                    overwrite=overwrite, run_parallel=True) for r in run_list]
-    for future in as_completed_callable(futures):
-        logger.info('New future as_completed result')
-        try:
-            err, db_datasets = future.result()
-            if err is not None:
-                n_fail += 1
-        except Exception as e:
-            errmsg = f'{type(e)}: {e}'
-            tb = ''.join(traceback.format_tb(e.__traceback__))
-            logger.info(f"ERROR: future.result()\n{errmsg}\n{tb}")
-            f = open(errlog, 'a')
-            f.write(f'\n{time.time()}, future.result() error\n{errmsg}\n{tb}\n')
-            f.close()
-            n_fail+=1
-            continue
-        futures.remove(future)
-
-        if db_datasets:
-            if err is None:
-                logger.info(f'Processing future result db_dataset: {db_datasets}')
-                for db_dataset in db_datasets:
-                    pp_util.cleanup_mandb(err, db_dataset, configs, logger)
-            else:
-                pp_util.cleanup_mandb(err, db_datasets, configs, logger)
-
-    if raise_error and n_fail > 0:
-        raise RuntimeError(f"preprocess_tod: {n_fail}/{len(run_list)} obs_ids failed")
-
 def main(configs: str,
-         query: Optional[str] = None,
+         query: Optional[str] = '',
          obs_id: Optional[str] = None,
          overwrite: bool = False,
          min_ctime: Optional[int] = None,


### PR DESCRIPTION
Sort of an update to #1156.  Does the following:

1. Switches to per-group parallelization for `preprocess_tod` and `multilayer_preprocess_tod`.
2. Reworks `preprocess_tod` and `multilayer_preprocess_tod` to rely more on `preproc_or_load_group` since it does many of the same things.
3. Start adding jobdb support for both `preprocess_tod` and `multilayer_preprocess_tod`.
4. Adds some standardized error messages in a class which can be input into a preprocessing error db.
5. Some more cleanup of functions and docstrings in `preprocess_util`.

Might split into multiple PRs if possible.  Will need to adjust some things to make sure it doesn't break things downstream.