### PR TITLE
Remove source_flags cut

### DIFF
--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -1945,7 +1945,6 @@ class SourceFlags(_Preprocess):
 
         if in_place:
             meta.restrict("dets", meta.dets.vals[keep_all])
-            source_flags.restrict("dets", source_flags.dets.vals[keep_all])
             return meta
         else:
             return keep_all


### PR DESCRIPTION
Removes an unneeded source flags cut that will cause a crash if all detectors are removed.