### PR TITLE
Add missing `requests` dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ dependencies = [
   "psycopg2-binary",
   "lmfit",
   "flacarray>=0.3.4",
-  "requests",
 ]
 dynamic=["version"]
 classifiers = [
@@ -56,6 +55,7 @@ site_pipeline = [
   "pandas",
   "alphashape",
   "slack-sdk",
+  "requests",
 ]
 tests = [
   "socs",


### PR DESCRIPTION
#1422 introduced a dependency on `requests` but the pyproject.toml wasn't updated, which leads to import errors when importing names from `sotodlib.site_pipeline` for example.