### PR TITLE
Det cal hwpss

### DIFF
--- a/sotodlib/site_pipeline/update_det_cal.py
+++ b/sotodlib/site_pipeline/update_det_cal.py
@@ -473,8 +473,8 @@ def biases_flags(bsa, buffer=200):
     Make flags that mask bias steps
 
     Args
-        bsa: BiasStepAnalysis object
-        buffer: buffet to apply on result flags
+        bsa: sodetlib BiasStepAnalysis object
+        buffer: Number of samples to buffer flags
     Returns
         RangesMatrix
     """
@@ -493,7 +493,7 @@ def load_and_reanalyze_bs(bsa, ctx, obs_id):
     Load raw data of biassteps and reanalyze it with hwpss subtraction
 
     Args
-        bsa: BiasStepAnalysis object
+        bsa: sodetlib BiasStepAnalysis object
         ctx: Context object
         obs_id: observation id of bias steps
     """


### PR DESCRIPTION
Update det_cal to reanalyze biasstep with hwpss subtraction. We found hwpss subtraction is imporant especially when hwpss is large, i.e. wiregrid, SAT-UHF. This is backward compatible and doesn't modify lat det_cal.
We need discussion but we probably keep normal det_cal running, and we will have another det_cal with hwpss subtraction.

Added special handling for metadata loader error so that this will try again when hwp_angle metadata was not produced before the det_cal.
Added an option to split h5 file based of first N digits of unixtime. Adresses https://github.com/simonsobs/sotodlib/issues/1367

Note: One of the tests are failed at the moment but this is not due to this PR, hopefully fixes by itself. I will rerun later