### PR TITLE
Fixing publishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -27,7 +27,6 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0  # Fetch full history for tags
-          ref: ${{ github.ref_name }}
       
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -37,8 +36,7 @@ jobs:
       - name: Verify we're on the correct tag
         run: |
           echo "Current tag: $(git describe --tags --exact-match)"
-          echo "Expected tag: ${{ github.ref_name }}"
-          git describe --tags --exact-match | grep -q "${{ github.ref_name }}"
+          git checkout "refs/tags/$(git describe --tags --exact-match)"
 
       - name: Build
         run: |


### PR DESCRIPTION
The last time the action was triggered correctly, however it got the master branch as the ref. This PR removes that check and checkouts always the latest tag.

Hopefully this is the last fix and next month everything goes fine.

I also checked if we can put sotodlib in conda-forge. Unfortunately, this is not possible because some of sotodlib's dependencies are not on conda-forge because so3g and flacarray are not on conda-forge.