### PR TITLE
Move sodetlib to pyproject site_pipeline group

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -86,16 +86,11 @@ There are several optional dependencies that you may want to install depending
 on which features of sotodlib you would like to use. These provided via
 dependency groups and can be installed using the syntax from your source checkout::
 
-    %> pip install -r requirements.txt
     %> pip install .[group1,group2]
 
 Current groups are:
 
-- ``site_pipeline`` - Modules required within ``sotodlib.site_pipeline``. Please install the required dependencies using the command from your source checkout::
-
-    %> pip install -r requirements.txt
-    %> pip install .[site_pipeline]
-
+- ``site_pipeline`` - Modules required within ``sotodlib.site_pipeline``.
 
 Running Tests
 ------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ classifiers = [
 site_pipeline = [
   "influxdb",
   "venn",
+  "sodetlib",
   "let-me-scroll-it",
   "plotly",
   "pandas",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-
-sodetlib @ git+https://github.com/simonsobs/sodetlib


### PR DESCRIPTION
sodetlib is now [published to PyPI](https://pypi.org/project/sodetlib/), so we don't need to install via VCS in the `requirements.txt` file anymore. The rest of this essentially undoes https://github.com/simonsobs/sotodlib/pull/1342.

I have not tested this beyond doing a local installation of it via:
```
$ python -m pip install --no-cache-dir .[site_pipeline]
```

and verifying it installs `sodetlib`:
```
$ pip freeze
alphashape==1.3.1
annotated-types==0.7.0
asteval==1.0.8
astropy==7.2.0
astropy-iers-data==0.2026.2.9.0.50.33
certifi==2026.1.4
charset-normalizer==3.4.4
click==8.3.1
click-log==0.4.0
contourpy==1.3.3
cycler==0.12.1
dill==0.4.1
ducc0==0.40.0
ephem==4.2
flacarray==0.3.4
fonttools==4.61.1
gitdb==4.0.12
GitPython==3.1.46
greenlet==3.3.1
h5py==3.15.1
healpy==1.19.0
idna==3.11
ImageIO==2.37.2
influxdb==5.3.2
iniconfig==2.3.0
Jinja2==3.1.6
jplephem==2.24
kiwisolver==1.4.9
lazy_loader==0.4
let-me-scroll-it==0.0.5
llvmlite==0.46.0
lmfit==1.3.4
MarkupSafe==3.0.3
matplotlib==3.10.8
mpmath==1.3.0
msgpack==1.1.2
narwhals==2.16.0
networkx==3.6.1
numba==0.63.1
numdifftools==0.9.42
numpy==2.3.5
numpy-quaternion==2024.0.13
packaging==26.0
pandas==3.0.0
pillow==12.1.0
pixell==0.31.7
plotly==6.5.2
pluggy==1.6.0
psycopg2-binary==2.9.11
pyaml==26.2.1
pydantic==2.12.5
pydantic_core==2.41.5
pyerfa==2.0.1.5
pyFFTW==0.15.1
Pygments==2.19.2
pyparsing==3.3.2
pytest==9.0.2
python-dateutil==2.9.0.post0
pytz==2025.2
PyYAML==6.0.3
qpoint==1.13.0
quaternionarray==0.6.2
requests==2.32.5
rtree==1.4.1
scikit-image==0.26.0
scipy==1.17.0
sgp4==2.25
shapely==2.1.2
six==1.17.0
skyfield==1.54
slack_sdk==3.39.0
smmap==5.0.2
so3g==0.2.5
sodetlib==0.6.3
sotodlib @ file:///home/koopman/git/sotodlib
SQLAlchemy==2.0.46
sympy==1.14.0
tifffile==2026.1.28
toml==0.10.2
tqdm==4.67.3
trimesh==4.11.2
typing-inspection==0.4.2
typing_extensions==4.15.0
uncertainties==3.2.3
unyt==3.1.0
urllib3==2.6.3
venn==0.1.3
```