### PR TITLE
Check coadd obslist and recompute if changed

### DIFF
--- a/sotodlib/mapmaking/coadd_mapmaker.py
+++ b/sotodlib/mapmaking/coadd_mapmaker.py
@@ -138,16 +138,6 @@ def setup_coadd_map(atomic_db, output_db, band, platform, split_label,
         start_time = start_time.timestamp()
     if isinstance(stop_time, dt.datetime):
         stop_time = stop_time.timestamp()
-        
-    if not overwrite:
-        conn = sqlite3.connect(output_db)
-        cur = conn.cursor()
-        query_stmt = f"SELECT * FROM {interval} WHERE telescope = ? AND freq_channel = ? AND split_label = ? AND start_time = ? AND stop_time = ?"
-        cur.execute(query_stmt, (platform,band,split_label,start_time,stop_time,))
-        rows = cur.fetchall()
-        conn.close()
-        if len(rows) > 0:
-            return False
 
     conn = sqlite3.connect(atomic_db)
     cur = conn.cursor()
@@ -166,6 +156,18 @@ def setup_coadd_map(atomic_db, output_db, band, platform, split_label,
     for j, row in enumerate(rows):
         for k, item in enumerate(row):
             data[columns[k]].append(item)
+            
+    obslist = ','.join(np.unique(data['obs_id']))
+    
+    if not overwrite:
+        conn = sqlite3.connect(output_db)
+        cur = conn.cursor()
+        query_stmt = f"SELECT * FROM {interval} WHERE telescope = ? AND freq_channel = ? AND split_label = ? AND start_time = ? AND stop_time = ? AND obslist = ?"
+        cur.execute(query_stmt, (platform,band,split_label,start_time,stop_time,obslist,))
+        rows = cur.fetchall()
+        conn.close()
+        if len(rows) > 0:
+            return False
 
     if '+' in band:
         band = band.split('+')[0]


### PR DESCRIPTION
Updates the coadd db query to check for the exact obslist created from the atomic db query. If additional obs were added within the interval after that interval was already computed, the coadd query would return 0 rows, allowing for coadding to continue to run, even when `overwrite=False`.