### PR TITLE
Add a valid ranges matrix to proc_aman

### DIFF
--- a/sotodlib/preprocess/pcore.py
+++ b/sotodlib/preprocess/pcore.py
@@ -513,6 +513,28 @@ class Pipeline(list):
                 success = process.name
                 break
 
+        if run_calc:
+            _, fs_dets, ns_dets = full.dets.intersection(
+                proc_aman.dets,
+                return_slices=True
+            )
+            _, fs_samps, ns_samps = full.samps.intersection(
+                proc_aman.samps,
+                return_slices=True
+            )
+
+            x = Ranges( full.samps.count )
+            m = x.mask()
+            m[fs_samps] = True
+            v = Ranges.from_mask(m)
+
+            valid = RangesMatrix(
+                [v if i in fs_dets else x for i in range(full.dets.count)]
+            )
+            if 'valid' in full:
+                full.move('valid', None)
+            full.wrap('valid', valid, [(0,'dets'),(1,'samps')])
+
         # copy updated frequency cutoffs to full
         if "frequency_cutoffs" in full:
             full.move("frequency_cutoffs", None)

--- a/sotodlib/preprocess/preprocess_util.py
+++ b/sotodlib/preprocess/preprocess_util.py
@@ -1044,7 +1044,7 @@ def preproc_or_load_group(obs_id, configs_init, dets, configs_proc=None,
 
                 # remove fields found in aman.preprocess from proc_aman
                 for fld_init in init_fields:
-                    if fld_init in proc_aman and fld_init:
+                    if fld_init in proc_aman:
                         proc_aman.move(fld_init, None)
 
                 proc_aman.wrap('pcfg_ref', aman_cfgs_ref)

--- a/sotodlib/preprocess/preprocess_util.py
+++ b/sotodlib/preprocess/preprocess_util.py
@@ -11,6 +11,7 @@ import inspect
 from sotodlib.hwp import hwp_angle_model
 from sotodlib.coords import demod as demod_mm
 from sotodlib.tod_ops import t2pleakage
+from sotodlib.core.flagman import has_any_cuts
 
 from .. import core
 
@@ -318,15 +319,15 @@ def load_preprocess_det_select(obs_id, configs, context=None,
     configs, context = get_preprocess_context(configs, context)
     pipe = Pipeline(configs["process_pipe"], logger=logger)
 
-    meta = context.get_meta(obs_id, dets=dets, meta=meta)
+    if meta is None:
+        meta = context.get_meta(obs_id, dets=dets)
     logger.info("Restricting detectors on all processes")
     keep_all = np.ones(meta.dets.count,dtype=bool)
     for process in pipe[:]:
         keep = process.select(meta, in_place=False)
         if isinstance(keep, np.ndarray):
             keep_all &= keep
-    meta.restrict("dets", meta.dets.vals[keep_all])
-    return meta
+    return meta.dets.vals[keep_all]
 
 
 def load_and_preprocess(obs_id, configs, context=None, dets=None, meta=None,
@@ -363,8 +364,14 @@ def load_and_preprocess(obs_id, configs, context=None, dets=None, meta=None,
         logger = init_logger("preprocess")
 
     configs, context = get_preprocess_context(configs, context)
-    meta = load_preprocess_det_select(obs_id, configs=configs, context=context,
-                                      dets=dets, meta=meta, logger=logger)
+    meta = context.get_meta(obs_id, dets=dets, meta=meta)
+    if 'valid' in meta.preprocess:
+        keep = has_any_cuts(meta.preprocess.valid)
+        meta.restrict("dets", keep)
+    else:
+        det_vals = load_preprocess_det_select(obs_id, configs=configs, context=context,
+                                              dets=dets, meta=meta, logger=logger)
+        meta.restrict("dets", [d for d in meta.dets.vals if d in det_vals])
 
     if meta.dets.count == 0:
         logger.info(f"No detectors left after cuts in obs {obs_id}")
@@ -444,11 +451,14 @@ def multilayer_load_and_preprocess(obs_id, configs_init, configs_proc,
             pipe_proc = Pipeline(configs_proc["process_pipe"], logger=logger)
 
             logger.info("Restricting detectors on all proc pipeline processes")
-            keep_all = np.ones(meta_proc.dets.count, dtype=bool)
-            for process in pipe_proc[:]:
-                keep = process.select(meta_proc, in_place=False)
-                if isinstance(keep, np.ndarray):
-                    keep_all &= keep
+            if 'valid' in meta_proc.preprocess:
+                keep_all = has_any_cuts(meta_proc.preprocess.valid)
+            else:
+                keep_all = np.ones(meta_proc.dets.count, dtype=bool)
+                for process in pipe_proc[:]:
+                    keep = process.select(meta_proc, in_place=False)
+                    if isinstance(keep, np.ndarray):
+                        keep_all &= keep
             meta_proc.restrict("dets", meta_proc.dets.vals[keep_all])
             meta_init.restrict('dets', meta_proc.dets.vals)
 
@@ -461,8 +471,9 @@ def multilayer_load_and_preprocess(obs_id, configs_init, configs_proc,
             logger.info("Running dependent pipeline")
             proc_aman = context_proc.get_meta(obs_id, meta=aman)
 
+            if 'valid' in aman.preprocess:
+                aman.preprocess.move('valid', None)
             aman.preprocess.merge(proc_aman.preprocess)
-
             pipe_proc.run(aman, aman.preprocess, select=False)
 
             return aman
@@ -579,6 +590,8 @@ def multilayer_load_and_preprocess_sim(obs_id, configs_init, configs_proc,
 
             logger.info("Running dependent pipeline")
             proc_aman = context_proc.get_meta(obs_id, meta=aman)
+            if 'valid' in aman.preprocess:
+                aman.preprocess.move('valid', None)
             aman.preprocess.merge(proc_aman.preprocess)
             pipe_proc.run(aman, aman.preprocess, sim=True)
 
@@ -943,6 +956,7 @@ def preproc_or_load_group(obs_id, configs_init, dets, configs_proc=None,
                 try:
                     outputs_proc = save_group(obs_id, configs_proc, dets, context_proc, subdir='temp_proc')
                     init_fields = aman.preprocess._fields.copy()
+                    init_fields.pop('valid', None)
                     logger.info(f"Generating new dependent preproc db entry for {obs_id} {dets}")
                     # pipeline for init config
                     pipe_init = Pipeline(configs_init["process_pipe"], plot_dir=configs_init["plot_dir"], logger=logger)
@@ -979,6 +993,7 @@ def preproc_or_load_group(obs_id, configs_init, dets, configs_proc=None,
                 logger.info(f"Saving data to {outputs_proc['temp_file']}:{outputs_proc['db_data']['dataset']}")
                 proc_aman.save(outputs_proc['temp_file'], outputs_proc['db_data']['dataset'], overwrite)
 
+                aman.preprocess.move('valid', None)
                 aman.preprocess.merge(proc_aman)
 
                 return error, [obs_id, dets], outputs_proc, aman
@@ -1013,6 +1028,7 @@ def preproc_or_load_group(obs_id, configs_init, dets, configs_proc=None,
             try:
                 outputs_proc = save_group(obs_id, configs_proc, dets, context_proc, subdir='temp_proc')
                 init_fields = aman.preprocess._fields.copy()
+                init_fields.pop('valid', None)
                 logger.info(f"Generating new dependent preproc db entry for {obs_id} {dets}")
                 # pipeline for processing config
                 pipe_proc = Pipeline(configs_proc["process_pipe"], plot_dir=configs_proc["plot_dir"], logger=logger)
@@ -1027,7 +1043,7 @@ def preproc_or_load_group(obs_id, configs_init, dets, configs_proc=None,
 
                 # remove fields found in aman.preprocess from proc_aman
                 for fld_init in init_fields:
-                    if fld_init in proc_aman:
+                    if fld_init in proc_aman and fld_init:
                         proc_aman.move(fld_init, None)
 
                 proc_aman.wrap('pcfg_ref', aman_cfgs_ref)
@@ -1045,6 +1061,7 @@ def preproc_or_load_group(obs_id, configs_init, dets, configs_proc=None,
             logger.info(f"Saving data to {outputs_proc['temp_file']}:{outputs_proc['db_data']['dataset']}")
             proc_aman.save(outputs_proc['temp_file'], outputs_proc['db_data']['dataset'], overwrite)
 
+            aman.preprocess.move('valid', None)
             aman.preprocess.merge(proc_aman)
 
             return error, outputs_init, outputs_proc, aman

--- a/sotodlib/preprocess/preprocess_util.py
+++ b/sotodlib/preprocess/preprocess_util.py
@@ -993,7 +993,8 @@ def preproc_or_load_group(obs_id, configs_init, dets, configs_proc=None,
                 logger.info(f"Saving data to {outputs_proc['temp_file']}:{outputs_proc['db_data']['dataset']}")
                 proc_aman.save(outputs_proc['temp_file'], outputs_proc['db_data']['dataset'], overwrite)
 
-                aman.preprocess.move('valid', None)
+                if 'valid' in aman.preprocess:
+                    aman.preprocess.move('valid', None)
                 aman.preprocess.merge(proc_aman)
 
                 return error, [obs_id, dets], outputs_proc, aman
@@ -1061,7 +1062,8 @@ def preproc_or_load_group(obs_id, configs_init, dets, configs_proc=None,
             logger.info(f"Saving data to {outputs_proc['temp_file']}:{outputs_proc['db_data']['dataset']}")
             proc_aman.save(outputs_proc['temp_file'], outputs_proc['db_data']['dataset'], overwrite)
 
-            aman.preprocess.move('valid', None)
+            if 'valid' in aman.preprocess:
+                aman.preprocess.move('valid', None)
             aman.preprocess.merge(proc_aman)
 
             return error, outputs_init, outputs_proc, aman

--- a/sotodlib/preprocess/preprocess_util.py
+++ b/sotodlib/preprocess/preprocess_util.py
@@ -365,8 +365,8 @@ def load_and_preprocess(obs_id, configs, context=None, dets=None, meta=None,
 
     configs, context = get_preprocess_context(configs, context)
     meta = context.get_meta(obs_id, dets=dets, meta=meta)
-    if 'valid' in meta.preprocess:
-        keep = has_any_cuts(meta.preprocess.valid)
+    if 'valid_data' in meta.preprocess:
+        keep = has_any_cuts(meta.preprocess.valid_data)
         meta.restrict("dets", keep)
     else:
         det_vals = load_preprocess_det_select(obs_id, configs=configs, context=context,
@@ -451,8 +451,8 @@ def multilayer_load_and_preprocess(obs_id, configs_init, configs_proc,
             pipe_proc = Pipeline(configs_proc["process_pipe"], logger=logger)
 
             logger.info("Restricting detectors on all proc pipeline processes")
-            if 'valid' in meta_proc.preprocess:
-                keep_all = has_any_cuts(meta_proc.preprocess.valid)
+            if 'valid_data' in meta_proc.preprocess:
+                keep_all = has_any_cuts(meta_proc.preprocess.valid_data)
             else:
                 keep_all = np.ones(meta_proc.dets.count, dtype=bool)
                 for process in pipe_proc[:]:
@@ -471,8 +471,8 @@ def multilayer_load_and_preprocess(obs_id, configs_init, configs_proc,
             logger.info("Running dependent pipeline")
             proc_aman = context_proc.get_meta(obs_id, meta=aman)
 
-            if 'valid' in aman.preprocess:
-                aman.preprocess.move('valid', None)
+            if 'valid_data' in aman.preprocess:
+                aman.preprocess.move('valid_data', None)
             aman.preprocess.merge(proc_aman.preprocess)
             pipe_proc.run(aman, aman.preprocess, select=False)
 
@@ -590,8 +590,8 @@ def multilayer_load_and_preprocess_sim(obs_id, configs_init, configs_proc,
 
             logger.info("Running dependent pipeline")
             proc_aman = context_proc.get_meta(obs_id, meta=aman)
-            if 'valid' in aman.preprocess:
-                aman.preprocess.move('valid', None)
+            if 'valid_data' in aman.preprocess:
+                aman.preprocess.move('valid_data', None)
             aman.preprocess.merge(proc_aman.preprocess)
             pipe_proc.run(aman, aman.preprocess, sim=True)
 
@@ -956,7 +956,7 @@ def preproc_or_load_group(obs_id, configs_init, dets, configs_proc=None,
                 try:
                     outputs_proc = save_group(obs_id, configs_proc, dets, context_proc, subdir='temp_proc')
                     init_fields = aman.preprocess._fields.copy()
-                    init_fields.pop('valid', None)
+                    init_fields.pop('valid_data', None)
                     logger.info(f"Generating new dependent preproc db entry for {obs_id} {dets}")
                     # pipeline for init config
                     pipe_init = Pipeline(configs_init["process_pipe"], plot_dir=configs_init["plot_dir"], logger=logger)
@@ -993,8 +993,8 @@ def preproc_or_load_group(obs_id, configs_init, dets, configs_proc=None,
                 logger.info(f"Saving data to {outputs_proc['temp_file']}:{outputs_proc['db_data']['dataset']}")
                 proc_aman.save(outputs_proc['temp_file'], outputs_proc['db_data']['dataset'], overwrite)
 
-                if 'valid' in aman.preprocess:
-                    aman.preprocess.move('valid', None)
+                if 'valid_data' in aman.preprocess:
+                    aman.preprocess.move('valid_data', None)
                 aman.preprocess.merge(proc_aman)
 
                 return error, [obs_id, dets], outputs_proc, aman
@@ -1029,7 +1029,7 @@ def preproc_or_load_group(obs_id, configs_init, dets, configs_proc=None,
             try:
                 outputs_proc = save_group(obs_id, configs_proc, dets, context_proc, subdir='temp_proc')
                 init_fields = aman.preprocess._fields.copy()
-                init_fields.pop('valid', None)
+                init_fields.pop('valid_data', None)
                 logger.info(f"Generating new dependent preproc db entry for {obs_id} {dets}")
                 # pipeline for processing config
                 pipe_proc = Pipeline(configs_proc["process_pipe"], plot_dir=configs_proc["plot_dir"], logger=logger)
@@ -1062,8 +1062,8 @@ def preproc_or_load_group(obs_id, configs_init, dets, configs_proc=None,
             logger.info(f"Saving data to {outputs_proc['temp_file']}:{outputs_proc['db_data']['dataset']}")
             proc_aman.save(outputs_proc['temp_file'], outputs_proc['db_data']['dataset'], overwrite)
 
-            if 'valid' in aman.preprocess:
-                aman.preprocess.move('valid', None)
+            if 'valid_data' in aman.preprocess:
+                aman.preprocess.move('valid_data', None)
             aman.preprocess.merge(proc_aman)
 
             return error, outputs_init, outputs_proc, aman

--- a/sotodlib/site_pipeline/multilayer_preprocess_tod.py
+++ b/sotodlib/site_pipeline/multilayer_preprocess_tod.py
@@ -148,7 +148,7 @@ def multilayer_preprocess_tod(obs_id,
                 outputs_init.append(outputs_grp_init)
 
             init_fields = aman.preprocess._fields.copy()
-            init_fields.pop('valid', None)
+            init_fields.pop('valid_data', None)
 
             outputs_grp_proc = pp_util.save_group(obs_id, configs_proc, dets,
                                       context_proc, subdir='temp_proc')

--- a/sotodlib/site_pipeline/multilayer_preprocess_tod.py
+++ b/sotodlib/site_pipeline/multilayer_preprocess_tod.py
@@ -148,6 +148,7 @@ def multilayer_preprocess_tod(obs_id,
                 outputs_init.append(outputs_grp_init)
 
             init_fields = aman.preprocess._fields.copy()
+            init_fields.pop('valid', None)
 
             outputs_grp_proc = pp_util.save_group(obs_id, configs_proc, dets,
                                       context_proc, subdir='temp_proc')

--- a/sotodlib/site_pipeline/preprocess_tod.py
+++ b/sotodlib/site_pipeline/preprocess_tod.py
@@ -228,9 +228,10 @@ def load_preprocess_tod_sim(obs_id, sim_map,
     configs, context = pp_util.get_preprocess_context(configs, context)
     if dets is not None:
         meta.restrict("dets", dets)
-    meta = pp_util.load_preprocess_det_select(
-        obs_id, configs=configs, context=context, meta=meta, logger=logger
+    det_vals = pp_util.load_preprocess_det_select(
+        obs_id, configs=configs, context=context, logger=logger
     )
+    meta.restrict("dets", [d for d in meta.dets.vals if d in det_vals])
 
     if meta.dets.count == 0:
         logger.info(f"No detectors left after cuts in obs {obs_id}")


### PR DESCRIPTION
Adds a `dets` x `samps` `valid` `RangesMatrix` at the end of the preprocess pipeline that keeps track of the final number of valid detectors.  Some changes were made to the `load_and_preprocess` functions to accommodate and use this when available.  Tested running through first and second layers, loading only first layer and both first and second.  Loaded existing db from before this change to check for backwards compatibility.  Confirmed same det vals appear in all cases.