### PR TITLE
When loading data from a Context into toast, use consistent weather

### DIFF
--- a/sotodlib/toast/instrument.py
+++ b/sotodlib/toast/instrument.py
@@ -97,6 +97,7 @@ class SOSite(GroundSite):
             lat,
             lon,
             alt,
+            weather=weather,
             **kwargs,
         )
 


### PR DESCRIPTION
In toast, the azel -> radec transform makes use of weather information. For real data we currently have access to the "typical weather" at the site in terms of temperature, pressure, and humidity.  Construct the toast site weather using the best info we have, which is the median MERRA-2 data for day of year and time of day, along with the "typical weather" parameters.  This allows us to build consistent pointing in toast relative to what is done in so3g.

Eventually, it would be nice if temperature, pressure, PWV, etc were recorded in the metadata loaded from the context.