### PR TITLE
Rename NET to noise for qa

### DIFF
--- a/sotodlib/qa/metrics.py
+++ b/sotodlib/qa/metrics.py
@@ -255,8 +255,9 @@ class PreprocessValidDets(PreprocessQA):
 
 
 # inherit from PreprocessQA to reuse available_obs method
-class PreprocessArrayNEP(PreprocessQA):
-    """Generate a QA metric for array NEP values for each wafer slot and bandpass.
+class PreprocessArrayNoise(PreprocessQA):
+    """Generate a QA metric for array Noise (usually NEP) values
+    for each wafer slot and bandpass.
 
     The config entry supports a `process_args` block where the following
     options can be specified:
@@ -273,7 +274,7 @@ class PreprocessArrayNEP(PreprocessQA):
     """
 
     _influx_meas = "preprocesstod"
-    _influx_field = "array_nep"
+    _influx_field = "array_noise"
 
     def __init__(
         self,
@@ -335,9 +336,9 @@ class PreprocessArrayNEP(PreprocessQA):
         }
 
 # inherit from PreprocessQA to reuse available_obs method
-class PreprocessDetNEP(PreprocessQA):
-    """Generate a QA metric for per detector NEP values for each wafer slot
-    and bandpass.
+class PreprocessDetNoise(PreprocessQA):
+    """Generate a QA metric for per detector noise (usually NEP) values
+    for each wafer slot and bandpass.
 
     The config entry supports a `process_args` block where the following
     options can be specified:
@@ -354,7 +355,7 @@ class PreprocessDetNEP(PreprocessQA):
     """
 
     _influx_meas = "preprocesstod"
-    _influx_field = "det_nep"
+    _influx_field = "det_noise"
 
     def __init__(
         self,


### PR DESCRIPTION
Since the preprocessing could be calibrated this just renames the metrics NET fields to noise to be most general.