### PR TITLE
TOAST mlmapmaker: Fix MPI hangs 

### DIFF
--- a/sotodlib/toast/ops/mlmapmaker.py
+++ b/sotodlib/toast/ops/mlmapmaker.py
@@ -637,10 +637,8 @@ class MLMapmaker(Operator):
     @function_timer
     def _exec(self, data, detectors=None, **kwargs):
         log = Logger.get()
-        timer = Timer()
         comm = data.comm.comm_world
         gcomm = data.comm.comm_group
-        timer.start()
 
         if self.write_div == 'all':
             self.write_div = self.comps
@@ -714,6 +712,8 @@ class MLMapmaker(Operator):
 
         for ipass, passinfo in enumerate(passes):
             # The multipass mapmaking loop
+            timer = Timer()
+            timer.start()
             log.info_rank(
                 f"Starting pass {ipass + 1}/{npass}, maxit={passinfo.maxiter} "
                 f"down={passinfo.downsample}, interp={passinfo.interpol}",
@@ -780,7 +780,7 @@ class MLMapmaker(Operator):
             if comm is not None:
                 comm.barrier()
             log.info_rank(
-                f"MLMapmaker wrapped observations in",
+                f"MLMapmaker wrapped observations and built noise models in",
                 comm=comm,
                 timer=timer,
             )

--- a/sotodlib/toast/ops/mlmapmaker.py
+++ b/sotodlib/toast/ops/mlmapmaker.py
@@ -392,11 +392,8 @@ class MLMapmaker(Operator):
         return
 
     @function_timer
-    def _wrap_obs(self, ob, dets, passinfo, comm):
+    def _wrap_obs(self, ob, dets, passinfo):
         """ Prepare data for the mapmaker """
-        log = Logger.get()
-        timer = Timer()
-        timer.start()
 
         # Get the focalplane for this observation
         fp = ob.telescope.focalplane
@@ -489,11 +486,6 @@ class MLMapmaker(Operator):
         # >>> tod.boresight
         # AxisManager(az[samps], el[samps], roll[samps], samps:OffsetAxis(372680))
 
-        log.info_rank(
-            f"MLMapmaker wrapped observations in",
-            comm=comm,
-            timer=timer,
-        )
         return axobs
 
     @function_timer
@@ -761,7 +753,7 @@ class MLMapmaker(Operator):
                 nmat, nmat_file = self._load_noise_model(ob, npass, ipass, gcomm)
 
                 # wrap_obs finishes in line 250 of make_ml_map.py, at the downsampling
-                axobs = self._wrap_obs(ob, dets, passinfo, comm)
+                axobs = self._wrap_obs(ob, dets, passinfo)
 
                 if ipass > 0:
                     # Evaluate the final model of the previous pass' mapmaker
@@ -787,6 +779,11 @@ class MLMapmaker(Operator):
 
             if comm is not None:
                 comm.barrier()
+            log.info_rank(
+                f"MLMapmaker wrapped observations in",
+                comm=comm,
+                timer=timer,
+            )
 
             # _init_mapmaker covers lines 293-303 of make_ml_map.py
             x0 = self._init_mapmaker(


### PR DESCRIPTION
Revert the previous commit that causes MPI hanging up. And re-fix the timing log.