### PR TITLE
fix unused name argument of smurfgaps_flags

### DIFF
--- a/sotodlib/tod_ops/flags.py
+++ b/sotodlib/tod_ops/flags.py
@@ -1174,7 +1174,7 @@ def expand_smurfgaps_flags(aman, buffer=200, name='smurfgaps', merge=True):
     if buffer:
         smurfgaps = smurfgaps.buffer(buffer)
     if merge:
-        aman.flags.wrap('smurfgaps', smurfgaps, [(0, 'dets'), (1, 'samps')])
+        aman.flags.wrap(name, smurfgaps, [(0, 'dets'), (1, 'samps')])
     return smurfgaps
 
 def get_good_distribution_flags(aman, param_name='wn_signal',


### PR DESCRIPTION
This resolves https://github.com/simonsobs/sotodlib/issues/1554
I fixed to properly use name argument instead of deleting it so that I won't break someone's config. For example this argument is used in isov4 config.