### PR TITLE
Rename coadd logger

### DIFF
--- a/sotodlib/site_pipeline/make_coadd_atomic_map.py
+++ b/sotodlib/site_pipeline/make_coadd_atomic_map.py
@@ -129,7 +129,7 @@ class CoaddAtomicConfig:
 
 
 def main(config_file: str, verbosity: int) -> None:
-    logger = sp_util.init_logger("Coadd atomic mapmaking", verbosity=verbosity)
+    logger = sp_util.init_logger("make_coadd_atomic_map", verbosity=verbosity)
     cfg = CoaddAtomicConfig.from_yaml(config_file)
     logger.info(f"Setup {cfg.interval} intervals")
     logger.debug(cfg.time_intervals)


### PR DESCRIPTION
Renames the logger in `make_coadd_atomic_map.py` without spaces to be more easily used by prefect.