### PR TITLE
Change sotodlib installation to include all dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Install sotodlib
         run: |
-          python3 -m pip install -vv .[site_pipeline,test]
+          python3 -m pip install -vv .[site_pipeline,tests]
 
       - name: Run Serial Tests
         run: |


### PR DESCRIPTION
This forces pip to install all possible optional dependencies for the github action workflow.

