### PR TITLE
Optimize coadd atomic mapmaker

### DIFF
--- a/sotodlib/mapmaking/coadd_mapmaker.py
+++ b/sotodlib/mapmaking/coadd_mapmaker.py
@@ -64,6 +64,8 @@ class CoaddMapmaker:
         self.hits_coadd = hits_coadd
         self.map_coadd = None
         
+        self.coadd_atomic = self.data.get('coadd_atomic', True)
+        
         if logger is None:
             logger = logging.getLogger("coadd")
         self.logger = logger
@@ -79,13 +81,21 @@ class CoaddMapmaker:
             Path to atomic map file.
         """
         file = os.path.normpath(file)
-        wmap = enmap.read_map(file+'_wmap.fits', geometry=(self.shape,self.wcs))
         weights = enmap.read_map(file+'_weights.fits', geometry=(self.shape,self.wcs))
         hits = enmap.read_map(file+'_hits.fits', geometry=(self.shape,self.wcs))
+        if self.coadd_atomic:
+            wmap = enmap.read_map(file+'_wmap.fits', geometry=(self.shape,self.wcs))
+            self.wmap_coadd += wmap
+            for i in range(3):
+                self.weights_coadd[i,i] += weights[i]
+        else:
+            wmap = enmap.read_map(file+'_map.fits', geometry=(self.shape,self.wcs))
+            # diagonalize if coadded weights still shape (3,3,shape,wcs)
+            if (weights.shape[0] == 3) & (weights.shape[1] == 3):
+                weights = weights[np.arange(3), np.arange(3), ...]
+            self.weights_coadd += weights
+            self.wmap_coadd += wmap * weights
 
-        self.wmap_coadd += wmap
-        for i in range(3):
-            self.weights_coadd[i,i] += weights[i]
         self.hits_coadd += hits
             
     def write(self, output_root, output_db, band, platform, split_label, start_time, 
@@ -99,18 +109,20 @@ class CoaddMapmaker:
         self.logger.debug(f'output path prefix: {oname}')
 
         enmap.write_map(oname+'_map.fits', self.map_coadd, extra={'BUNIT':unit})
+        # write diagonalized weights, shape (3,shape,wcs), to file
+        if (self.weights_coadd.shape[0] == 3) & (self.weights_coadd.shape[1] == 3):
+            self.weights_coadd = self.weights_coadd[np.arange(3), np.arange(3), ...]
         enmap.write_map(oname+'_weights.fits', self.weights_coadd, extra={'BUNIT':unit})
         enmap.write_map(oname+'_hits.fits', self.hits_coadd)
         self.logger.info(f'wrote map to {oname}'+'_map.fits')
         self.logger.info(f'wrote weights to {oname}'+'_weights.fits')
         self.logger.info(f'wrote hits to {oname}'+'_hits.fits')
 
-        obslist = ','.join(np.unique(self.data['obs_id']))
         conn = sqlite3.connect(output_db)
         cur = conn.cursor()
         col_names = ['telescope', 'freq_channel', 'split_label', 'prefix_path', 'geom_file_path', 'obslist', 'start_time', 'stop_time']
         placeholders = ','.join(['?'] * len(col_names))
-        row_values = [platform, band, split_label, oname, self.geom_file_path, obslist, start_time, stop_time]
+        row_values = [platform, band, split_label, oname, self.geom_file_path, self.data['obslist'], start_time, stop_time]
         insert_stmt = f'INSERT OR REPLACE INTO {interval} ({",".join(col_names)}) VALUES ({placeholders})'
         cur.execute(insert_stmt, row_values)
         conn.commit()
@@ -133,31 +145,64 @@ def setup_coadd_map(atomic_db, output_db, band, platform, split_label,
     """
     Queries the atomic database and setup the CoaddMapmaker object.
     """
-    columns = ['obs_id', 'telescope', 'freq_channel', 'ctime', 'split_label', 'prefix_path']
     if isinstance(start_time, dt.datetime):
         start_time = start_time.timestamp()
     if isinstance(stop_time, dt.datetime):
         stop_time = stop_time.timestamp()
-
-    conn = sqlite3.connect(atomic_db)
-    cur = conn.cursor()
-    if '+' in band:
-        query_stmt = f"SELECT {','.join(columns)} FROM atomic WHERE telescope = ? AND split_label = ? AND ctime >= ? AND ctime <= ?"
-        cur.execute(query_stmt, (platform,split_label,start_time,stop_time,))
+       
+    lower_interval = None
+    coadd_atomic = False
+    if (interval == 'weekly') or (interval == 'monthly'):
+        lower_interval = 'daily'
     else:
-        query_stmt = f"SELECT {','.join(columns)} FROM atomic WHERE telescope = ? AND split_label = ? AND ctime >= ? AND ctime <= ? AND freq_channel = ?"
-        cur.execute(query_stmt, (platform,split_label,start_time,stop_time,band,))
-    rows = cur.fetchall()
-    conn.close()
-
+        coadd_atomic = True
+    
+    if lower_interval:
+        logger.debug('Attempting to coadd from existing coadded maps')
+        columns = ['telescope', 'freq_channel', 'split_label', 'prefix_path', 'geom_file_path', 'obslist', 'start_time', 'stop_time']
+        conn = sqlite3.connect(output_db)
+        cur = conn.cursor()
+        query_stmt = f"SELECT {','.join(columns)} FROM {lower_interval} WHERE telescope = ? AND freq_channel = ? AND split_label = ? AND start_time >= ? AND stop_time <= ?"
+        cur.execute(query_stmt, (platform,band,split_label,start_time,stop_time,))
+        rows = cur.fetchall()
+        conn.close()
+        
+        if len(rows) == 0:
+            logger.debug('No existing coadds found. Coadding from atomic maps')
+            coadd_atomic = True
+    
+    if coadd_atomic:
+        columns = ['obs_id', 'telescope', 'freq_channel', 'ctime', 'split_label', 'prefix_path']
+        conn = sqlite3.connect(atomic_db)
+        cur = conn.cursor()
+        if '+' in band:
+            query_stmt = f"SELECT {','.join(columns)} FROM atomic WHERE telescope = ? AND split_label = ? AND ctime >= ? AND ctime <= ?"
+            cur.execute(query_stmt, (platform,split_label,start_time,stop_time,))
+        else:
+            query_stmt = f"SELECT {','.join(columns)} FROM atomic WHERE telescope = ? AND split_label = ? AND ctime >= ? AND ctime <= ? AND freq_channel = ?"
+            cur.execute(query_stmt, (platform,split_label,start_time,stop_time,band,))
+        rows = cur.fetchall()
+        conn.close()
+        
     data = {}
     for col in columns:
         data[col] = []
     for j, row in enumerate(rows):
         for k, item in enumerate(row):
             data[columns[k]].append(item)
-            
-    obslist = ','.join(np.unique(data['obs_id']))
+
+    if coadd_atomic:
+        obslist = ','.join(np.unique(data['obs_id']))
+        data['coadd_atomic'] = True
+    else:
+        combined_list = []
+        for obslist in data['obslist']:
+            combined_list.extend(obslist.split(','))
+        
+        obslist = ','.join(np.unique(combined_list))
+        data['coadd_atomic'] = False
+    
+    data['obslist'] = obslist
     
     if not overwrite:
         conn = sqlite3.connect(output_db)
@@ -174,7 +219,10 @@ def setup_coadd_map(atomic_db, output_db, band, platform, split_label,
     geom_file_path = geom_file_prefix+f'_{band}.fits'
     shape, wcs = enmap.read_map_geometry(geom_file_path)
     wmap_coadd = enmap.zeros((3,)+shape, wcs=wcs)
-    weights_coadd = enmap.zeros((3,3,)+shape, wcs=wcs)
+    if coadd_atomic:
+        weights_coadd = enmap.zeros((3,3,)+shape, wcs=wcs)
+    else:
+        weights_coadd = enmap.zeros((3,)+shape, wcs=wcs)
     hits_coadd = enmap.zeros((3,)+shape, wcs=wcs)
     
     mapmaker = CoaddMapmaker(data, shape, wcs, geom_file_path, 
@@ -237,15 +285,19 @@ def make_coadd_map(atomic_db, output_root, output_db, band, platform, split_labe
     if not mapmaker:
         return False, "Map found in database and overwrite=False. Skipping."
 
-    mapmaker.logger.info(f"# of fits files: {len(mapmaker.data['prefix_path'])}")
     if len(mapmaker.data['prefix_path']) == 0:
         return False, "No fits files found to coadd. Skipping."
+    mapmaker.logger.info(f"# of fits files: {len(mapmaker.data['prefix_path'])}")
+    
     mapmaker.logger.info(f"Using geometry from {mapmaker.geom_file_path}")
     for file in tqdm(mapmaker.data['prefix_path'], total=len(mapmaker.data['prefix_path'])):
         mapmaker.add_map(file)
 
-    iweights = safe_invert_div(mapmaker.weights_coadd)
-    mapmaker.map_coadd = enmap.map_mul(iweights, mapmaker.wmap_coadd)
+    if mapmaker.data.get('coadd_atomic', True):
+        iweights = safe_invert_div(mapmaker.weights_coadd)
+        mapmaker.map_coadd = enmap.map_mul(iweights, mapmaker.wmap_coadd)
+    else:
+        mapmaker.map_coadd = np.nan_to_num(mapmaker.wmap_coadd / mapmaker.weights_coadd, nan=0.0)
 
     write_coadd_map(mapmaker, output_root, output_db, band, platform, split_label, 
                     start_time, stop_time, interval, unit=unit, plot=plot)


### PR DESCRIPTION
- Attempts to coadd existing coadded daily maps when interval is `'weekly'` or `'monthly'`. Falls back on coadding atomic maps if none exist.
- Changes weights output to write diagonalized weights with shape `(3,shape,wcs)`. Adds handling for both shape inputs to work with already existing weights files that have shape `(3,3,shape,wcs)`.
- Tested on existing coadded maps and compared the new weekly coadds made from daily coadds vs. weekly coadds made from atomic maps from site. Found a median difference between pixels to be `1e-24` and maximum difference to be `1e-17`.