### PR TITLE
Explicitly close preprocess db in cleanup_mandb

### DIFF
--- a/sotodlib/preprocess/preprocess_util.py
+++ b/sotodlib/preprocess/preprocess_util.py
@@ -1124,6 +1124,8 @@ def cleanup_mandb(error, outputs, configs, logger=None, overwrite=False):
         db = get_preprocess_db(configs, group_by, logger)
         if len(db.inspect(outputs['db_data'])) == 0:
             db.add_entry(outputs['db_data'], h5_path)
+        # make sure we close the db each time
+        db.conn.close()
         os.remove(src_file)
     elif error == 'load_success':
         return


### PR DESCRIPTION
Closes the preprocess db in `cleanup_mandb` to prevent it from becoming locked and therefore blocking it from being written to.

Tested with `preproc_or_load_group` and confirmed no issues in saving.  Have not tested in the context of preventing the locked db error.