### PR TITLE
SSOFootprint add handling for sources with dot in name

### DIFF
--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -2,6 +2,7 @@ import numpy as np
 from operator import attrgetter
 import copy
 import warnings
+import re
 
 from so3g.proj import Ranges, RangesMatrix
 
@@ -1415,8 +1416,7 @@ class SSOFootprint(_Preprocess):
 
             planet_aman.wrap('mean_distance', np.round(np.mean(np.rad2deg(np.sqrt(xi_p**2 + eta_p**2))), 1))
 
-            if "." in planet:
-                planet = planet.replace(".", "")
+            planet = re.sub('[^0-9a-zA-Z]+', '', planet)
             sso_aman.wrap(planet, planet_aman)
         self.save(proc_aman, sso_aman)
 

--- a/sotodlib/site_pipeline/preprocess_obs.py
+++ b/sotodlib/site_pipeline/preprocess_obs.py
@@ -5,6 +5,7 @@ import numpy as np
 import argparse
 import traceback
 from typing import Optional, List
+import re
 
 from sotodlib import core
 import sotodlib.site_pipeline.util as sp_util
@@ -57,8 +58,7 @@ def preprocess_obs(
             raise ValueError('Invalid style of source')
 
     for i, source in enumerate(source_names):
-        if "." in source:
-            source_names[i] = source_names[i].replace(".", "")
+        source_names[i] = re.sub('[^0-9a-zA-Z]+', '', source)
  
     if os.path.exists(configs['archive']['index']):
         logger.info(f"Mapping {configs['archive']['index']} for the "


### PR DESCRIPTION
Add handling for source names with dot `'.'` which would break both dict key referencing and file naming when saving plots. Issue found specifically for `'G025.36-00.14'` source causing obs to fail.