### PR TITLE
Allow ufm selection in update_det_match

### DIFF
--- a/sotodlib/site_pipeline/update_det_match.py
+++ b/sotodlib/site_pipeline/update_det_match.py
@@ -134,6 +134,9 @@ class UpdateDetMatchesConfig:
             if self.resonator_set_dir is None:
                 raise ValueError("Must specify resonator_set_dir for solution_type='resonator_set'")
 
+        if self.ufms is not None:
+            self.ufms = [u.lower() for u in self.ufms]
+
 
 class Runner:
     def __init__(self, cfg: UpdateDetMatchesConfig):


### PR DESCRIPTION
In order to prevent failures from new ufms being added that do not currently have `detmatch_solutions`, this adds an optional list input to the `update_det_match` config that allows for only running `update_det_match` on the detsets that are from the specified ufms.  Other ufms will not be added to the missing obs_id list.