### PR TITLE
Remove NaN for hwp mean rate

### DIFF
--- a/sotodlib/qa/metrics.py
+++ b/sotodlib/qa/metrics.py
@@ -546,7 +546,7 @@ class HWPSolMeanRate(HWPSolQA):
     def _gen_value(self, meta):
         good_samp = ~meta.hwp_solution[f"filled_flag_{self._encoder}"]
         nsamp = good_samp.sum()
-        rate = np.nan if nsamp == 0 else (meta.hwp_solution[f"hwp_rate_{self._encoder}"] * good_samp).sum() / nsamp
+        rate = 0.0 if nsamp == 0 else (meta.hwp_solution[f"hwp_rate_{self._encoder}"] * good_samp).sum() / nsamp
         return rate
 
 


### PR DESCRIPTION
Not conclusive, but I believe the `NaN` here results in the partial write failures we're seeing in Prefect with `record_qa` and potentially in the `daq-db1` problems from SATp2. Example failed flow:

https://prefect.simonsobs.org/flow-runs/flow-run/ac3f13af-39b7-4bac-ab51-50460ab08f33

An example obs_id is:
`obs_1742642488_satp2_1111111`

Doing the following for encoder 1 (2 is fine for this obs_id):
```
good_samp = ~meta.hwp_solution[f"filled_flag_{1}"]
nsamp = good_samp.sum()
rate = np.nan if nsamp == 0 else (meta.hwp_solution[f"hwp_rate_{1}"] * good_samp).sum() / nsamp
```
Results in a `NaN`.  Confirmed with @ykyohei that 0.0 is a good replacement for this case.



