### PR TITLE
Preprocess jobdb fixes

### DIFF
--- a/sotodlib/preprocess/preprocess_util.py
+++ b/sotodlib/preprocess/preprocess_util.py
@@ -150,7 +150,9 @@ def filter_preproc_runlist_by_jobdb(jdb, jclass, db, run_list, group_by,
                 with jdb.locked(job) as j:
                     if overwrite == True:
                         j.jstate = "open"
-                        j.tags["error"] = None
+                        for _t in j._tags:
+                            if _t.key == "error":
+                                _t.value = None
             else:
                 if job.jstate == JState.done:
                     done += 1

--- a/sotodlib/site_pipeline/multilayer_preprocess_tod.py
+++ b/sotodlib/site_pipeline/multilayer_preprocess_tod.py
@@ -104,8 +104,8 @@ def _check_init_jobdb(
 
     Arguments
     ----------
-    jdb : JobDB
-        JobDB instance.
+    jdb : JobManager
+        A preprocesing jobdb.
     init_db : ManifestDb or None
         Init preproc database.
     init_jobs_map : dict


### PR DESCRIPTION
Fixes preprocessing `jobdb` tag handing when overwrite is `True` and some small docstring fixes.

Also, adds a short helper function to reopen jobs that failed with a particular `PreprocessError` string.  This is useful when running a large job and some fail due to a temporary failure (metadata, locked db, etc) and you want to re-run just those.