### PR TITLE
Update preprocessing Fourier filter docstring

### DIFF
--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -1663,6 +1663,18 @@ class FourierFilter(_Preprocess):
               timeconst: "det_cal.tau_eff"
               invert: True
 
+    Example for passing in a different signal name and wrapping into a new
+    field::
+
+        - name: "fourier_filter"
+              wrap_name: "lpf_demodQ"
+              signal_name: "demodQ"
+              process:
+                filt_function: "sine2"
+                filter_params:
+                  cutoff: 1
+                  trans_width: 0.1
+
     Example config file entry for two filters::
 
         - name: "fourier_filter"

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -1657,8 +1657,6 @@ class FourierFilter(_Preprocess):
     Example config file entry for one filter::
 
         - name: "fourier_filter"
-          wrap_name: "lpf_sig"
-          signal_name: "signal"
           process:
             filt_function: "timeconst_filter"
             filter_params:
@@ -1667,9 +1665,7 @@ class FourierFilter(_Preprocess):
 
     Example config file entry for two filters::
 
-        - name: "fourier_filter_chain"
-          wrap_name: "lpf_sig"
-          signal_name: "signal"
+        - name: "fourier_filter"
           process:
             filters:
               - name: "iir_filter"
@@ -1682,9 +1678,7 @@ class FourierFilter(_Preprocess):
 
     Or with params from a noise fit::
 
-        - name: "fourier_filter_chain"
-          wrap_name: "lpf_sig"
-          signal_name: "signal"
+        - name: "fourier_filter"
           process:
             noise_fit_array: "noiseQ_fit"
             filters:


### PR DESCRIPTION
Docstring for the Fourier filter in preprocessing had some typos and didn't apply to the signal which caused some confusion when I was using it in the site-pipeline-configs preprocessing configurations.