### PR TITLE
Allow ignoring preprocess archive when using TOAST LoadContext operator

### DIFF
--- a/sotodlib/toast/ops/load_context.py
+++ b/sotodlib/toast/ops/load_context.py
@@ -128,6 +128,11 @@ class LoadContext(Operator):
         help="Apply site-pipeline pre-processing with this configuration",
     )
 
+    ignore_preprocess_archive = Bool(
+        False,
+        help="If True alway compute preprocess on the fly, don't load from archive.",
+    )
+
     observations = List(list(), help="List of observation IDs to load")
 
     readout_ids = List(list(), help="Only load this list of readout_id values")
@@ -390,7 +395,7 @@ class LoadContext(Operator):
             # If we are using preprocessing, load the archive DB and cut any
             # observations or wafer slots that do not exist.
             preproc_lookup = None
-            if preproc_conf is not None:
+            if (preproc_conf is not None) and (not self.ignore_preprocess_archive):
                 preproc_lookup = dict()
                 preproc_db = preproc_conf["archive"]["index"]
                 con = sqlite3.connect(preproc_db)
@@ -1024,6 +1029,7 @@ class LoadContext(Operator):
             wafer_readers,
             wafer_dets,
             preconfig=pconf,
+            ignore_preprocess_archive=self.ignore_preprocess_archive,
             context=self.context,
             context_file=self.context_file,
         )


### PR DESCRIPTION
https://github.com/simonsobs/sotodlib/commit/27d0d7278e7fdcc82282b0b518bbeb9fba5d9e84 ignore 'archive' field defined in `preprocess_config`. So that it ignore the preprocess archive database and force compute preprocess steps on the fly. Based on [this](https://github.com/simonsobs/pwg-tutorials/blob/master/2025_F2F_Tutorials/02_02_TOD_preprocessing.ipynb) tutorial, section: _How to selectively apply processing to TODs (interactive preprocess)._

https://github.com/simonsobs/sotodlib/commit/7653673de46e94e01f19d67ebd160f82eb872ee7 fix a minor bug when checking `pointing_model` and `hwp_angle_model` in preprocess config file.