### PR TITLE
gamma from wiregrid

### DIFF
--- a/sotodlib/preprocess/preprocess_util.py
+++ b/sotodlib/preprocess/preprocess_util.py
@@ -738,7 +738,8 @@ def multilayer_load_and_preprocess_sim(obs_id, configs_init, configs_proc,
             # One needs to correct HWP model and gamma
             # before loading in the simulated map
             aman = hwp_angle_model.apply_hwp_angle_model(aman)
-            if hasattr(aman.det_info, "wiregrid_cal"):
+            if "wiregrid_cal" in aman.det_info:
+                logger.info(f"gamma from wiregrid_cal")
                 aman.move(
                     name="det_info.wiregrid_cal.gamma",
                     new_name="focal_plane.gamma"


### PR DESCRIPTION
This PR modifies `preprocess_util.multilayer_load_and_preprocess_sim` to load `focal_plane.gamma` from `wiregrid_cal` before loading any simulated TOD into the `AxisManager`.