### PR TITLE
Catch empty string in source coverage

### DIFF
--- a/sotodlib/qa/quality_reports/report_data.py
+++ b/sotodlib/qa/quality_reports/report_data.py
@@ -529,12 +529,8 @@ def get_source_footprints(d: ReportData) -> List[Footprint]:
     
     for obs in source_obs_list:
         entry = db.inspect({'obs:obs_id': obs})
-        # coverage = np.array([hitpair.split(':') for hitpair in entry[0]['coverage'].split(',')])
-        # for source in d.cfg.cal_targets:
-        #     if source in coverage[:, 0]:
-        #         fps.append(Footprint(obs_id=obs,
-        #                              target=source,
-        #                              wafers=coverage[coverage[:, 0] == source, 1]))
+        if entry[0]['coverage'] == '':
+            continue
         for pair in entry[0]['coverage'].split(','):
             source, wafer = pair.split(':')
             if source in d.cfg.cal_targets:


### PR DESCRIPTION
- Added catch for empty strings in `coverage` field in sources causing `generate_report` to crash.