### PR TITLE
Set detector pointing default boresight field.

### DIFF
--- a/sotodlib/toast/workflows/pointing.py
+++ b/sotodlib/toast/workflows/pointing.py
@@ -25,10 +25,18 @@ def setup_pointing(operators):
     """
     # Detector quaternion pointing
     operators.append(
-        toast.ops.PointingDetectorSimple(name="det_pointing_azel", quats="quats_azel")
+        toast.ops.PointingDetectorSimple(
+            name="det_pointing_azel",
+            boresight=defaults.boresight_azel,
+            quats="quats_azel",
+        )
     )
     operators.append(
-        toast.ops.PointingDetectorSimple(name="det_pointing_radec", quats="quats_radec")
+        toast.ops.PointingDetectorSimple(
+            name="det_pointing_radec",
+            boresight=defaults.boresight_radec,
+            quats="quats_radec",
+        )
     )
     # Stokes weights
     operators.append(


### PR DESCRIPTION
This is also set in the select_pointing() function, but it should be set correctly at instantiation too.