### PR TITLE
Modified view for compatibility with Toast Intervals

### DIFF
--- a/sotodlib/toast/ops/mlmapmaker.py
+++ b/sotodlib/toast/ops/mlmapmaker.py
@@ -420,7 +420,7 @@ class MLMapmaker(Operator):
              view_ranges = np.array(
                  [[x.first, x.last] for x in ob.intervals[self.view]]
              )
-             ranges += so3g.proj.ranges.Ranges.from_array(view_ranges, nsample)
+             ranges += so3g.proj.ranges.Ranges.from_array(view_ranges.astype(np.int32), nsample)
 
         # Convert the focalplane offsets into the expected form
         det_to_row = {y["name"]: x for x, y in enumerate(fp.detector_data)}


### PR DESCRIPTION
On sotodlib/toast/ops/mlmapmaker.py

An error is raised when trying to set the view trait in the ML_mapmaker, because TOAST intervals bounds are given by np.int64 when [https://github.com/hpc4cmb/toast/blob/7420a315d9145f1e642b207c52db83e9cfec2ab3/src/toast/intervals.py#L28](url) when buffer 'src' is expected to contain items of type int32.