### PR TITLE
Fix interpolate method of azss model

### DIFF
--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -1373,8 +1373,8 @@ class AzSS(_Preprocess):
     def select(self, meta, proc_aman=None, in_place=True):
         if self.select_cfgs is None:
             return meta
-        if 'bad_dets' in meta[self.azss_stats_name]:
-            keep = ~meta[self.azss_stats_name]['bad_dets']
+        if 'bad_dets' in meta[self.save_name]:
+            keep = ~meta[self.save_name]['bad_dets']
         else:
             keep = np.ones(aman.dets.count, dtype=bool)
         

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -1369,15 +1369,17 @@ class AzSS(_Preprocess):
         else:
             tod_ops.azss.get_azss(aman, **self.calc_cfgs)
         return aman, proc_aman
-    
+
     def select(self, meta, proc_aman=None, in_place=True):
         if self.select_cfgs is None:
             return meta
-        if 'bad_dets' in meta[self.save_name]:
-            keep = ~meta[self.save_name]['bad_dets']
+        if proc_aman is None:
+            proc_aman = meta.preprocess
+        if 'bad_dets' in proc_aman[self.save_name]:
+            keep = ~proc_aman[self.save_name]['bad_dets']
         else:
-            keep = np.ones(aman.dets.count, dtype=bool)
-        
+            keep = np.ones(meta.dets.count, dtype=bool)
+
         if in_place:
             meta.restrict("dets", meta.dets.vals[keep])
             return meta

--- a/sotodlib/tod_ops/azss.py
+++ b/sotodlib/tod_ops/azss.py
@@ -261,6 +261,7 @@ def get_azss(aman, signal='signal', az=None, azrange=None, bins=100, flags=None,
         - azss_stats: core.AxisManager
             - azss statistics including: azumith bin centers, bin counts, binned signal, std of each detector-az bin, std of each detector.
             - If ``method=fit`` then also includes: binned legendre model, legendre bin centers, fit coefficients, reduced chi2.
+            - If ``return_det_mask=True`` then also includes: bad_dets, coverages.
         - model_sig_tod: numpy.array
             - azss model as a function of time either from fits or interpolation depending on ``method`` argument.
     """
@@ -353,8 +354,6 @@ def get_azss_model(aman, azss_stats, az=None, method='interpolate',
     -------
     model: array-like
         AZSS model for each detector
-    good_dets_mask: array-like (optional)
-        Boolean mask of detectors with sufficient coverage (if return_det_mask=True)
     """
     if az is None:
         az = aman.boresight.az

--- a/sotodlib/tod_ops/azss.py
+++ b/sotodlib/tod_ops/azss.py
@@ -365,18 +365,22 @@ def get_azss_model(aman, azss_stats, az=None, method='interpolate',
         model = fit_azss(az=az, azss_stats=azss_stats, max_mode=max_mode, fit_range=azrange)
 
     if method == 'interpolate':
+        model = np.zeros((aman.dets.count, aman.samps.count))
         if 'bad_dets' in azss_stats:
-            model = np.zeros((aman.dets.count, aman.samps.count))
             valid_dets = ~azss_stats['bad_dets']
-            if sum(valid_dets) != 0:
-                mask = ~np.any(np.isnan(azss_stats.binned_signal[valid_dets, :]), axis=0)
-                f_template = interp1d(azss_stats.binned_az[mask], azss_stats.binned_signal[:, mask][valid_dets, :], fill_value='extrapolate')
-                model[valid_dets, :] = f_template(az)
         else:
-            # mask az bins that has no data
-            mask = ~np.any(np.isnan(azss_stats.binned_signal), axis=0)
-            f_template = interp1d(azss_stats.binned_az[mask], azss_stats.binned_signal[:, mask], fill_value='extrapolate')
-            model = f_template(az)
+            valid_dets = np.ones(aman.dets.count, dtype=bool)
+
+        mask = ~np.isnan(azss_stats.binned_signal[valid_dets, :])
+        is_uniform = np.all(mask == mask[0, :])
+        if is_uniform:
+            m = mask[0, :]
+            f_template = interp1d(azss_stats.binned_az[m], azss_stats.binned_signal[:, m][valid_dets, :], fill_value='extrapolate')
+            model[valid_dets, :] = f_template(az)
+        else:
+            for i, (m, binned_signal) in enumerate(zip(mask, azss_stats.binned_signal[valid_dets, :])):
+                f_template = interp1d(azss_stats.binned_az[m], binned_signal[m], fill_value='extrapolate')
+                model[valid_dets, :][i] = f_template(az)
 
     if np.any(~np.isfinite(model)):
         logger.warning('azss model has nan. set zero to nan but this may make glitch')

--- a/sotodlib/tod_ops/azss.py
+++ b/sotodlib/tod_ops/azss.py
@@ -369,6 +369,9 @@ def get_azss_model(aman, azss_stats, az=None, method='interpolate',
             valid_dets = ~azss_stats['bad_dets']
         else:
             valid_dets = np.ones(aman.dets.count, dtype=bool)
+        if sum(valid_dets) == 0:
+            logger.info('All the detectors have low az coverage and cannot make model')
+            return model
 
         mask = ~np.isnan(azss_stats.binned_signal[valid_dets, :])
         is_uniform = np.all(mask == mask[0, :])

--- a/sotodlib/tod_ops/azss.py
+++ b/sotodlib/tod_ops/azss.py
@@ -365,10 +365,18 @@ def get_azss_model(aman, azss_stats, az=None, method='interpolate',
         model = fit_azss(az=az, azss_stats=azss_stats, max_mode=max_mode, fit_range=azrange)
 
     if method == 'interpolate':
-        # mask az bins that has no data and extrapolate
-        mask = ~np.any(np.isnan(azss_stats.binned_signal), axis=0)
-        f_template = interp1d(azss_stats.binned_az[mask], azss_stats.binned_signal[:, mask], fill_value='extrapolate')
-        model = f_template(az)
+        if 'bad_dets' in azss_stats:
+            model = np.zeros((aman.dets.count, aman.samps.count))
+            valid_dets = ~azss_stats['bad_dets']
+            if sum(valid_dets) != 0:
+                mask = ~np.any(np.isnan(azss_stats.binned_signal[valid_dets, :]), axis=0)
+                f_template = interp1d(azss_stats.binned_az[mask], azss_stats.binned_signal[:, mask][valid_dets, :], fill_value='extrapolate')
+                model[valid_dets, :] = f_template(az)
+        else:
+            # mask az bins that has no data
+            mask = ~np.any(np.isnan(azss_stats.binned_signal), axis=0)
+            f_template = interp1d(azss_stats.binned_az[mask], azss_stats.binned_signal[:, mask], fill_value='extrapolate')
+            model = f_template(az)
 
     if np.any(~np.isfinite(model)):
         logger.warning('azss model has nan. set zero to nan but this may make glitch')

--- a/tests/test_azss.py
+++ b/tests/test_azss.py
@@ -11,6 +11,7 @@ from numpy.polynomial import legendre as L
 
 from sotodlib import core
 from sotodlib.tod_ops import azss
+from so3g.proj import RangesMatrix
 
 
 def get_scan(n_scans=33, scan_accel=0.025, scanrate=0.025,
@@ -61,7 +62,7 @@ def make_fake_azss_tod(max_mode=20, noise_amp=1, n_scans=10,
     az_min, az_max = np.min(azpoint), np.max(azpoint)
     x = ( 2*azpoint - (az_min+az_max) ) / (az_max - az_min)
 
-    fake_signal = np.zeros((ndets, len(ts)))
+    fake_signal = np.zeros((ndets, len(ts)), dtype='float32')
     if input_coeffs is None:
         input_coeffs = np.random.uniform(-10, 11, size=(ndets, max_mode+1))
     for nd in range(ndets):
@@ -85,6 +86,7 @@ def make_fake_azss_tod(max_mode=20, noise_amp=1, n_scans=10,
                   axis_map=[(0, 'dets'), (1, 'samps')])
     tod_fake.wrap('input_coeffs', np.atleast_2d(input_coeffs),
                   axis_map=[(0, 'dets'), (1, 'modes')])
+    tod_fake.wrap('flags', core.AxisManager())
     return tod_fake
 
 
@@ -104,10 +106,59 @@ class AzssTest(unittest.TestCase):
     def test_fit(self):
         max_mode = 10
         tod = make_fake_azss_tod(noise_amp=0, n_scans=50, max_mode=max_mode)
-        azss_stats, model_sig_tod = azss.get_azss(tod, method='fit', max_mode=max_mode, azrange=None, bins=100)
+        azss_stats, model_sig_tod = azss.get_azss(
+            tod,
+            method='fit',
+            max_mode=max_mode,
+            azrange=None,
+            bins=100
+        )
         ommedian = get_coeff_metric(tod)
         print(ommedian)
         self.assertTrue(ommedian < 5.0)
+        self.assertTrue(~np.any(np.isnan(tod.signal)))
+        self.assertTrue(np.std(tod.signal) > np.std(tod.signal - model_sig_tod))
+
+    def test_interpolate(self):
+        """
+        Test the interpolation method of Azimuth Synchronous Signal subtraction.
+        """
+        max_mode = 10
+        tod = make_fake_azss_tod(noise_amp=0, n_scans=50, max_mode=max_mode)
+
+        azss_stats, model_sig_tod = azss.get_azss(
+            tod,
+            method='interpolate',
+            azrange=None,
+            bins=100,
+        )
+        self.assertTrue(~np.any(np.isnan(tod.signal)))
+        self.assertTrue(np.std(tod.signal) > np.std(tod.signal - model_sig_tod))
+
+    def test_interpolate_with_flags(self):
+        """
+        Test the interpolation method of Azimuth Synchronous Signal subtraction
+        with flags.
+        """
+        max_mode = 10
+        tod = make_fake_azss_tod(noise_amp=0, n_scans=50, max_mode=max_mode)
+
+        mask = np.zeros((tod.dets.count, tod.samps.count), dtype=bool)
+        mask[-1, :] = True  # one detector has low az coverage
+        flags = RangesMatrix.from_mask(mask)
+
+        azss_stats, model_sig_tod = azss.get_azss(
+            tod,
+            method='interpolate',
+            azrange=None,
+            bins=100,
+            flags=flags,
+            return_det_mask=True,
+            exclude_turnarounds=False,
+        )
+        self.assertTrue(~np.any(np.isnan(tod.signal)))
+        self.assertTrue(np.std(tod.signal) > np.std(tod.signal - model_sig_tod))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR fixes the error of azss interpolation.
When there are some detectors with very low azimuth coverage, the interpolation of azss was completely failing.

We modified the get_azss_model to use the flag of _check_azimuth_coverage to avoid this interpolation error.
_check_azimuth_coverage was implemented but it has not been used properly so far.
Also changed that the azimuth interpolation range can be different between detectors. Previously the azimuth interpolation range was smaller than optimal. 
We tested this on 200 satp1 observations as part of isov4 test.

Example of error.
```
/scratch/gpfs/SIMONSOBS/env/v0.6.8/soconda_v0.6.8/lib/python3.12/site-packages/numpy/lib/_nanfunctions_impl.py:1217: RuntimeWarning: All-NaN slice encountered
  return fnb._ureduce(a, func=_nanmedian, keepdims=keepdims,
  48.577: Pipeline Run Error for obs_1743676089_satp1_1111111: [np.str_('ws2'), np.str_('f150')]
<class 'ValueError'>: cannot reshape array of size 0 into shape (0,newaxis)
  File "/home/er5768/.local/soconda_v0.6.8/lib/python3.12/site-packages/sotodlib/preprocess/preprocess_util.py", line 1406, in preproc_or_load_group
    proc_aman, success = pipe_proc.run(aman)
                         ^^^^^^^^^^^^^^^^^^^
  File "/home/er5768/.local/soconda_v0.6.8/lib/python3.12/site-packages/sotodlib/preprocess/pcore.py", line 552, in run
    process.process(aman, proc_aman, sim, data_aman)
  File "/home/er5768/.local/soconda_v0.6.8/lib/python3.12/site-packages/sotodlib/preprocess/processes.py", line 1368, in process
    tod_ops.azss.get_azss(aman, subtract_in_place=True, **self.calc_cfgs)
  File "/home/er5768/.local/soconda_v0.6.8/lib/python3.12/site-packages/sotodlib/tod_ops/azss.py", line 321, in get_azss
    model_sig_tod = get_azss_model(aman, azss_stats, az, method, max_mode, azrange)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/er5768/.local/soconda_v0.6.8/lib/python3.12/site-packages/sotodlib/tod_ops/azss.py", line 370, in get_azss_model
    f_template = interp1d(azss_stats.binned_az[mask], azss_stats.binned_signal[:, mask], fill_value='extrapolate')
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/scratch/gpfs/SIMONSOBS/env/v0.6.8/soconda_v0.6.8/lib/python3.12/site-packages/scipy/interpolate/_interpolate.py", line 329, in __init__
    self._y = self._reshape_yi(self.y)
              ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/scratch/gpfs/SIMONSOBS/env/v0.6.8/soconda_v0.6.8/lib/python3.12/site-packages/scipy/interpolate/_polyint.py", line 114, in _reshape_yi
    return yi.reshape((yi.shape[0], -1))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```