### PR TITLE
Add counter 1/f and common mode subtraction to preprocess

### DIFF
--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -454,6 +454,48 @@ class PSDCalc(_Preprocess):
             plot_psd(aman, signal=attrgetter(f"{self.wrap}.Pxx")(proc_aman),
                      xx=attrgetter(f"{self.wrap}.freqs")(proc_aman), filename=filename, **self.plot_cfgs)
 
+class PSDFit(_Preprocess):
+    """ Calculate the PSD of the data and add it to the Preprocessing AxisManager under the
+    "psd" field.
+
+    Note: noverlap = 0 amd full_output = True are recommended to get unbiased
+        median white noise estimation by Noise.
+
+    Example config block::
+
+      - "name : "psdfit"
+        "freqs: "psd.freqs" # optional
+        "Pxx: "psd.Pxx" # optional
+        "wrap": "psdfit" # optional
+        "calc":
+          "fknee_est": 1 # optional
+          "wn_est": 4E-5 # optional
+          "alpha_est": 3.4 # optional
+          "f_max": 100 # optional
+        "save": True
+
+    .. autofunction:: sotodlib.tod_ops.fft_ops.calc_psd
+    """
+    name = "psdfit"
+
+    def __init__(self, step_cfgs):
+        self.freqs = step_cfgs.get('freqs', 'psd.freqs')
+        self.Pxx = step_cfgs.get('Pxx', 'psd.Pxx')
+        self.wrap = step_cfgs.get('wrap', 'psdfit')
+
+        super().__init__(step_cfgs)
+
+    def calc_and_save(self, aman, proc_aman):
+        freqs = proc_aman[self.freqs]
+        Pxx = proc_aman[self.Pxx]
+        noise_fit_stats = tod_ops.fft_ops.fit_noise_model(aman, f=freqs, pxx=Pxx,
+                                                          **self.calc_cfgs)
+        self.save(proc_aman, noise_fit_stats)
+        return aman, proc_aman
+
+    def save(self, proc_aman, noise_fit_stats):
+        if not(self.save_cfgs is None):
+            proc_aman.wrap(self.wrap, noise_fit_stats)
 
 class GetStats(_Preprocess):
     """

--- a/sotodlib/tod_ops/fft_ops.py
+++ b/sotodlib/tod_ops/fft_ops.py
@@ -1145,17 +1145,24 @@ def build_hpf_params_dict(
     if noise_fit is not None:
 
         pars_mapping = {
-            "high_pass_butter4": {
-                "fc": "fknee",
-            },
             "counter_1_over_f": {
                 "fk": "fknee", 
                 "n": "alpha"
             },
+            "high_pass_butter4": {
+                "fc": "fknee",
+            },
             "high_pass_sine2": {
                 "cutoff": "fknee",
                 "width": None
-            }
+            },
+            "low_pass_butter4": {
+                "fc": "fknee",
+            },
+            "low_pass_sine2": {
+                "cutoff": "fknee",
+                "width": None
+            },
         }
 
         if filter_name not in pars_mapping.keys():

--- a/sotodlib/tod_ops/filters.py
+++ b/sotodlib/tod_ops/filters.py
@@ -310,6 +310,9 @@ def counter_1_over_f(freqs, tod, fk=None, n=None, noise_fit_stats=None):
         return 1/(1+(fk/freqs)**n)
 
     if fk is None and n is None and noise_fit_stats is not None:
+        if isinstance(noise_fit_stats, str):
+            _f = attrgetter(noise_fit_stats)
+            noise_fit_stats = _f(tod)
         fk = noise_fit_stats.fit.T[1]
         n = noise_fit_stats.fit.T[2]
 

--- a/sotodlib/tod_ops/filters.py
+++ b/sotodlib/tod_ops/filters.py
@@ -306,9 +306,15 @@ def counter_1_over_f(freqs, tod, fk, n):
     where w is the white noise level, fk is the knee frequency, and
     n is the 1/f index.
     """
+    if isinstance(fk, str):
+        fk = tod[fk]
+    if isinstance(n, str):
+        n = tod[n]
+
     if np.isscalar(fk) and np.isscalar(n):
         return 1/(1+(fk/freqs)**n)
-    elif len(fk) == tod.dets.count and len(n) == tod.dets.count:
+
+    if len(fk) == tod.dets.count and len(n) == tod.dets.count:
         return 1 / (1 + (fk[:, None]/freqs[None,:])**n[:, None])
     else:
         raise ValueError("The fk and n must be a float value or array-like with length of number of detectors")

--- a/sotodlib/tod_ops/filters.py
+++ b/sotodlib/tod_ops/filters.py
@@ -306,7 +306,12 @@ def counter_1_over_f(freqs, tod, fk, n):
     where w is the white noise level, fk is the knee frequency, and
     n is the 1/f index.
     """
-    return 1/(1+(fk/freqs)**n)
+    if np.isscalar(fk) and np.isscalar(n):
+        return 1/(1+(fk/freqs)**n)
+    elif len(fk) == tod.dets.count and len(n) == tod.dets.count:
+        return 1 / (1 + (fk[:, None]/freqs[None,:])**n[:, None])
+    else:
+        raise ValueError("The fk and n must be a float value or array-like with length of number of detectors")
 
 @fft_filter
 def identity_filter(freqs, tod, invert=False):

--- a/sotodlib/tod_ops/filters.py
+++ b/sotodlib/tod_ops/filters.py
@@ -298,7 +298,7 @@ fft_apply_filter = FilterApplyFunc.deco
 # Filtering Functions
 #################
 @fft_filter
-def counter_1_over_f(freqs, tod, fk, n):
+def counter_1_over_f(freqs, tod, fk=None, n=None, noise_fit_stats=None):
     """
     Counter 1/f filter for noise w/ PSD that follows:
     
@@ -306,13 +306,12 @@ def counter_1_over_f(freqs, tod, fk, n):
     where w is the white noise level, fk is the knee frequency, and
     n is the 1/f index.
     """
-    if isinstance(fk, str):
-        fk = tod[fk]
-    if isinstance(n, str):
-        n = tod[n]
-
     if np.isscalar(fk) and np.isscalar(n):
         return 1/(1+(fk/freqs)**n)
+
+    if fk is None and n is None and noise_fit_stats is not None:
+        fk = noise_fit_stats.fit.T[1]
+        n = noise_fit_stats.fit.T[2]
 
     if len(fk) == tod.dets.count and len(n) == tod.dets.count:
         return 1 / (1 + (fk[:, None]/freqs[None,:])**n[:, None])

--- a/sotodlib/tod_ops/pca.py
+++ b/sotodlib/tod_ops/pca.py
@@ -129,7 +129,8 @@ def get_pca(tod=None, cov=None, signal=None, wrap=None, mask=None):
 
     E, R = np.linalg.eigh(cov)
     E[np.isnan(E)] = 0.
-    E, R = E.real, R.real
+    if np.isrealobj(signal):
+        E, R = E.real, R.real
 
     idx = np.argsort(-E)
 


### PR DESCRIPTION
This PR modifies the scripts to enable fancy counter 1/f filter and common mode subtraction.

The changes for counter 1/f filter:
The filter function 'counter_1_over_f' is modified to accept the array-like input of parameters.
This enables to apply independent 1/f parameters to individual detectors.

The changes for common mode subtraction:
The PCAFilter is modified to have `signal` and `model_signal` independently.
This enables to estimate PCA model from the down sampled signal, and then subtract it from the signal.
For the fancy operations, I introduced `get_common_noise_params` to estimate knee frequency of the common noise.
The estimated knee frequency is applied to the down sample frequency of `model_signal` .
However, this deployment requires many changes in `fft_ops`.
(As common mode aman doesn't have 'dets' LabelAxis, aman.dets is changed to aman[LabelAxis].)
These changes can be discarded if they are too much.

The following lines are the example of the process pipeline after the demodulation.
I have confirmed the processes run with this config.

```
process_pipe:
    # correct boresight rotation to zero
    - name : "rotate_focal_plane"
      process:
        hwp: True

    # telescope coordinate
    - name : "rotate_qu"
      process:
        sign: 1 
        offset: 0 
        update_focal_plane: True

    # radial coordinate
    - name : "rotate_qu"
      process:
        sign: 1 
        offset: 0 
        radial: True
        update_focal_plane: True

    # calculate psd
    - name: "psd"
      skip_on_sim: False
      signal: "demodQ"
      wrap: "psdQ"
      calc:
        max_samples: 524288 #2**19
        merge: False
        nperseg: 65536 #2**16
        noverlap: 0
        full_output: True
      save: True

    # fit psd
    - name: "noise"
      skip_on_sim: False
      psd: "psdQ"
      fit: True
      calc:
        fwhite: [1, 2]
        f_max: 2
        merge_name: 'noise_fit_statsQ'
      save:
        wrap_name: "noise_fitQ"

    # apply counter 1/f
    - name: "fourier_filter"
      skip_on_sim: False
      signal_name: "demodQ"
      wrap_name: "demodQ"
      process:
        filt_function: "counter_1_over_f"
        filter_params:
          noise_fit_stats: "noise_fit_statsQ"
          
    # get common mode and its fknee
    - name: "get_common_mode"
      noise_fit: True
      f_max: 2
      wrap_name: "demodQ_commonmode"
      calc:
        signal: "demodQ"
        method: "median"
      save: True

    # get signal downsampled to fknee
    - name: "fourier_filter"
      signal_name: "demodQ"
      wrap_name: "lpf_demodQ"
      process:
        noise_fit_array: "demodQ_commonmode"
        filters:
          - name: "low_pass_butter4"

    # estimate and subtract common noise estimated from 
    # the down sampled signal
    - name: "pca_filter"
      signal: "demodQ"
      model_signal: "lpf_demodQ"
      process:
        n_modes: 3
```