### PR TITLE
Pypi release

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,9 +4,15 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+  workflow_run:
+    workflows: ["SOTODLIB Monthly Release"]
+    types:
+      - completed
 
 jobs:
   pypi-publish:
+    if: |
+      github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     permissions:
       id-token: write # IMPORTANT: this permission is mandatory for trusted publishing

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,6 +4,10 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+  # SOTODLIB Monthly Release uses GITHUB_TOKEN. Any repository changes it makes do
+  # not trigger a new workflow run.
+  # This is a "workflow" based trigger. It checks the events and when the monthly
+  # release is run successfully, it gets triggered.
   workflow_run:
     workflows: ["SOTODLIB Monthly Release"]
     types:
@@ -11,6 +15,7 @@ on:
 
 jobs:
   pypi-publish:
+    # This if statement checks if the event is not a workflow_run or if the workflow_run was successful
     if: |
       github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest


### PR DESCRIPTION
Our Pypi release did not run because as it seems when we use `GITHUB_TOKEN` in a workflow any repository changes the workflow makes do not trigger a new workflow run.

This PR makes a change to the Pypi release to allow for a "workflow" based trigger. It checks the events and when the monthly release is run successfully, it gets triggered and releases to pypi.