### PR TITLE
Allow preproc_or_load_group to save archive

### DIFF
--- a/sotodlib/preprocess/preprocess_util.py
+++ b/sotodlib/preprocess/preprocess_util.py
@@ -913,7 +913,8 @@ def preproc_or_load_group(obs_id, configs_init, dets, configs_proc=None,
         Optional. Whether or not to overwrite existing entries in the preprocess manifest db.
     save_archive :
         Call cleanup_mandb if True to save to the archive and database files
-        in configs_init and configs_proc
+        in configs_init and configs_proc. Should be False if preproc_or_load_group
+        is being called from within a parallelized script (i.e. python multiprocessing or MPI).
 
     Returns
     -------


### PR DESCRIPTION
Addresses point made in #1440.

Adds `save_archive` option (default `False`) to `preproc_or_load_group` which will automatically save the archive instead of having to call it separately.

Tested with simple preproc configs in single and multiple layers.