### PR TITLE
Change preprocess tags typing

### DIFF
--- a/sotodlib/site_pipeline/multilayer_preprocess_tod.py
+++ b/sotodlib/site_pipeline/multilayer_preprocess_tod.py
@@ -2,7 +2,7 @@ import os
 import yaml
 import time
 import logging
-from typing import Optional, Union, Callable
+from typing import Optional, Union, Callable, List
 import numpy as np
 import argparse
 import traceback

--- a/sotodlib/site_pipeline/preprocess_tod.py
+++ b/sotodlib/site_pipeline/preprocess_tod.py
@@ -2,7 +2,7 @@ import os
 import yaml
 import time
 import logging
-from typing import Optional, Union, Callable
+from typing import Optional, Union, Callable, List
 import numpy as np
 import argparse
 import traceback


### PR DESCRIPTION
Just changes the typing for `tags` in `preprocess_tod` and `multilayer_preprocess_tod` to a list of strings to match `preprocess_obs`.   I think this is related to the LAT planet preprocess `Prefect` flow failures.  Other small formatting corrections were just from my editor.