### PR TITLE
Check if wafer and band exist for qa

### DIFF
--- a/sotodlib/preprocess/pcore.py
+++ b/sotodlib/preprocess/pcore.py
@@ -586,32 +586,34 @@ class _FracFlaggedMixIn(object):
                 frac_flagged = np.array([
                     np.dot(r.ranges(), [-1, 1]).sum() for r in proc_aman[key1][key2][subset]
                 ], dtype=float)
-                num_valid = np.array([
-                    np.dot(r.ranges(), [-1, 1]).sum() for r in proc_aman[key1].valid[subset]
-                ])
-                with np.errstate(divide="ignore"):
-                    frac_flagged *= np.where(num_valid > 0, 1 / num_valid, 0)
 
-                # record percentiles over detectors and fraction of samples flagged
-                perc = np.percentile(frac_flagged, percentiles)
-                mean = frac_flagged.mean()
+                if len(frac_flagged) > 0:
+                    num_valid = np.array([
+                        np.dot(r.ranges(), [-1, 1]).sum() for r in proc_aman[key1].valid[subset]
+                    ])
+                    with np.errstate(divide="ignore"):
+                        frac_flagged *= np.where(num_valid > 0, 1 / num_valid, 0)
 
-                # get the tags for this wafer (all detectors in this subset share these)
-                tags_base = {
-                    k: _get_tag(meta.det_info, k, subset[0]) for k in tag_keys if _has_tag(meta.det_info, k)
-                }
-                tags_base["telescope"] = meta.obs_info.telescope
+                    # record percentiles over detectors and fraction of samples flagged
+                    perc = np.percentile(frac_flagged, percentiles)
+                    mean = frac_flagged.mean()
 
-                # add tags and values to respective lists in order
-                tags_perc = [tags_base.copy() for i in range(perc.size)]
-                for i, t in enumerate(tags_perc):
-                    t["det_stat"] = f"percentile_{percentiles[i]}"
-                vals += list(perc)
-                tags += tags_perc
-                tags_mean = tags_base.copy()
-                tags_mean["det_stat"] = "mean"
-                vals.append(mean)
-                tags.append(tags_mean)
+                    # get the tags for this wafer (all detectors in this subset share these)
+                    tags_base = {
+                        k: _get_tag(meta.det_info, k, subset[0]) for k in tag_keys if _has_tag(meta.det_info, k)
+                    }
+                    tags_base["telescope"] = meta.obs_info.telescope
+
+                    # add tags and values to respective lists in order
+                    tags_perc = [tags_base.copy() for i in range(perc.size)]
+                    for i, t in enumerate(tags_perc):
+                        t["det_stat"] = f"percentile_{percentiles[i]}"
+                    vals += list(perc)
+                    tags += tags_perc
+                    tags_mean = tags_base.copy()
+                    tags_mean["det_stat"] = "mean"
+                    vals.append(mean)
+                    tags.append(tags_mean)
 
         obs_time = [meta.obs_info.timestamp] * len(vals)
         return {

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -826,46 +826,47 @@ class EstimateHWPSS(_Preprocess):
                     (meta.det_info.wafer_slot == ws) & (meta.det_info.wafer.bandpass == bp)
                 )[0]
 
-                # get the coefficients for every detector
-                coeff = proc_aman.hwpss_stats.coeffs[subset]
-                # mask those that were not set
-                nonzero = np.any(coeff != 0.0, axis=1)
+                if len(subset) > 0:
+                    # get the coefficients for every detector
+                    coeff = proc_aman.hwpss_stats.coeffs[subset]
+                    # mask those that were not set
+                    nonzero = np.any(coeff != 0.0, axis=1)
 
-                # calculate amplitude of each mode
-                mode_labels = list(proc_aman.hwpss_stats.modes.vals)
-                num_re = re.compile("^[SC](\d+)$")
-                nums = sorted(list(set([num_re.match(l).group(1) for l in mode_labels])))
-                coeff_amp = np.zeros((coeff.shape[0], len(nums)), coeff.dtype)
-                amp_labels = []
-                for i, n in enumerate(nums):
-                    c_ind = mode_labels.index(f"C{n}")
-                    s_ind = mode_labels.index(f"S{n}")
-                    coeff_amp[:, i] = np.sqrt(coeff[:, c_ind]**2 + coeff[:, s_ind]**2)
-                    amp_labels.append(f"A{n}")
+                    # calculate amplitude of each mode
+                    mode_labels = list(proc_aman.hwpss_stats.modes.vals)
+                    num_re = re.compile("^[SC](\d+)$")
+                    nums = sorted(list(set([num_re.match(l).group(1) for l in mode_labels])))
+                    coeff_amp = np.zeros((coeff.shape[0], len(nums)), coeff.dtype)
+                    amp_labels = []
+                    for i, n in enumerate(nums):
+                        c_ind = mode_labels.index(f"C{n}")
+                        s_ind = mode_labels.index(f"S{n}")
+                        coeff_amp[:, i] = np.sqrt(coeff[:, c_ind]**2 + coeff[:, s_ind]**2)
+                        amp_labels.append(f"A{n}")
 
-                # record percentiles over detectors and fraction of samples flagged
-                perc = np.percentile(coeff_amp[nonzero], cls._influx_percentiles, axis=0)
-                mean = coeff_amp[nonzero].mean(axis=0)
+                    # record percentiles over detectors and fraction of samples flagged
+                    perc = np.percentile(coeff_amp[nonzero], cls._influx_percentiles, axis=0)
+                    mean = coeff_amp[nonzero].mean(axis=0)
 
-                tags_base = {
-                    k: _get_tag(meta.det_info, k, subset[0]) for k in tag_keys if _has_tag(meta.det_info, k)
-                }
-                tags_base["telescope"] = meta.obs_info.telescope
+                    tags_base = {
+                        k: _get_tag(meta.det_info, k, subset[0]) for k in tag_keys if _has_tag(meta.det_info, k)
+                    }
+                    tags_base["telescope"] = meta.obs_info.telescope
 
-                # loop over percentiles and coefficient labels
-                for pi, p in enumerate(cls._influx_percentiles):
+                    # loop over percentiles and coefficient labels
+                    for pi, p in enumerate(cls._influx_percentiles):
+                        for l in amp_labels:
+                            t_new = tags_base.copy()
+                            t_new.update({"mode": l, "det_stat": f"percentile_{p}"})
+                            tags.append(t_new)
+                        vals += list(perc[pi])
+
+                    # finally also record the mean
                     for l in amp_labels:
                         t_new = tags_base.copy()
-                        t_new.update({"mode": l, "det_stat": f"percentile_{p}"})
+                        t_new.update({"mode": l, "det_stat": "mean"})
                         tags.append(t_new)
-                    vals += list(perc[pi])
-
-                # finally also record the mean
-                for l in amp_labels:
-                    t_new = tags_base.copy()
-                    t_new.update({"mode": l, "det_stat": "mean"})
-                    tags.append(t_new)
-                vals += list(mean)
+                    vals += list(mean)
 
         obs_time = [meta.obs_info.timestamp] * len(tags)
         return {

--- a/sotodlib/qa/metrics.py
+++ b/sotodlib/qa/metrics.py
@@ -212,24 +212,25 @@ class PreprocessValidDets(PreprocessQA):
                     (meta.det_info.wafer_slot == ws) & (meta.det_info.wafer.bandpass == bp)
                 )[0]
 
-                # Compute the number of samples that are valid
-                frac_valid = np.array([
-                    np.dot(r.ranges(), [-1, 1]).sum() / len(subset)
-                    for r in meta.preprocess[self._key].valid[subset]
-                ])
+                if len(subset) > 0:
+                    # Compute the number of samples that are valid
+                    frac_valid = np.array([
+                        np.dot(r.ranges(), [-1, 1]).sum() / len(subset)
+                        for r in meta.preprocess[self._key].valid[subset]
+                    ])
 
-                # Count detectors with fraction valid above threshold
-                n_good = (frac_valid > self._thresh).sum()
+                    # Count detectors with fraction valid above threshold
+                    n_good = (frac_valid > self._thresh).sum()
 
-                # get the tags for this wafer (all detectors in this subset share these)
-                tags_i = {
-                    k: _get_tag(meta.det_info, k, subset[0]) for k in tag_keys if _has_tag(meta.det_info, k)
-                }
-                tags_i["telescope"] = meta.obs_info.telescope
+                    # get the tags for this wafer (all detectors in this subset share these)
+                    tags_i = {
+                        k: _get_tag(meta.det_info, k, subset[0]) for k in tag_keys if _has_tag(meta.det_info, k)
+                    }
+                    tags_i["telescope"] = meta.obs_info.telescope
 
-                # add tags and values to respective lists in order
-                vals.append(n_good)
-                tags.append(tags_i)
+                    # add tags and values to respective lists in order
+                    vals.append(n_good)
+                    tags.append(tags_i)
 
         obs_time = [meta.obs_info.timestamp] * len(vals)
         return {
@@ -290,14 +291,12 @@ class PreprocessArrayNET(PreprocessQA):
                 good_indices = np.nonzero(mask)[0]
                 if good_indices.size > 0:
                     vals.append(np.sqrt(1.0 / np.nansum(1.0 / (white_noise[good_indices])**2)))
-                else:
-                    vals.append(0.0)
 
-                tags_base = {
-                    k: _get_tag(meta.det_info, k, subset[0]) for k in tag_keys if _has_tag(meta.det_info, k)
-                }
-                tags_base["telescope"] = meta.obs_info.telescope
-                tags.append(tags_base)
+                    tags_base = {
+                        k: _get_tag(meta.det_info, k, subset[0]) for k in tag_keys if _has_tag(meta.det_info, k)
+                    }
+                    tags_base["telescope"] = meta.obs_info.telescope
+                    tags.append(tags_base)
 
         obs_time = [meta.obs_info.timestamp] * len(tags)
         return {
@@ -358,14 +357,12 @@ class PreprocessDetNET(PreprocessQA):
                 good_indices = np.nonzero(mask)[0]
                 if good_indices.size > 0:
                     vals.append(np.sqrt(1.0 / np.nansum(1.0 / (white_noise[good_indices])**2)) * np.sqrt(len(good_indices)))
-                else:
-                    vals.append(0.0)
 
-                tags_base = {
-                    k: _get_tag(meta.det_info, k, subset[0]) for k in tag_keys if _has_tag(meta.det_info, k)
-                }
-                tags_base["telescope"] = meta.obs_info.telescope
-                tags.append(tags_base)
+                    tags_base = {
+                        k: _get_tag(meta.det_info, k, subset[0]) for k in tag_keys if _has_tag(meta.det_info, k)
+                    }
+                    tags_base["telescope"] = meta.obs_info.telescope
+                    tags.append(tags_base)
 
         obs_time = [meta.obs_info.timestamp] * len(tags)
         return {


### PR DESCRIPTION
There are errors in the `record_qa` flows on Prefect due to some obs_ids having a single band from a wafer missing from the preprocessing database so the `subsets` array is empty causing failures in the statistics calculations.  This adds in some checks to guard against that and does not add that wafer and band combo to the list if it fails.  Have tested with the `dev-db` and confirmed a failed obs_id now runs, but have not tested in Grafana.

Should note I think this is a LAT exclusive problem seemingly (but not really to any one obs tube I think), so it may go away with better preprocessing and detector setup.