### PR TITLE
Pass full aman into preprocess pipe

### DIFF
--- a/sotodlib/preprocess/preprocess_util.py
+++ b/sotodlib/preprocess/preprocess_util.py
@@ -513,7 +513,7 @@ def load_and_preprocess(obs_id, configs, context=None, dets=None, meta=None,
     logger : PythonLogger
         Optional. Logger object.  If None, a new logger
         is created.
-    return_full_aman: bool
+    return_full_aman : bool
         Optional. Return unrestricted axis manager alongside restricted aman
         if True, otherwise return None.
 

--- a/sotodlib/site_pipeline/make_depth1_map.py
+++ b/sotodlib/site_pipeline/make_depth1_map.py
@@ -154,7 +154,7 @@ def make_depth1_map(
         # which is pointless, but shouldn't cost that much time
         # obs = context.get_obs(obs_id, dets={"wafer_slot":detset, "band":band})
         try:
-            obs = pp_util.load_and_preprocess(
+            obs, _ = pp_util.load_and_preprocess(
                 obs_id,
                 preproc,
                 dets={"wafer_slot": detset, "wafer.bandpass": band},

--- a/sotodlib/site_pipeline/multilayer_preprocess_tod.py
+++ b/sotodlib/site_pipeline/multilayer_preprocess_tod.py
@@ -464,7 +464,7 @@ def _main(executor: Union["MPICommExecutor", "ProcessPoolExecutor"],
                         n_groups_fail += 1
 
         if n_groups_fail > 0:
-            raise RuntimeError(f"preprocess_tod ended with {n_obs_fail}/{len(obs_errors)} "
+            raise RuntimeError(f"multilayer_preprocess_tod ended with {n_obs_fail}/{len(obs_errors)} "
                                f"failed obsids and {n_groups_fail}/{len(run_list)} failed groups")
     logger.info("multilayer_preprocess_tod is done")
 


### PR DESCRIPTION
Addresses #1323.

Replacement for #1346 since the preprocessing infrastructure changed and the code could be simplified.  This allows passing in an unrestricted preprocessing axis manager into the pipeline run function so that the total number of detectors is preserved when running the multiple layers as opposed to the current implementation where the second layer only retains the number of detectors left after the first layer cuts.

Tested by running `preproc_or_load_group` with both layers and checking the dimensions of `proc_aman` prior to saving.  Also tested with multilayer_load_and_preprocess and confirmed both calls to `get_meta` return the full dimensions.