### PR TITLE
Adjust overwrite for cleanup_mandb

### DIFF
--- a/sotodlib/preprocess/preprocess_util.py
+++ b/sotodlib/preprocess/preprocess_util.py
@@ -1179,19 +1179,16 @@ def cleanup_mandb(error, outputs, configs, logger=None, overwrite=False):
 
         src_file = outputs['temp_file']
 
-        logger.debug(f"Source file: {src_file}")
-        logger.debug(f"Destination file: {dest_file}")
+        logger.debug(f"Copying from {src_file} to {dest_file}")
 
         with h5py.File(dest_file,'a') as f_dest:
             with h5py.File(src_file,'r') as f_src:
                 for dts in f_src.keys():
-                    logger.debug(f"\t{dts}")
                     # If the dataset or group already exists, delete it to overwrite
                     if overwrite and dts in f_dest:
                         del f_dest[dts]
                     f_src.copy(f_src[f'{dts}'], f_dest, f'{dts}')
                     for member in f_src[dts]:
-                        logger.debug(f"\t{dts}/{member}")
                         if isinstance(f_src[f'{dts}/{member}'], h5py.Dataset):
                             f_src.copy(f_src[f'{dts}/{member}'], f_dest[f'{dts}'], f'{dts}/{member}')
         logger.info(f"Saving to database under {outputs['db_data']}")

--- a/sotodlib/site_pipeline/multilayer_preprocess_tod.py
+++ b/sotodlib/site_pipeline/multilayer_preprocess_tod.py
@@ -373,18 +373,22 @@ def _main(executor: Union["MPICommExecutor", "ProcessPoolExecutor"],
         if db_datasets_init:
             if err is None:
                 for db_dataset in db_datasets_init:
-                    logger.info(f'Processing future result db_dataset: {db_datasets_init}')
-                    pp_util.cleanup_mandb(err, db_dataset, configs_init, logger, overwrite)
+                    logger.info(f'Processing init future result')
+                    pp_util.cleanup_mandb(err, db_dataset, configs_init,
+                                          logger, overwrite)
             else:
-                pp_util.cleanup_mandb(err, db_datasets_init, configs_init, logger, overwrite)
+                pp_util.cleanup_mandb(err, db_datasets_init, configs_init,
+                                      logger, overwrite)
 
         if db_datasets_proc:
             if err is None:
-                logger.info(f'Processing future dependent result db_dataset: {db_datasets_proc}')
+                logger.info(f'Processing future proc result')
                 for db_dataset in db_datasets_proc:
-                    pp_util.cleanup_mandb(err, db_dataset, configs_proc, logger, overwrite)
+                    pp_util.cleanup_mandb(err, db_dataset, configs_proc,
+                                          logger, overwrite)
             else:
-                pp_util.cleanup_mandb(err, db_datasets_proc, configs_proc, logger, overwrite)
+                pp_util.cleanup_mandb(err, db_datasets_proc, configs_proc,
+                                      logger, overwrite)
 
     if raise_error and n_fail > 0:
         raise RuntimeError(f"multilayer_preprocess_tod: {n_fail}/{len(run_list)} obs_ids failed")

--- a/sotodlib/site_pipeline/preprocess_tod.py
+++ b/sotodlib/site_pipeline/preprocess_tod.py
@@ -399,11 +399,13 @@ def _main(executor: Union["MPICommExecutor", "ProcessPoolExecutor"],
 
         if db_datasets:
             if err is None:
-                logger.info(f'Processing future result db_dataset: {db_datasets}')
+                logger.info(f'Processing future result')
                 for db_dataset in db_datasets:
-                    pp_util.cleanup_mandb(err, db_dataset, configs, logger)
+                    pp_util.cleanup_mandb(err, db_dataset, configs,
+                                          logger, overwrite)
             else:
-                pp_util.cleanup_mandb(err, db_datasets, configs, logger)
+                pp_util.cleanup_mandb(err, db_datasets, configs,
+                                      logger, overwrite)
 
     if raise_error and n_fail > 0:
         raise RuntimeError(f"preprocess_tod: {n_fail}/{len(run_list)} obs_ids failed")


### PR DESCRIPTION
Minor update to add overwrite to `preprocess_tod` to make sure that the entry is fully deleted instead of only some fields being added to or edited.  Was already added for `multilayer_preprocess_tod`.  Also just removes some logging that was added for debugging a while ago and has duplicate information that I think is no longer needed.