### PR TITLE
Valid data backwards compatibility

### DIFF
--- a/sotodlib/preprocess/preprocess_util.py
+++ b/sotodlib/preprocess/preprocess_util.py
@@ -14,6 +14,7 @@ from sotodlib.hwp import hwp_angle_model
 from sotodlib.coords import demod as demod_mm
 from sotodlib.tod_ops import t2pleakage
 from sotodlib.core.flagman import has_any_cuts
+from so3g.proj import RangesMatrix
 
 from .. import core
 
@@ -368,7 +369,11 @@ def load_and_preprocess(obs_id, configs, context=None, dets=None, meta=None,
     configs, context = get_preprocess_context(configs, context)
     meta = context.get_meta(obs_id, dets=dets, meta=meta)
     if 'valid_data' in meta.preprocess:
-        keep = has_any_cuts(meta.preprocess.valid_data.valid_data)
+        if isinstance(meta.preprocess.valid_data, core.AxisManager):
+            field = meta.preprocess.valid_data.valid_data
+        else:
+            field = meta.preprocess.valid_data
+        keep = has_any_cuts(field)
         meta.restrict("dets", keep)
     else:
         det_vals = load_preprocess_det_select(obs_id, configs=configs, context=context,
@@ -454,7 +459,11 @@ def multilayer_load_and_preprocess(obs_id, configs_init, configs_proc,
 
             logger.info("Restricting detectors on all proc pipeline processes")
             if 'valid_data' in meta_proc.preprocess:
-                keep_all = has_any_cuts(meta_proc.preprocess.valid_data.valid_data)
+                if isinstance(meta_proc.preprocess.valid_data, core.AxisManager):
+                    field = meta_proc.preprocess.valid_data.valid_data
+                else:
+                    field = meta_proc.preprocess.valid_data
+                keep = has_any_cuts(field)
             else:
                 keep_all = np.ones(meta_proc.dets.count, dtype=bool)
                 for process in pipe_proc[:]:

--- a/sotodlib/preprocess/preprocess_util.py
+++ b/sotodlib/preprocess/preprocess_util.py
@@ -368,12 +368,11 @@ def load_and_preprocess(obs_id, configs, context=None, dets=None, meta=None,
 
     configs, context = get_preprocess_context(configs, context)
     meta = context.get_meta(obs_id, dets=dets, meta=meta)
-    if 'valid_data' in meta.preprocess:
-        if isinstance(meta.preprocess.valid_data, core.AxisManager):
-            field = meta.preprocess.valid_data.valid_data
-        else:
-            field = meta.preprocess.valid_data
-        keep = has_any_cuts(field)
+    if (
+        'valid_data' in meta.preprocess and
+        isinstance(meta.preprocess.valid_data, core.AxisManager)
+       ):
+        keep = has_any_cuts(meta.preprocess.valid_data.valid_data)
         meta.restrict("dets", keep)
     else:
         det_vals = load_preprocess_det_select(obs_id, configs=configs, context=context,
@@ -458,12 +457,11 @@ def multilayer_load_and_preprocess(obs_id, configs_init, configs_proc,
             pipe_proc = Pipeline(configs_proc["process_pipe"], logger=logger)
 
             logger.info("Restricting detectors on all proc pipeline processes")
-            if 'valid_data' in meta_proc.preprocess:
-                if isinstance(meta_proc.preprocess.valid_data, core.AxisManager):
-                    field = meta_proc.preprocess.valid_data.valid_data
-                else:
-                    field = meta_proc.preprocess.valid_data
-                keep = has_any_cuts(field)
+            if (
+                'valid_data' in meta_proc.preprocess and
+                isinstance(meta_proc.preprocess.valid_data, core.AxisManager)
+               ):
+                keep_all = has_any_cuts(meta_proc.preprocess.valid_data.valid_data)
             else:
                 keep_all = np.ones(meta_proc.dets.count, dtype=bool)
                 for process in pipe_proc[:]:

--- a/sotodlib/preprocess/preprocess_util.py
+++ b/sotodlib/preprocess/preprocess_util.py
@@ -14,7 +14,6 @@ from sotodlib.hwp import hwp_angle_model
 from sotodlib.coords import demod as demod_mm
 from sotodlib.tod_ops import t2pleakage
 from sotodlib.core.flagman import has_any_cuts
-from so3g.proj import RangesMatrix
 
 from .. import core
 


### PR DESCRIPTION
Adds a check for `valid_data` in preprocessing to see if it is an axis manager or not.  This just allows obs_ids that were processed while `valid_data` was still a `RangesMatrix` to be loaded.