### PR TITLE
Fix edge case of biases_flags in update_det_cal

### DIFF
--- a/sotodlib/site_pipeline/update_det_cal.py
+++ b/sotodlib/site_pipeline/update_det_cal.py
@@ -485,6 +485,8 @@ def biases_flags(bsa, buffer=200):
     for i, bg in enumerate(bsa.bgmap):
         if bg == -1:
             continue
+        if len(bsa.edge_idxs[bg]) == 0:
+            continue
         mask[i][bsa.edge_idxs[bg][0]:bsa.edge_idxs[bg][-1]] = 1
     flags = RangesMatrix.from_mask(mask).buffer(buffer)
     return flags


### PR DESCRIPTION
This PR will fix the failure of update_det_cal due to IndexError of the biases_flags function used for det_cal with hwpss subtraction.
This happens because there are few observations which do not have bias step in one of the bias lines, for some reason.
An error in one of the bias lines on one of the wafers is causing the entire observation to fail.

- obs_1725391751_satp2_0011011
- obs_1719596265_satp1_1110101
- obs_1721869990_satp1_1101111

```
obs_1725391751_satp2_0011011: "Traceback (most recent call last):\n  File \"/home/kyoheiy/sotodlib/sotodlib/site_pipeline/update_det_cal.py\"\
  , line 595, in get_cal_resset\n    load_and_reanalyze_bs(bsa, ctx, oid)\n  File\
  \ \"/home/kyoheiy/sotodlib/sotodlib/site_pipeline/update_det_cal.py\", line\
  \ 533, in load_and_reanalyze_bs\n    flags = biases_flags(bsa)\n            ^^^^^^^^^^^^^^^^^\n\
  \  File \"/home/kyoheiy/tools/sotodlib/sotodlib/site_pipeline/update_det_cal.py\"\
  , line 488, in biases_flags\n    mask[i][bsa.edge_idxs[bg][0]:bsa.edge_idxs[bg][-1]]\
  \ = 1\n            ~~~~~~~~~~~~~~~~~^^^\nIndexError: index 0 is out of bounds for\
  \ axis 0 with size 0\n"
```
For example, in this observations, bias group 0 does not have bias step
<img width="640" height="480" alt="Figure 14 (13)" src="https://github.com/user-attachments/assets/99bceb5c-7e4d-463c-ae4f-b1bf2183d9ca" />

