### PR TITLE
Change update_smurf_caldbs obsid with detset query

### DIFF
--- a/sotodlib/site_pipeline/update_smurf_caldbs.py
+++ b/sotodlib/site_pipeline/update_smurf_caldbs.py
@@ -367,9 +367,17 @@ def get_obs_with_detsets(ctx, detset_idx):
     """Gets all observations with type 'obs' that have detset data"""
     db = core.metadata.ManifestDb(detset_idx)
     detsets = db.get_entries(['dataset'])['dataset']
-    obs_ids = set()
-    for dset in detsets:
-        obs_ids = obs_ids.union(ctx.obsfiledb.get_obs_with_detset(dset))
+
+    values = ",".join("?" for _ in detsets)
+    query = f"""
+        SELECT DISTINCT obs_id
+        FROM files
+        WHERE detset IN ({values})
+    """
+
+    c = ctx.obsfiledb.conn.execute(query, detsets)
+    obs_ids = set([r[0] for r in c])
+
     return obs_ids
 
 

--- a/sotodlib/site_pipeline/update_smurf_caldbs.py
+++ b/sotodlib/site_pipeline/update_smurf_caldbs.py
@@ -59,9 +59,12 @@ if not logger.hasHandlers():
 
 
 
-def main(config: Union[str, dict], 
-        overwrite:Optional[bool]=False,
-        skip_detset=False, skip_detcal=False):
+def main(
+    config: Union[str, dict],
+    overwrite: Optional[bool] = False,
+    skip_detset: Optional[bool] = False,
+    skip_detcal: Optional[bool] = False,
+):
     if not skip_detset:
         smurf_detset_info(config, overwrite)
     if not skip_detcal:


### PR DESCRIPTION
Still investigating...

`update_smurf_caldbs` appears to have a runtime that increases slowly over time when running in Prefect.  Example flow:

https://prefect.simonsobs.org/flow-runs/flow-run/6a855656-459b-4ddd-ac71-de01911155c5?tab=Logs

Even though there were no detsets to add, it still took more than one hour.  This slowdown must be occurring either in [smurf_detset_info](https://github.com/simonsobs/sotodlib/blob/01a3dffd0c0197699190f20a69d5102578353281/sotodlib/site_pipeline/update_smurf_caldbs.py#L66C9-L66C26) or in `update_det_caldb` but before [line 470](https://github.com/simonsobs/sotodlib/blob/01a3dffd0c0197699190f20a69d5102578353281/sotodlib/site_pipeline/update_smurf_caldbs.py#L470) meaning that it would be nearly entirely due to loading db retrieval time only since almost all of the Prefect run time is taken up before that line.

Running these functions manually on `compute11`, I don't immediately reproduce such a long duration.  I did see that `get_obs_with_detsets` is slow (on the order of ~5 minutes), so I have updated the query to be much faster.

One thing I did find was that when I tried querying the db on compute21 and doing the same on compute11 at the same time, the one on compute21 ran normally, but when it finished (with a locked db error because it tried to execute another query) the one on compute11 dramatically slowed down, putting it exactly in line with how long the `update_smurf_caldbs` loading are taking.

Looking at this flow (https://prefect.simonsobs.org/flow-runs/flow-run/b0abc8f2-51ca-4d26-a2c5-eb4f8af9537e), there is basically no time spent before line 470, so it is not a consistent duration which I think points to it being the above data loading issue.