### PR TITLE
Fix invalid escape sequences

### DIFF
--- a/sotodlib/io/datapkg_completion.py
+++ b/sotodlib/io/datapkg_completion.py
@@ -283,7 +283,7 @@ class DataPackaging:
                     if len(status.tags)==0:
                         no_tags += 1
                     else:
-                        msg += f"\Trying to add {fpath} to database"
+                        msg += f"\nTrying to add {fpath} to database"
                         self.SMURF.add_file( 
                             fpath, self.g3session, overwrite=True
                         )

--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -648,7 +648,7 @@ class G3tSmurf:
             The active session
         """
 
-        band = int(re.findall("b\d.txt", cha)[0][1])
+        band = int(re.findall(r"b\d.txt", cha)[0][1])
 
         ch_assign = session.query(ChanAssignments).filter(
             ChanAssignments.ctime == ctime,
@@ -1580,7 +1580,7 @@ class G3tSmurf:
                     # same folder
                     root = os.path.join("/", *path.split("/")[:-1])
                     fname = path.split("/")[-1]
-                    fband = int(re.findall("b\d.txt", fname)[0][1])
+                    fband = int(re.findall(r"b\d.txt", fname)[0][1])
                     cha_times = [
                         int(f.split("_")[0])
                         for f in os.listdir(root)

--- a/sotodlib/preprocess/preprocess_plot.py
+++ b/sotodlib/preprocess/preprocess_plot.py
@@ -539,7 +539,7 @@ def plot_flag_stats(aman, flag_aman, flag_type="glitches", N_bins=30, filename="
         meansamps + stdsamps,
         color="wheat",
         alpha=0.2,
-        label=f"$\sigma$: {stdsamps:.2e}%",
+        label=rf"$\sigma$: {stdsamps:.2e}%",
     )
     ax[0].legend()
     ax[0].set_xlim(10**binmin, 10**binmax)
@@ -547,9 +547,9 @@ def plot_flag_stats(aman, flag_aman, flag_type="glitches", N_bins=30, filename="
     ax[0].set_xlabel("Fraction of Samples Flagged\nper Detector [%]", fontsize=16)
     ax[0].set_ylabel("Counts", fontsize=16)
     ax[0].set_title(
-        "Samples Flagged Stats\n$N_{\mathrm{dets}}$ = "
+        "Samples Flagged Stats\n$N_{\\mathrm{dets}}$ = "
         + f"{aman.dets.count}"
-        + " and $N_{\mathrm{samps}}$ = "
+        + r" and $N_{\mathrm{samps}}$ = "
         + f"{aman.samps.count}"
     )
 
@@ -578,7 +578,7 @@ def plot_flag_stats(aman, flag_aman, flag_type="glitches", N_bins=30, filename="
         meanints + stdints,
         color="wheat",
         alpha=0.2,
-        label=f"$\sigma$: {stdints:.2e} intervals",
+        label=rf"$\sigma$: {stdints:.2e} intervals",
     )
 
     ax[1].legend()
@@ -586,7 +586,7 @@ def plot_flag_stats(aman, flag_aman, flag_type="glitches", N_bins=30, filename="
     ax[1].set_xlabel("Number of Flag Intervals\nper Detector", fontsize=16)
     ax[1].set_ylabel("Counts", fontsize=16)
     ax[1].set_title(
-        "Ranges Flag Manager Stats\n$N_{\mathrm{dets}}$ with $\geq$ 1 interval = "
+        "Ranges Flag Manager Stats\n$N_{\\mathrm{dets}}$ with $\\geq$ 1 interval = "
         + f"{len(interval_glitches[interval_glitches > 0])}/{aman.dets.count}\n(98th quantile bin max)"
     )
     


### PR DESCRIPTION
Currently, importing some sotodlib modules leads to syntax warnings, e.g.
```
sotodlib/io/load_smurf.py:651: SyntaxWarning: invalid escape sequence '\d'
  band = int(re.findall("b\d.txt", cha)[0][1])
sotodlib/io/load_smurf.py:651: SyntaxWarning: invalid escape sequence '\d'
  band = int(re.findall("b\d.txt", cha)[0][1])
sotodlib/io/load_smurf.py:651: SyntaxWarning: invalid escape sequence '\d'
  band = int(re.findall("b\d.txt", cha)[0][1])
```

This fixes the few cases of invalid escape sequences in the codebase by making the strings "raw".

Finding them was easy using this ruff rule: https://docs.astral.sh/ruff/rules/invalid-escape-sequence/

NB: I think the one in `datapkg_completion.py` was just a missing `n` to produce a new line.