### PR TITLE
update_det_cal: Add another transient error

### DIFF
--- a/sotodlib/site_pipeline/update_det_cal.py
+++ b/sotodlib/site_pipeline/update_det_cal.py
@@ -799,6 +799,17 @@ def get_obsids_to_run(cfg: DetCalCfg) -> List[str]:
 def add_to_failed_cache(cfg: DetCalCfg, obs_id: str, msg: str) -> None:
     if "KeyboardInterrupt" in msg:  # Don't cache keyboard interrupts
         return
+    # Transient errors of metadata loading.
+    # These can happen when hwpss_subtraction is True, but we can retry.
+    transient_errors = [
+        'sotodlib.core.metadata.loader.LoaderError',
+        'BlockingIOError',
+    ]
+    for err in transient_errors:
+        if err in msg:
+            logger.error(f"obs_id {obs_id} failed to load metadata {err}."
+                         " Try again later")
+            return
 
     if cfg.cache_failed_obsids:
         logger.info(f"Adding {obs_id} to failed_file_cache")
@@ -825,10 +836,6 @@ def handle_result(result: CalRessetResult, cfg: DetCalCfg) -> None:
         msg = result.fail_msg
         if msg is None:
             msg = "unknown error"
-        if 'sotodlib.core.metadata.loader.LoaderError' in msg:
-            logger.error(f"obs_id {obs_id} failed due to medatada loader "
-                         "error, try again later")
-            return
         add_to_failed_cache(cfg, obs_id, msg)
         return
 


### PR DESCRIPTION
Some observations of satpX_det_cal_260217m failed due to BlockingIOError.
This occurs only when hwpss_subtraction is set to True, most likely due to race conditions in the site_pipelines.
In this case, the update_det_cal should retry.

This PR adds BlockingIOError as another transient error to retry.

For example, in satp1, following observations failed.
obs_1773365885_satp1_1111111
obs_1774335307_satp1_1111111
obs_1774351938_satp1_1111111
obs_1774441565_satp1_1111111
obs_1774512567_satp1_1111111
```
obs_1774335307_satp1_1111111: "Traceback (most recent call last):\n  File \"/usr/local/lib/python3.12/site-packages/sotodlib/site_pipeline/update_det_cal.py\"\
  , line 609, in get_cal_resset\n    load_and_reanalyze_bs(bsa, ctx, oid)\n  File\
  \ \"/usr/local/lib/python3.12/site-packages/sotodlib/site_pipeline/update_det_cal.py\"\
  , line 531, in load_and_reanalyze_bs\n    am = ctx.get_obs(obs_id, special_channels=True,\
  \ reindex_dets=True)\n         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n\
  \  File \"/usr/local/lib/python3.12/site-packages/sotodlib/core/context.py\", line\
  \ 294, in get_obs\n    meta = self.get_meta(obs_id=obs_id, dets=dets, samples=samples,\n\
  \           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"\
  /usr/local/lib/python3.12/site-packages/sotodlib/core/context.py\", line 583, in\
  \ get_meta\n    meta = self.loader.load(metadata_list, request, det_info=det_info,\
  \ check=check,\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n\
  \  File \"/usr/local/lib/python3.12/site-packages/sotodlib/core/metadata/loader.py\"\
  , line 480, in load\n    reraise(_spec, e)\n  File \"/usr/local/lib/python3.12/site-packages/sotodlib/core/metadata/loader.py\"\
  , line 406, in reraise\n    raise e\n  File \"/usr/local/lib/python3.12/site-packages/sotodlib/core/metadata/loader.py\"\
  , line 471, in load\n    item = self.load_one(spec, aug_request, det_info)\n   \
  \        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/usr/local/lib/python3.12/site-packages/sotodlib/core/metadata/loader.py\"\
  , line 262, in load_one\n    mi1 = loader_object.from_loadspec(index_line, **loader_kwargs)\n\
  \          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/usr/local/lib/python3.12/site-packages/sotodlib/io/metadata.py\"\
  , line 94, in from_loadspec\n    with h5py.File(load_params['filename'], mode='r')\
  \ as fin:\n         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/usr/local/lib/python3.12/site-packages/h5py/_hl/files.py\"\
  , line 555, in __init__\n    fid = make_fid(name, mode, userblock_size, fapl, fcpl,\
  \ swmr=swmr)\n          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n\
  \  File \"/usr/local/lib/python3.12/site-packages/h5py/_hl/files.py\", line 232,\
  \ in make_fid\n    fid = h5f.open(name, flags, fapl=fapl)\n          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n\
  \  File \"h5py/_objects.pyx\", line 54, in h5py._objects.with_phil.wrapper\n  File\
  \ \"h5py/_objects.pyx\", line 55, in h5py._objects.with_phil.wrapper\n  File \"\
  h5py/h5f.pyx\", line 106, in h5py.h5f.open\nBlockingIOError: [Errno 11] Unable to\
  \ synchronously open file (unable to lock file, errno = 11, error message = 'Resource\
  \ temporarily unavailable')\n"
```