### PR TITLE
Fix preprocess plotting edge case and in multilayer_preprocess_tod

### DIFF
--- a/sotodlib/site_pipeline/preprocess_tod.py
+++ b/sotodlib/site_pipeline/preprocess_tod.py
@@ -134,6 +134,8 @@ def preprocess_tod(obs_id,
     else:
         make_lmsi = False
 
+    new_plots = None
+
     n_fail = 0
     for group in groups:
         logger.info(f"Beginning run for {obs_id}:{group}")
@@ -180,7 +182,7 @@ def preprocess_tod(obs_id,
         from pathlib import Path
         import lmsi.core as lmsi
 
-        if os.path.exists(new_plots):
+        if new_plots is not None and os.path.exists(new_plots):
             lmsi.core([Path(x.name) for x in Path(new_plots).glob("*.png")],
                       Path(configs["lmsi_config"]),
                       Path(os.path.join(new_plots, 'index.html')))


### PR DESCRIPTION
Fixes an edge case where `preprocess_tod` throws an error when `new_plots` doesn't get defined due to no groups running successfully.  Example of the error occurring here:
https://prefect.simonsobs.org/flow-runs/flow-run/8cd900e1-70dc-419c-8ad9-d5c929e252c6

Also adds some missing plotting components to `multilayer_preprocess_tod`
