### PR TITLE
When loading data into toast in DAQ units, round before truncation.

### DIFF
--- a/sotodlib/toast/ops/load_context.py
+++ b/sotodlib/toast/ops/load_context.py
@@ -1144,7 +1144,6 @@ class LoadContext(Operator):
             ignore_preprocess_archive=self.ignore_preprocess_archive,
             context=self.context,
             context_file=self.context_file,
-            daq_units=self.daq_units,
         )
 
         log.debug_rank(


### PR DESCRIPTION
Also centralize this conversion to a single place in the code when the detector data is communicated.