### PR TITLE
Book ctime limit fix

### DIFF
--- a/sotodlib/io/bookbinder.py
+++ b/sotodlib/io/bookbinder.py
@@ -602,7 +602,7 @@ class SmurfStreamProcessor:
             self.times >= self.min_ctime,
             self.times <= self.max_ctime,
         ], axis=0)
-        if np.any( np.diff(self.times[msk]) < 0):
+        if np.any(np.diff(self.times[msk]) <= 0):
             raise BadTimeSamples(
                 f"{self.obs_id} has time samples not increasing"
             )


### PR DESCRIPTION
While debugging some recent book failures I realized I had not correct implemented the max_ctime limitations.

Also changed maxed drop sample error throwing from 100 to 200 samples because that doesn't meaningfully change the science but experience says that will significantly reduce the number of books flagged as failed. 