### PR TITLE
Fix angle wrapping in get_footprint

### DIFF
--- a/sotodlib/coords/helpers.py
+++ b/sotodlib/coords/helpers.py
@@ -369,7 +369,7 @@ def get_footprint(tod, wcs_kernel, dets=None, timestamps=None, boresight=None,
     # of non-oblique cylindrical projections, we can modify crval
     # and crpix to construct a compatible pixelization centered on
     # the patch center.
-    recenter = wcsutils.is_separable(wcs_kernel) and True
+    recenter = wcsutils.is_separable(wcs_kernel)
     if recenter:
         # First part of recentering:
         # Unwind each detector in ra to avoid angle jumps, letting
@@ -395,6 +395,14 @@ def get_footprint(tod, wcs_kernel, dets=None, timestamps=None, boresight=None,
     w = wcs_kernel.deepcopy()
     # Adjust crpix so p1 → 1.
     w.wcs.crpix -= p1-1
+    # If we cover the whole width of the sky, even after unwrapping,
+    # then this might end up being 1 pixel too wide, giving a sky
+    # slightly > 360° which can cause some minor problems.
+    # Can't remove the +1 though, as that would sometimes chop off
+    # a pixel from the exposed area. Either just ignore, since
+    # this is a hypothetical case very unlikely to actually happen,
+    # or add a special case. NB! This case *will* trigger regularly
+    # due to wrapping if recentering is turned off.
     shape = (p2-p1+1)[::-1]
 
     if recenter:

--- a/sotodlib/coords/helpers.py
+++ b/sotodlib/coords/helpers.py
@@ -356,6 +356,13 @@ def get_footprint(tod, wcs_kernel, dets=None, timestamps=None, boresight=None,
         asm.Q = rot * asm.Q
     proj.get_planar(asm, output=planar)
 
+    # Unwind each detector in ra to avoid angle jumps
+    planar[:,:,0] = utils.unwind(planar[:,:,0])
+    # Harmonize them. This assumes that the detectors won't
+    # be more than 180° away from each other at any given time
+    offs = (planar[:,0,0]-planar[0,0,0]+np.pi)//(2*np.pi)*(2*np.pi)
+    planar[:,:,0] -= offs[:,None]
+
     # Get the pixel extrema in the form [{xmin,ymin},{xmax,ymax}]
     delts  = wcs_kernel.wcs.cdelt * DEG
     ranges = utils.minmax(planar[:,:,:2]/delts,(0,1))


### PR DESCRIPTION
Avoids huge maps when patch straddles geometry limits, and the geometry is being automatically built.