### PR TITLE
Update record_qa for preprocess_lite

### DIFF
--- a/sotodlib/preprocess/pcore.py
+++ b/sotodlib/preprocess/pcore.py
@@ -608,9 +608,9 @@ class _FracFlaggedMixIn(object):
         vals = []
         # record one metric per wafer slot, per bandpass
         for bp in np.unique(bandpasses):
-            for ws in np.unique(bandpasses):
+            for ws in np.unique(meta.det_info.wafer_slot):
                 subset = np.where(
-                    (meta.det_info.wafer_slot == ws) & (meta.det_cal.bandpass == bp)
+                    (meta.det_info.wafer_slot == ws) & (bandpasses == bp)
                 )[0]
 
                 # Compute the number of samples that were flagged

--- a/sotodlib/preprocess/pcore.py
+++ b/sotodlib/preprocess/pcore.py
@@ -553,7 +553,7 @@ class _FracFlaggedMixIn(object):
         proc_aman,
         flags_key=None,
         percentiles=[0, 50, 75, 90, 95, 100],
-        tags=[],
+        tags={},
     ):
         """ Generate a QA metric from the output of this process.
 
@@ -569,9 +569,11 @@ class _FracFlaggedMixIn(object):
             process name.
         percentiles : list
             Percentiles to compute across detectors
-        tags : list
-            Keys into `metadata.det_info` to record as tags with the Influx line.
-            Added to the default list ["wafer_slot", "tel_tube", "wafer.bandpass"].
+        tags : dict
+            The values are keys into `metadata.det_info` to record as tags with
+            the Influx line. The keys are addded to the default list
+            ["wafer_slot", "tel_tube", "bandpass"] with "bandpass" being taken
+            from "wafer.bandpass" or "det_cal.bandpass" if the former isn't found.
 
         Returns
         -------
@@ -593,16 +595,19 @@ class _FracFlaggedMixIn(object):
 
         # add specified tags
         from ..qa.metrics import _get_tag, _has_tag
-        tag_keys = ["wafer_slot", "tel_tube"]
+        tag_keys = {
+            "wafer_slot": "wafer_slot",
+            "tel_tube": "tel_tube",
+        }
 
         if _has_tag(meta.det_info, 'wafer.bandpass'):
             bandpasses = meta.det_info.wafer.bandpass
-            tag_keys += ["wafer.bandpass"]
+            tag_keys["bandpass"] = "wafer.bandpass"
         else:
             bandpasses = meta.det_info.det_cal.bandpass
-            tag_keys += ["det_cal.bandpass"]
+            tag_keys["bandpass"] = "det_cal.bandpass"
 
-        tag_keys += [t for t in tags if t not in tag_keys]
+        tag_keys.update(tags)
 
         tags = []
         vals = []
@@ -631,7 +636,7 @@ class _FracFlaggedMixIn(object):
 
                     # get the tags for this wafer (all detectors in this subset share these)
                     tags_base = {
-                        k: _get_tag(meta.det_info, k, subset[0]) for k in tag_keys if _has_tag(meta.det_info, k)
+                        k: _get_tag(meta.det_info, i, subset[0]) for k, i in tag_keys.items() if _has_tag(meta.det_info, i)
                     }
                     tags_base["telescope"] = meta.obs_info.telescope
 

--- a/sotodlib/preprocess/pcore.py
+++ b/sotodlib/preprocess/pcore.py
@@ -595,19 +595,14 @@ class _FracFlaggedMixIn(object):
         tag_keys = ["wafer_slot", "tel_tube", "wafer.bandpass"]
         tag_keys += [t for t in tags if t not in tag_keys]
 
-        if "wafer" in meta.det_info:
-            bandpasses = meta.det_info.wafer.bandpass
-        else:
-            bandpasses = meta.det_info.det_cal.bandpass
-
         tags = []
         vals = []
         from ..qa.metrics import _get_tag, _has_tag
         # record one metric per wafer slot, per bandpass
-        for bp in np.unique(bandpasses):
-            for ws in np.unique(meta.det_info.wafer_slot):
+        for bp in np.unique(meta.det_cal.bandpass):
+            for ws in np.unique(meta.det_cal.bandpass):
                 subset = np.where(
-                    (meta.det_info.wafer_slot == ws) & (bandpasses == bp)
+                    (meta.det_info.wafer_slot == ws) & (meta.det_cal.bandpass == bp)
                 )[0]
 
                 # Compute the number of samples that were flagged

--- a/sotodlib/preprocess/pcore.py
+++ b/sotodlib/preprocess/pcore.py
@@ -595,14 +595,19 @@ class _FracFlaggedMixIn(object):
         tag_keys = ["wafer_slot", "tel_tube", "wafer.bandpass"]
         tag_keys += [t for t in tags if t not in tag_keys]
 
+        if "wafer" in meta.det_info:
+            bandpasses = meta.det_info.wafer.bandpass
+        else:
+            bandpasses = meta.det_info.det_cal.bandpass
+
         tags = []
         vals = []
         from ..qa.metrics import _get_tag, _has_tag
         # record one metric per wafer slot, per bandpass
-        for bp in np.unique(meta.det_info.wafer.bandpass):
+        for bp in np.unique(bandpasses):
             for ws in np.unique(meta.det_info.wafer_slot):
                 subset = np.where(
-                    (meta.det_info.wafer_slot == ws) & (meta.det_info.wafer.bandpass == bp)
+                    (meta.det_info.wafer_slot == ws) & (bandpasses == bp)
                 )[0]
 
                 # Compute the number of samples that were flagged

--- a/sotodlib/preprocess/pcore.py
+++ b/sotodlib/preprocess/pcore.py
@@ -592,15 +592,23 @@ class _FracFlaggedMixIn(object):
                 raise ValueError(f"Could not parse flags_key {flags_key}")
 
         # add specified tags
-        tag_keys = ["wafer_slot", "tel_tube", "wafer.bandpass"]
+        from ..qa.metrics import _get_tag, _has_tag
+        tag_keys = ["wafer_slot", "tel_tube"]
+
+        if _has_tag(meta.det_info, 'wafer.bandpass'):
+            bandpasses = meta.det_info.wafer.bandpass
+            tag_keys += ["wafer.bandpass"]
+        else:
+            bandpasses = meta.det_info.det_cal.bandpass
+            tag_keys += ["det_cal.bandpass"]
+
         tag_keys += [t for t in tags if t not in tag_keys]
 
         tags = []
         vals = []
-        from ..qa.metrics import _get_tag, _has_tag
         # record one metric per wafer slot, per bandpass
-        for bp in np.unique(meta.det_cal.bandpass):
-            for ws in np.unique(meta.det_cal.bandpass):
+        for bp in np.unique(bandpasses):
+            for ws in np.unique(bandpasses):
                 subset = np.where(
                     (meta.det_info.wafer_slot == ws) & (meta.det_cal.bandpass == bp)
                 )[0]

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -838,18 +838,12 @@ class EstimateHWPSS(_Preprocess):
         tag_keys = ["wafer_slot", "tel_tube", "wafer.bandpass"]
         tags = []
         vals = []
-
-        if "wafer" in meta.det_info:
-            bandpasses = meta.det_info.wafer.bandpass
-        else:
-            bandpasses = meta.det_info.det_cal.bandpass
-
         from ..qa.metrics import _get_tag, _has_tag
         import re
-        for bp in np.unique(bandpasses):
+        for bp in np.unique(meta.det_cal.bandpass):
             for ws in np.unique(meta.det_info.wafer_slot):
                 subset = np.where(
-                    (meta.det_info.wafer_slot == ws) & (bandpasses == bp)
+                    (meta.det_info.wafer_slot == ws) & (meta.det_cal.bandpass == bp)
                 )[0]
 
                 if len(subset) > 0:

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -836,14 +836,17 @@ class EstimateHWPSS(_Preprocess):
         # record one metric per wafer_slot per bandpass
         # add specified tags
         from ..qa.metrics import _get_tag, _has_tag
-        tag_keys = ["wafer_slot", "tel_tube"]
+        tag_keys = {
+            "wafer_slot": "wafer_slot",
+            "tel_tube": "tel_tube",
+        }
 
         if _has_tag(meta.det_info, 'wafer.bandpass'):
             bandpasses = meta.det_info.wafer.bandpass
-            tag_keys += ["wafer.bandpass"]
+            tag_keys["bandpass"] = "wafer.bandpass"
         else:
             bandpasses = meta.det_info.det_cal.bandpass
-            tag_keys += ["det_cal.bandpass"]
+            tag_keys["bandpass"] = "det_cal.bandpass"
 
         tags = []
         vals = []
@@ -877,7 +880,7 @@ class EstimateHWPSS(_Preprocess):
                     mean = coeff_amp[nonzero].mean(axis=0)
 
                     tags_base = {
-                        k: _get_tag(meta.det_info, k, subset[0]) for k in tag_keys if _has_tag(meta.det_info, k)
+                        k: _get_tag(meta.det_info, i, subset[0]) for k, i in tag_keys.items() if _has_tag(meta.det_info, i)
                     }
                     tags_base["telescope"] = meta.obs_info.telescope
 

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -838,12 +838,18 @@ class EstimateHWPSS(_Preprocess):
         tag_keys = ["wafer_slot", "tel_tube", "wafer.bandpass"]
         tags = []
         vals = []
+
+        if "wafer" in meta.det_info:
+            bandpasses = meta.det_info.wafer.bandpass
+        else:
+            bandpasses = meta.det_info.det_cal.bandpass
+
         from ..qa.metrics import _get_tag, _has_tag
         import re
-        for bp in np.unique(meta.det_info.wafer.bandpass):
+        for bp in np.unique(bandpasses):
             for ws in np.unique(meta.det_info.wafer_slot):
                 subset = np.where(
-                    (meta.det_info.wafer_slot == ws) & (meta.det_info.wafer.bandpass == bp)
+                    (meta.det_info.wafer_slot == ws) & (bandpasses == bp)
                 )[0]
 
                 if len(subset) > 0:

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -834,16 +834,24 @@ class EstimateHWPSS(_Preprocess):
             `site_pipeline.monitor.Monitor.record`
         """
         # record one metric per wafer_slot per bandpass
-        # extract these tags for the metric
-        tag_keys = ["wafer_slot", "tel_tube", "wafer.bandpass"]
+        # add specified tags
+        from ..qa.metrics import _get_tag, _has_tag
+        tag_keys = ["wafer_slot", "tel_tube"]
+
+        if _has_tag(meta.det_info, 'wafer.bandpass'):
+            bandpasses = meta.det_info.wafer.bandpass
+            tag_keys += ["wafer.bandpass"]
+        else:
+            bandpasses = meta.det_info.det_cal.bandpass
+            tag_keys += ["det_cal.bandpass"]
+
         tags = []
         vals = []
-        from ..qa.metrics import _get_tag, _has_tag
         import re
-        for bp in np.unique(meta.det_cal.bandpass):
+        for bp in np.unique(bandpasses):
             for ws in np.unique(meta.det_info.wafer_slot):
                 subset = np.where(
-                    (meta.det_info.wafer_slot == ws) & (meta.det_cal.bandpass == bp)
+                    (meta.det_info.wafer_slot == ws) & (bandpasses == bp)
                 )[0]
 
                 if len(subset) > 0:

--- a/sotodlib/qa/metrics.py
+++ b/sotodlib/qa/metrics.py
@@ -199,17 +199,25 @@ class PreprocessValidDets(PreprocessQA):
     def _process(self, meta):
 
         # add specified tags
-        tag_keys = ["wafer_slot", "tel_tube", "wafer.bandpass"]
+        tag_keys = ["wafer_slot", "tel_tube"]
+
+        if _has_tag(meta.det_info, 'wafer.bandpass'):
+            bandpasses = meta.det_info.wafer.bandpass
+            tag_keys += ["wafer.bandpass"]
+        else:
+            bandpasses = meta.det_cal.bandpass
+            tag_keys += ["det_cal.bandpass"]
+
         tag_keys += [t for t in self._tags if t not in tag_keys]
 
         # record one metric per wafer slot, per bandpass
         # extract these tags for the metric
         tags = []
         vals = []
-        for bp in np.unique(meta.det_cal.bandpass):
+        for bp in np.unique(bandpasses):
             for ws in np.unique(meta.det_info.wafer_slot):
                 subset = np.where(
-                    (meta.det_info.wafer_slot == ws) & (meta.det_cal.bandpass == bp)
+                    (meta.det_info.wafer_slot == ws) & (bandpasses == bp)
                 )[0]
 
                 if len(subset) > 0:
@@ -278,14 +286,22 @@ class PreprocessArrayNET(PreprocessQA):
 
         # record one metric per wafer_slot per bandpass
         # extract these tags for the metric
-        tag_keys = ["wafer_slot", "tel_tube", "wafer.bandpass"]
+        tag_keys = ["wafer_slot", "tel_tube"]
+
+        if _has_tag(meta.det_info, 'wafer.bandpass'):
+            bandpasses = meta.det_info.wafer.bandpass
+            tag_keys += ["wafer.bandpass"]
+        else:
+            bandpasses = meta.det_info.det_cal.bandpass
+            tag_keys += ["det_cal.bandpass"]
+
         tag_keys += [t for t in self._tags if t not in tag_keys]
         tags = []
         vals = []
-        for bp in np.unique(meta.det_cal.bandpass):
+        for bp in np.unique(bandpasses):
             for ws in np.unique(meta.det_info.wafer_slot):
                 subset = np.where(
-                    (meta.det_info.wafer_slot == ws) & (meta.det_cal.bandpass == bp)
+                    (meta.det_info.wafer_slot == ws) & (bandpasses == bp)
                 )[0]
 
                 white_noise = meta.preprocess[self._noise_aman].white_noise[subset] * self._unit_factor
@@ -346,14 +362,22 @@ class PreprocessDetNET(PreprocessQA):
 
         # record one metric per wafer_slot per bandpass
         # extract these tags for the metric
-        tag_keys = ["wafer_slot", "tel_tube", "wafer.bandpass"]
+        tag_keys = ["wafer_slot", "tel_tube"]
+
+        if _has_tag(meta.det_info, 'wafer.bandpass'):
+            bandpasses = meta.det_info.wafer.bandpass
+            tag_keys += ["wafer.bandpass"]
+        else:
+            bandpasses = meta.det_info.det_cal.bandpass
+            tag_keys += ["det_cal.bandpass"]
+
         tag_keys += [t for t in self._tags if t not in tag_keys]
         tags = []
         vals = []
-        for bp in np.unique(meta.det_cal.bandpass):
+        for bp in np.unique(bandpasses):
             for ws in np.unique(meta.det_info.wafer_slot):
                 subset = np.where(
-                    (meta.det_info.wafer_slot == ws) & (meta.det_cal.bandpass == bp)
+                    (meta.det_info.wafer_slot == ws) & (bandpasses == bp)
                 )[0]
 
                 white_noise = meta.preprocess[self._noise_aman].white_noise[subset] * self._unit_factor

--- a/sotodlib/qa/metrics.py
+++ b/sotodlib/qa/metrics.py
@@ -206,16 +206,10 @@ class PreprocessValidDets(PreprocessQA):
         # extract these tags for the metric
         tags = []
         vals = []
-
-        if "wafer" in meta.det_info:
-            bandpasses = meta.det_info.wafer.bandpass
-        else:
-            bandpasses = meta.det_info.det_cal.bandpass
-
-        for bp in np.unique(bandpasses):
+        for bp in np.unique(meta.det_cal.bandpass):
             for ws in np.unique(meta.det_info.wafer_slot):
                 subset = np.where(
-                    (meta.det_info.wafer_slot == ws) & (bandpasses == bp)
+                    (meta.det_info.wafer_slot == ws) & (meta.det_cal.bandpass == bp)
                 )[0]
 
                 if len(subset) > 0:
@@ -288,16 +282,10 @@ class PreprocessArrayNET(PreprocessQA):
         tag_keys += [t for t in self._tags if t not in tag_keys]
         tags = []
         vals = []
-
-        if "wafer" in meta.det_info:
-            bandpasses = meta.det_info.wafer.bandpass
-        else:
-            bandpasses = meta.det_info.det_cal.bandpass
-
-        for bp in np.unique(bandpasses):
+        for bp in np.unique(meta.det_cal.bandpass):
             for ws in np.unique(meta.det_info.wafer_slot):
                 subset = np.where(
-                    (meta.det_info.wafer_slot == ws) & (bandpasses == bp)
+                    (meta.det_info.wafer_slot == ws) & (meta.det_cal.bandpass == bp)
                 )[0]
 
                 white_noise = meta.preprocess[self._noise_aman].white_noise[subset] * self._unit_factor
@@ -314,7 +302,7 @@ class PreprocessArrayNET(PreprocessQA):
 
         obs_time = [meta.obs_info.timestamp] * len(tags)
         return {
-            "field": f"{self._influx_field}{'_' + self._field_name.replace("_", "", 1) if self._field_name else ''}",
+            "field": f"{self._influx_field}{'_' + self._field_name if self._field_name else ''}",
             "values": vals,
             "timestamps": obs_time,
             "tags": tags,
@@ -362,16 +350,10 @@ class PreprocessDetNET(PreprocessQA):
         tag_keys += [t for t in self._tags if t not in tag_keys]
         tags = []
         vals = []
-
-        if "wafer" in meta.det_info:
-            bandpasses = meta.det_info.wafer.bandpass
-        else:
-            bandpasses = meta.det_info.det_cal.bandpass
-
-        for bp in np.unique(bandpasses):
+        for bp in np.unique(meta.det_cal.bandpass):
             for ws in np.unique(meta.det_info.wafer_slot):
                 subset = np.where(
-                    (meta.det_info.wafer_slot == ws) & (bandpasses == bp)
+                    (meta.det_info.wafer_slot == ws) & (meta.det_cal.bandpass == bp)
                 )[0]
 
                 white_noise = meta.preprocess[self._noise_aman].white_noise[subset] * self._unit_factor
@@ -388,7 +370,7 @@ class PreprocessDetNET(PreprocessQA):
 
         obs_time = [meta.obs_info.timestamp] * len(tags)
         return {
-            "field": f"{self._influx_field}{'_' + self._field_name.replace("_", "", 1) else ''}",
+            "field": f"{self._influx_field}{'_' + self._field_name if self._field_name else ''}",
             "values": vals,
             "timestamps": obs_time,
             "tags": tags,

--- a/sotodlib/qa/metrics.py
+++ b/sotodlib/qa/metrics.py
@@ -206,10 +206,16 @@ class PreprocessValidDets(PreprocessQA):
         # extract these tags for the metric
         tags = []
         vals = []
-        for bp in np.unique(meta.det_info.wafer.bandpass):
+
+        if "wafer" in meta.det_info:
+            bandpasses = meta.det_info.wafer.bandpass
+        else:
+            bandpasses = meta.det_info.det_cal.bandpass
+
+        for bp in np.unique(bandpasses):
             for ws in np.unique(meta.det_info.wafer_slot):
                 subset = np.where(
-                    (meta.det_info.wafer_slot == ws) & (meta.det_info.wafer.bandpass == bp)
+                    (meta.det_info.wafer_slot == ws) & (bandpasses == bp)
                 )[0]
 
                 if len(subset) > 0:
@@ -271,7 +277,8 @@ class PreprocessArrayNET(PreprocessQA):
         # extract parameters
         self._tags = process_args.get("tags", [])
         self._noise_aman = process_args.get("noise_aman", "noise")
-        self._unit_factor = process_args.get("unit_factor", 1e6)
+        self._field_name = process_args.get("field_name", "")
+        self._unit_factor = process_args.get("unit_factor", 1)
 
     def _process(self, meta):
 
@@ -281,10 +288,16 @@ class PreprocessArrayNET(PreprocessQA):
         tag_keys += [t for t in self._tags if t not in tag_keys]
         tags = []
         vals = []
-        for bp in np.unique(meta.det_info.wafer.bandpass):
+
+        if "wafer" in meta.det_info:
+            bandpasses = meta.det_info.wafer.bandpass
+        else:
+            bandpasses = meta.det_info.det_cal.bandpass
+
+        for bp in np.unique(bandpasses):
             for ws in np.unique(meta.det_info.wafer_slot):
                 subset = np.where(
-                    (meta.det_info.wafer_slot == ws) & (meta.det_info.wafer.bandpass == bp)
+                    (meta.det_info.wafer_slot == ws) & (bandpasses == bp)
                 )[0]
 
                 white_noise = meta.preprocess[self._noise_aman].white_noise[subset] * self._unit_factor
@@ -301,7 +314,7 @@ class PreprocessArrayNET(PreprocessQA):
 
         obs_time = [meta.obs_info.timestamp] * len(tags)
         return {
-            "field": self._influx_field,
+            "field": f"{self._influx_field}{'_' + self._field_name.replace("_", "", 1) if self._field_name else ''}",
             "values": vals,
             "timestamps": obs_time,
             "tags": tags,
@@ -338,7 +351,8 @@ class PreprocessDetNET(PreprocessQA):
         # extract parameters
         self._tags = process_args.get("tags", [])
         self._noise_aman = process_args.get("noise_aman", "noise")
-        self._unit_factor = process_args.get("unit_factor", 1e6)
+        self._field_name = process_args.get("field_name", "")
+        self._unit_factor = process_args.get("unit_factor", 1)
 
     def _process(self, meta):
 
@@ -348,10 +362,16 @@ class PreprocessDetNET(PreprocessQA):
         tag_keys += [t for t in self._tags if t not in tag_keys]
         tags = []
         vals = []
-        for bp in np.unique(meta.det_info.wafer.bandpass):
+
+        if "wafer" in meta.det_info:
+            bandpasses = meta.det_info.wafer.bandpass
+        else:
+            bandpasses = meta.det_info.det_cal.bandpass
+
+        for bp in np.unique(bandpasses):
             for ws in np.unique(meta.det_info.wafer_slot):
                 subset = np.where(
-                    (meta.det_info.wafer_slot == ws) & (meta.det_info.wafer.bandpass == bp)
+                    (meta.det_info.wafer_slot == ws) & (bandpasses == bp)
                 )[0]
 
                 white_noise = meta.preprocess[self._noise_aman].white_noise[subset] * self._unit_factor
@@ -368,7 +388,7 @@ class PreprocessDetNET(PreprocessQA):
 
         obs_time = [meta.obs_info.timestamp] * len(tags)
         return {
-            "field": self._influx_field,
+            "field": f"{self._influx_field}{'_' + self._field_name.replace("_", "", 1) else ''}",
             "values": vals,
             "timestamps": obs_time,
             "tags": tags,

--- a/sotodlib/qa/metrics.py
+++ b/sotodlib/qa/metrics.py
@@ -169,9 +169,11 @@ class PreprocessValidDets(PreprocessQA):
     The config entry supports a `process_args` block where the following options can be
     specified:
 
-    tags : list
-        Keys into `metadata.det_info` to record as tags with the Influx line.
-        Added to the default list ["wafer_slot", "tel_tube", "wafer.bandpass"].
+    tags : dict
+        The values are keys into `metadata.det_info` to record as tags with
+        the Influx line. The keys are addded to the default list
+        ["wafer_slot", "tel_tube", "bandpass"] with "bandpass" being taken
+        from "wafer.bandpass" or "det_cal.bandpass" if the former isn't found.
     thresh : float
         The threshold for the fraction of valid samples above which a detector is
         deemed good (default 0.75)
@@ -192,23 +194,26 @@ class PreprocessValidDets(PreprocessQA):
         # bypass the PreprocessQA __init__
         super(PreprocessQA, self).__init__(*args, **kwargs)
         # extract parameters
-        self._tags = process_args.get("tags", [])
+        self._tags = process_args.get("tags", {})
         self._thresh = process_args.get("thresh", 0.75)
         self._key = process_args.get("process_name", "glitches")
 
     def _process(self, meta):
 
         # add specified tags
-        tag_keys = ["wafer_slot", "tel_tube"]
+        tag_keys = {
+            "wafer_slot": "wafer_slot",
+            "tel_tube": "tel_tube",
+        }
 
         if _has_tag(meta.det_info, 'wafer.bandpass'):
             bandpasses = meta.det_info.wafer.bandpass
-            tag_keys += ["wafer.bandpass"]
+            tag_keys["bandpass"] = "wafer.bandpass"
         else:
-            bandpasses = meta.det_cal.bandpass
-            tag_keys += ["det_cal.bandpass"]
+            bandpasses = meta.det_info.det_cal.bandpass
+            tag_keys["bandpass"] = "det_cal.bandpass"
 
-        tag_keys += [t for t in self._tags if t not in tag_keys]
+        tag_keys.update(self._tags)
 
         # record one metric per wafer slot, per bandpass
         # extract these tags for the metric
@@ -232,7 +237,7 @@ class PreprocessValidDets(PreprocessQA):
 
                     # get the tags for this wafer (all detectors in this subset share these)
                     tags_i = {
-                        k: _get_tag(meta.det_info, k, subset[0]) for k in tag_keys if _has_tag(meta.det_info, k)
+                        k: _get_tag(meta.det_info, i, subset[0]) for k, i in tag_keys.items() if _has_tag(meta.det_info, i)
                     }
                     tags_i["telescope"] = meta.obs_info.telescope
 
@@ -256,9 +261,11 @@ class PreprocessArrayNET(PreprocessQA):
     The config entry supports a `process_args` block where the following
     options can be specified:
 
-    tags : list
-        Keys into `metadata.det_info` to record as tags with the Influx line.
-        Added to the default list ["wafer_slot", "tel_tube", "wafer.bandpass"].
+    tags : dict
+        The values are keys into `metadata.det_info` to record as tags with
+        the Influx line. The keys are addded to the default list
+        ["wafer_slot", "tel_tube", "bandpass"] with "bandpass" being taken
+        from "wafer.bandpass" or "det_cal.bandpass" if the former isn't found.
     noise_aman : str
         The name of the axis manager that holds the white noise array.
         (default 'noise')
@@ -277,7 +284,7 @@ class PreprocessArrayNET(PreprocessQA):
         # bypass the PreprocessQA __init__
         super(PreprocessQA, self).__init__(*args, **kwargs)
         # extract parameters
-        self._tags = process_args.get("tags", [])
+        self._tags = process_args.get("tags", {})
         self._noise_aman = process_args.get("noise_aman", "noise")
         self._field_name = process_args.get("field_name", "")
         self._unit_factor = process_args.get("unit_factor", 1)
@@ -286,16 +293,19 @@ class PreprocessArrayNET(PreprocessQA):
 
         # record one metric per wafer_slot per bandpass
         # extract these tags for the metric
-        tag_keys = ["wafer_slot", "tel_tube"]
+        tag_keys = {
+            "wafer_slot": "wafer_slot",
+            "tel_tube": "tel_tube",
+        }
 
         if _has_tag(meta.det_info, 'wafer.bandpass'):
             bandpasses = meta.det_info.wafer.bandpass
-            tag_keys += ["wafer.bandpass"]
+            tag_keys["bandpass"] = "wafer.bandpass"
         else:
             bandpasses = meta.det_info.det_cal.bandpass
-            tag_keys += ["det_cal.bandpass"]
+            tag_keys["bandpass"] = "det_cal.bandpass"
 
-        tag_keys += [t for t in self._tags if t not in tag_keys]
+        tag_keys.update(self._tags)
         tags = []
         vals = []
         for bp in np.unique(bandpasses):
@@ -311,7 +321,7 @@ class PreprocessArrayNET(PreprocessQA):
                     vals.append(np.sqrt(1.0 / np.nansum(1.0 / (white_noise[good_indices])**2)))
 
                     tags_base = {
-                        k: _get_tag(meta.det_info, k, subset[0]) for k in tag_keys if _has_tag(meta.det_info, k)
+                        k: _get_tag(meta.det_info, i, subset[0]) for k, i in tag_keys.items() if _has_tag(meta.det_info, i)
                     }
                     tags_base["telescope"] = meta.obs_info.telescope
                     tags.append(tags_base)
@@ -332,9 +342,11 @@ class PreprocessDetNET(PreprocessQA):
     The config entry supports a `process_args` block where the following
     options can be specified:
 
-    tags : list
-        Keys into `metadata.det_info` to record as tags with the Influx line.
-        Added to the default list ["wafer_slot", "tel_tube", "wafer.bandpass"].
+    tags : dict
+        The values are keys into `metadata.det_info` to record as tags with
+        the Influx line. The keys are addded to the default list
+        ["wafer_slot", "tel_tube", "bandpass"] with "bandpass" being taken
+        from "wafer.bandpass" or "det_cal.bandpass" if the former isn't found.
     noise_aman : str
         The name of the axis manager that holds the white noise array.
         (default 'noise')
@@ -353,7 +365,7 @@ class PreprocessDetNET(PreprocessQA):
         # bypass the PreprocessQA __init__
         super(PreprocessQA, self).__init__(*args, **kwargs)
         # extract parameters
-        self._tags = process_args.get("tags", [])
+        self._tags = process_args.get("tags", {})
         self._noise_aman = process_args.get("noise_aman", "noise")
         self._field_name = process_args.get("field_name", "")
         self._unit_factor = process_args.get("unit_factor", 1)
@@ -362,16 +374,19 @@ class PreprocessDetNET(PreprocessQA):
 
         # record one metric per wafer_slot per bandpass
         # extract these tags for the metric
-        tag_keys = ["wafer_slot", "tel_tube"]
+        tag_keys = {
+            "wafer_slot": "wafer_slot",
+            "tel_tube": "tel_tube",
+        }
 
         if _has_tag(meta.det_info, 'wafer.bandpass'):
             bandpasses = meta.det_info.wafer.bandpass
-            tag_keys += ["wafer.bandpass"]
+            tag_keys["bandpass"] = "wafer.bandpass"
         else:
             bandpasses = meta.det_info.det_cal.bandpass
-            tag_keys += ["det_cal.bandpass"]
+            tag_keys["bandpass"] = "det_cal.bandpass"
 
-        tag_keys += [t for t in self._tags if t not in tag_keys]
+        tag_keys.update(self._tags)
         tags = []
         vals = []
         for bp in np.unique(bandpasses):
@@ -387,7 +402,7 @@ class PreprocessDetNET(PreprocessQA):
                     vals.append(np.sqrt(1.0 / np.nansum(1.0 / (white_noise[good_indices])**2)) * np.sqrt(len(good_indices)))
 
                     tags_base = {
-                        k: _get_tag(meta.det_info, k, subset[0]) for k in tag_keys if _has_tag(meta.det_info, k)
+                        k: _get_tag(meta.det_info, i, subset[0]) for k, i in tag_keys.items() if _has_tag(meta.det_info, i)
                     }
                     tags_base["telescope"] = meta.obs_info.telescope
                     tags.append(tags_base)


### PR DESCRIPTION
Updates `record_qa` and related functions to be able to parse preprocess_lite databases which do not have `wafer_info` and instead use `det_cal` bandpasses.

Also adds the ability to add a field name suffix to the end of the noise metric names so we can get out T, Q, and U.  Changes default noise units factor to 1 since we are interested in pW noise values.