### PR TITLE
Add 2nd order basetilt and Az centering error correction to SAT point…

### DIFF
--- a/sotodlib/coords/pointing_model.py
+++ b/sotodlib/coords/pointing_model.py
@@ -335,7 +335,7 @@ param_defaults={
         'harmonic_2az_sin': 0.,
         'harmonic_2az_cos': 0.,
         'acec': 0.,
-        'aces': 0.
+        'aces': 0.,
     }
 }
 
@@ -391,3 +391,4 @@ def get_base_tilt_q_2nd(az, el, dE_C2A, dE_S2A, dA_C2A, dA_S2A):
     q_HE = quat.euler(2, az) * quat.euler(1, delta_el) * quat.euler(2, -az)
 
     return q_HE * q_HA
+

--- a/sotodlib/coords/pointing_model.py
+++ b/sotodlib/coords/pointing_model.py
@@ -253,7 +253,9 @@ def model_sat_v1(params, az, el, roll):
         Sign convention: True = Encoder + Offset
       - base_tilt_{cos,sin}: Base tilt coefficients, in radians. 
       - az_rot: Dimensionless parameter describing a linear dependence of Az on El.
-
+      - harmonic_2az_{cos,sin}: 2nd order azimuth correction, Rad  (HACA2, HASA2)
+      - harmonic_2el_{cos,sin}: 2nd order azimuth correction, Rad  (HECA2, HESA2)
+      - acec, aces: Az Centering Error params, TPoint, in Radians
     """
     _p = dict(param_defaults['sat_v1'])
     if isinstance(params, dict):
@@ -270,14 +272,20 @@ def model_sat_v1(params, az, el, roll):
 
     # Construct offsetted encoders.
     az_orig = az.copy()
+    ace = -params['aces'] * np.sin(az) + params['acec'] * np.cos(az)
     az_twist = params['az_rot'] * (el + params['enc_offset_el'])
-    az = az + params['enc_offset_az'] + az_twist
+    az = az + params['enc_offset_az'] + az_twist + ace
     el = el + params['enc_offset_el'] 
     roll = roll - params['enc_offset_boresight'] 
 
     # Rotation that tilts the base (referred to vals after enc correction).
     base_tilt = get_base_tilt_q(params['base_tilt_cos'], params['base_tilt_sin'])
 
+    #Rotations to account for second order basetilts
+    q_2_base_tilt = get_base_tilt_q_2nd(az, el,
+                                        params['harmonic_2el_cos'], params['harmonic_2el_sin'],
+                                        params['harmonic_2az_cos'], params['harmonic_2az_sin'])
+    
     # Rotation that takes a vector in array-centered focal plane coords
     # to a vector in boresight-rotation-centered focal plane coords.
     q_fp_rot = ~quat.rotation_xieta(params['fp_rot_xi0'], params['fp_rot_eta0'])
@@ -286,7 +294,7 @@ def model_sat_v1(params, az, el, roll):
     q_fp_offset = quat.rotation_xieta(params['fp_offset_xi0'], params['fp_offset_eta0'])
 
     # Horizon coordinates.
-    q_hs = (base_tilt * quat.rotation_lonlat(-az, el)
+    q_hs = (q_2_base_tilt * base_tilt * quat.rotation_lonlat(-az, el)
             * q_fp_offset * ~q_fp_rot * quat.euler(2, roll) * q_fp_rot)
 
     neg_az, el, roll = quat.decompose_lonlat(q_hs)
@@ -321,7 +329,13 @@ param_defaults={
         'fp_rot_eta0': 0.,
         'az_rot': 0.,
         'base_tilt_cos': 0.,
-        'base_tilt_sin': 0.
+        'base_tilt_sin': 0.,
+        'harmonic_2el_sin': 0.,
+        'harmonic_2el_cos': 0.,
+        'harmonic_2az_sin': 0.,
+        'harmonic_2az_cos': 0.,
+        'acec': 0.,
+        'aces': 0.
     }
 }
 
@@ -364,3 +378,16 @@ def get_base_tilt_q(c, s):
     amp = (c**2 + s**2)**.5
     return quat.euler(2, phi) * quat.euler(1, amp) * quat.euler(2, -phi)
 
+def get_base_tilt_q_2nd(az, el, dE_C2A, dE_S2A, dA_C2A, dA_S2A):
+    """ Returns quaternion rotation that applies 2nd order basetilt motion
+    Input Tpoint parameters in radians.
+    """
+    # Azimuth harmonic correction
+    delta_az = dA_C2A * np.cos(2 * az) + dA_S2A * np.sin(2 * az)
+    q_HA = quat.euler(2, delta_az)
+
+    # Elevation harmonic correction (Euler sandwich)
+    delta_el = dE_C2A * np.cos(2*az) + dE_S2A * np.sin(2*az)
+    q_HE = quat.euler(2, az) * quat.euler(1, delta_el) * quat.euler(2, -az)
+
+    return q_HE * q_HA


### PR DESCRIPTION
Added critical ACES and ACEC pointing parameters to pointing model which are very needed for SATp2 pointing. Also staged 2nd order az-dependent base tilt parameter quaternion, although they will not be used yet. 

(aces/acec params brought satp2 pointing errors down from ~8-10 arcminutes to 3-4 :) 