### PR TITLE
Reduce generate_reports buffer time

### DIFF
--- a/sotodlib/site_pipeline/generate_reports.py
+++ b/sotodlib/site_pipeline/generate_reports.py
@@ -93,8 +93,8 @@ class GenerateReportConfig:
         now = dt.datetime.now(tz=dt.timezone.utc)
         while start < self.stop_time:
             stop: dt.datetime = start + delta
-            if stop > now - dt.timedelta(days=1):
-                # Give a buffer of 1 day to compile report for previous interval
+            if stop > now - dt.timedelta(hours=1):
+                # Give a buffer of 1 hour to compile report for previous interval
                 break
             self.time_intervals.append((start, stop))
             start += delta


### PR DESCRIPTION
Reduces the buffer time for starting adding a time interval to the list of time intervals to run to 1 hour from 1 day.  This fixes an issue on Prefect where if you run on the last day of the final interval, it won't add that week.  Tested on site and confirmed it made up to the current date and did not add any future time periods (would happen if the buffer is zero).