### PR TITLE
Fix D1 mapmaker config create bug

### DIFF
--- a/sotodlib/site_pipeline/make_depth1_map.py
+++ b/sotodlib/site_pipeline/make_depth1_map.py
@@ -103,7 +103,7 @@ def get_parser(parser=None):
     )
     parser.add_argument("--pretend-now-is",
         type=str,
-        help='Change current time for running with update-delay. In format %Y-%m-%d %H:%M:%S',
+        help='Change current time for running with update-delay. In format %%Y-%%m-%%d %%H:%%M:%%S',
     )
     return parser
 

--- a/sotodlib/site_pipeline/utils/depth1_utils.py
+++ b/sotodlib/site_pipeline/utils/depth1_utils.py
@@ -389,15 +389,17 @@ def calibrate_obs(
 
 
 def create_mapmaker_config(
-    defaults: dict = DEPTH1MAPMAKER_DEFAULTS, config_file: Optional[str] = None, **args
+    defaults: dict = DEPTH1MAPMAKER_DEFAULTS, config_file: Optional[str] = None, args: dict = dict()
 ) -> dict:
 
     config = dict(defaults)
-    # Merge flags from config file and defaults with any passed through CLI
+    
+    # Apply CLI args on top of defaults
     config.update({k: v for k, v in args.items() if v is not None})
-    # Update the default dict with values provided from a config.yaml file
+    # Config file takes highest priority, overriding both defaults and CLI args
     if config_file is not None:
         config_from_file = _get_config(config_file)
+        print(config_from_file)
         config.update({k: v for k, v in config_from_file.items() if v is not None})
     else:
         print("No config file provided, assuming default values")
@@ -410,7 +412,9 @@ def create_mapmaker_config(
             raise KeyError(
                 f"{req} is a required argument. Please supply it in a config file or via the command line"
             )
-
+    print("Using the following configuration for depth-1 mapmaking:")
+    for key, value in config.items():
+        print(f"  {key}: {value}")
     return config
 
 

--- a/sotodlib/site_pipeline/utils/depth1_utils.py
+++ b/sotodlib/site_pipeline/utils/depth1_utils.py
@@ -399,7 +399,6 @@ def create_mapmaker_config(
     # Config file takes highest priority, overriding both defaults and CLI args
     if config_file is not None:
         config_from_file = _get_config(config_file)
-        print(config_from_file)
         config.update({k: v for k, v in config_from_file.items() if v is not None})
     else:
         print("No config file provided, assuming default values")
@@ -412,9 +411,7 @@ def create_mapmaker_config(
             raise KeyError(
                 f"{req} is a required argument. Please supply it in a config file or via the command line"
             )
-    print("Using the following configuration for depth-1 mapmaking:")
-    for key, value in config.items():
-        print(f"  {key}: {value}")
+
     return config
 
 

--- a/sotodlib/site_pipeline/utils/depth1_utils.py
+++ b/sotodlib/site_pipeline/utils/depth1_utils.py
@@ -15,7 +15,7 @@ from sotodlib.site_pipeline.utils.config import _get_config
 from sotodlib.tod_ops import detrend_tod
 
 DEPTH1MAPMAKER_DEFAULTS = {
-    "query": "1",
+    "query": "type == 'obs' and subtype == 'cmb'",
     "odir": "./outputs",
     "comps": "T",
     "ntod": None,
@@ -45,6 +45,9 @@ DEPTH1MAPMAKER_DEFAULTS = {
     "mapcat_database_name": "mapcat.db",
     "mapcat_depth_one_parent": "./",
     "min_dets": 50,
+    "update_delay": None,
+    "min_dur": 300,
+    "pretend_now_is": None,
 }
 
 SENS_LIMITS = {

--- a/sotodlib/site_pipeline/utils/depth1_utils.py
+++ b/sotodlib/site_pipeline/utils/depth1_utils.py
@@ -15,7 +15,7 @@ from sotodlib.site_pipeline.utils.config import _get_config
 from sotodlib.tod_ops import detrend_tod
 
 DEPTH1MAPMAKER_DEFAULTS = {
-    "query": "type == 'obs' and subtype == 'cmb'",
+    "query": "1",
     "odir": "./outputs",
     "comps": "T",
     "ntod": None,
@@ -45,9 +45,6 @@ DEPTH1MAPMAKER_DEFAULTS = {
     "mapcat_database_name": "mapcat.db",
     "mapcat_depth_one_parent": "./",
     "min_dets": 50,
-    "update_delay": None,
-    "min_dur": 300,
-    "pretend_now_is": None,
 }
 
 SENS_LIMITS = {
@@ -393,7 +390,8 @@ def create_mapmaker_config(
 ) -> dict:
 
     config = dict(defaults)
-
+    # Merge flags from config file and defaults with any passed through CLI
+    config.update({k: v for k, v in args.items() if v is not None})
     # Update the default dict with values provided from a config.yaml file
     if config_file is not None:
         config_from_file = _get_config(config_file)
@@ -401,9 +399,7 @@ def create_mapmaker_config(
     else:
         print("No config file provided, assuming default values")
 
-    # Merge flags from config file and defaults with any passed through CLI
-    config.update({k: v for k, v in args.items() if v is not None})
-
+    
     # Certain fields are required. Check if they are all supplied here
     required_fields = ["area", "context"]
     for req in required_fields:

--- a/sotodlib/site_pipeline/utils/depth1_utils.py
+++ b/sotodlib/site_pipeline/utils/depth1_utils.py
@@ -393,17 +393,17 @@ def create_mapmaker_config(
 ) -> dict:
 
     config = dict(defaults)
-    
-    # Apply CLI args on top of defaults
-    config.update({k: v for k, v in args.items() if v is not None})
-    # Config file takes highest priority, overriding both defaults and CLI args
+
+    # Update the default dict with values provided from a config.yaml file
     if config_file is not None:
         config_from_file = _get_config(config_file)
         config.update({k: v for k, v in config_from_file.items() if v is not None})
     else:
         print("No config file provided, assuming default values")
 
-    
+    # Merge flags from config file and defaults with any passed through CLI
+    config.update({k: v for k, v in args.items() if v is not None})
+
     # Certain fields are required. Check if they are all supplied here
     required_fields = ["area", "context"]
     for req in required_fields:

--- a/tests/test_depth1_utils.py
+++ b/tests/test_depth1_utils.py
@@ -17,7 +17,7 @@ class TestCreateMapmakerConfig(unittest.TestCase):
             create_mapmaker_config()
 
     def test_defaults(self):
-        config = create_mapmaker_config(area="a", context="c")
+        config = create_mapmaker_config(args={"area": "a", "context": "c"})
         for key, value in DEPTH1MAPMAKER_DEFAULTS.items():
             self.assertIn(key, config)
             self.assertEqual(config[key], value)
@@ -79,7 +79,7 @@ class TestCreateMapmakerConfig(unittest.TestCase):
             yaml.dump(file_config, f)
             fname = f.name
         try:
-            config = create_mapmaker_config(config_file=fname, preprocess_config="file2.yaml")
+            config = create_mapmaker_config(config_file=fname, args={"preprocess_config": "file2.yaml"})
             for key, value in file_config.items():
                 self.assertIn(key, config)
                 self.assertEqual(config[key], value)
@@ -113,10 +113,14 @@ class TestCreateMapmakerConfig(unittest.TestCase):
             yaml.dump(file_config, f)
             fname = f.name
         try:
-            config = create_mapmaker_config(config_file=fname, preprocess_config="file2.yaml")
+            config = create_mapmaker_config(config_file=fname, args={"preprocess_config": "file2.yaml"})
             for key, value in file_config.items():
+                if key == "preprocess_config":
+                    continue
                 self.assertIn(key, config)
                 self.assertEqual(config[key], value)
+            # args override config_file values
+            self.assertEqual(config["preprocess_config"], "file2.yaml")
         finally:
             os.unlink(fname)
 

--- a/tests/test_depth1_utils.py
+++ b/tests/test_depth1_utils.py
@@ -1,0 +1,125 @@
+import os
+import tempfile
+import unittest
+
+import yaml
+
+from sotodlib.site_pipeline.utils.depth1_utils import (
+    DEPTH1MAPMAKER_DEFAULTS,
+    create_mapmaker_config,
+)
+
+
+class TestCreateMapmakerConfig(unittest.TestCase):
+
+    def test_defaults_only_raises_without_required_fields(self):
+       with self.assertRaises(KeyError):
+            create_mapmaker_config()
+
+    def test_defaults(self):
+        config = create_mapmaker_config(area="a", context="c")
+        for key, value in DEPTH1MAPMAKER_DEFAULTS.items():
+            self.assertIn(key, config)
+            self.assertEqual(config[key], value)
+
+    def test_config_file(self):
+        file_config = {"query": "type == 'obs' and subtype == 'cmb' and tube_flavor == 'mf'",
+                       "context": "/so/metadata/lat/contexts/use_this.yaml",
+                       "area": "/so/site-pipeline/lat/maps/so_geometry_f090_lat.fits",
+                       "odir": "/so/site-pipeline/lat/maps/depth1/",
+                       "site": "so_lat",
+                       "preprocess_config": "/config/lat/preprocess_config_cmb_mf.yaml",
+                        "mapcat_database_name": '/so/site-pipeline/lat/maps/depth1/mapcat.sqlite',
+                        "mapcat_depth_one_parent": '/so/site-pipeline/lat/maps/depth1/',
+                        "srcsamp": '/so/site-pipeline/lat/srcsamp/srcsamp_mask.fits',
+                        "comps": 'T',
+                        "downsample": 2,
+                        "tiled": 1,
+                        "maxiter": 20,
+                        "verbose": True,
+                        "quiet": False,
+                        "tasks_per_group": 4,
+                        "unit": 'K',
+                        "update_delay": 2}
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".yaml", delete=False
+        ) as f:
+            yaml.dump(file_config, f)
+            fname = f.name
+        try:
+            config = create_mapmaker_config(config_file=fname)
+            for key, value in file_config.items():
+                self.assertIn(key, config)
+                self.assertEqual(config[key], value)
+        finally:
+            os.unlink(fname)
+
+    def test_kwargs_config_file(self):
+        file_config = {"query": "type == 'obs' and subtype == 'cmb' and tube_flavor == 'mf'",
+                "context": "/so/metadata/lat/contexts/use_this.yaml",
+                "area": "/so/site-pipeline/lat/maps/so_geometry_f090_lat.fits",
+                "odir": "/so/site-pipeline/lat/maps/depth1/",
+                "site": "so_lat",
+                "mapcat_database_name": '/so/site-pipeline/lat/maps/depth1/mapcat.sqlite',
+                "mapcat_depth_one_parent": '/so/site-pipeline/lat/maps/depth1/',
+                "srcsamp": '/so/site-pipeline/lat/srcsamp/srcsamp_mask.fits',
+                "comps": 'T',
+                "downsample": 2,
+                "tiled": 1,
+                "maxiter": 20,
+                "verbose": True,
+                "quiet": False,
+                "tasks_per_group": 4,
+                "unit": 'K',
+                "update_delay": 2}
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".yaml", delete=False
+        ) as f:
+            yaml.dump(file_config, f)
+            fname = f.name
+        try:
+            config = create_mapmaker_config(config_file=fname, preprocess_config="file2.yaml")
+            for key, value in file_config.items():
+                self.assertIn(key, config)
+                self.assertEqual(config[key], value)
+            self.assertEqual(config["preprocess_config"], "file2.yaml")
+        finally:
+            os.unlink(fname)
+
+    def test_config_file_override_kargs(self):
+        file_config = {"query": "type == 'obs' and subtype == 'cmb' and tube_flavor == 'mf'",
+                "context": "/so/metadata/lat/contexts/use_this.yaml",
+                "area": "/so/site-pipeline/lat/maps/so_geometry_f090_lat.fits",
+                "odir": "/so/site-pipeline/lat/maps/depth1/",
+                "site": "so_lat",
+                "preprocess_config": "/config/lat/preprocess_config_cmb_mf.yaml",
+                "mapcat_database_name": '/so/site-pipeline/lat/maps/depth1/mapcat.sqlite',
+                "mapcat_depth_one_parent": '/so/site-pipeline/lat/maps/depth1/',
+                "srcsamp": '/so/site-pipeline/lat/srcsamp/srcsamp_mask.fits',
+                "comps": 'T',
+                "downsample": 2,
+                "tiled": 1,
+                "maxiter": 20,
+                "verbose": True,
+                "quiet": False,
+                "tasks_per_group": 4,
+                "unit": 'K',
+                "update_delay": 2,
+                "preprocess_config": "file1.yaml"}
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".yaml", delete=False
+        ) as f:
+            yaml.dump(file_config, f)
+            fname = f.name
+        try:
+            config = create_mapmaker_config(config_file=fname, preprocess_config="file2.yaml")
+            for key, value in file_config.items():
+                self.assertIn(key, config)
+                self.assertEqual(config[key], value)
+        finally:
+            os.unlink(fname)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixed how the args from the arg parser are passed to the `create_mapmaker_config`

I also added a unit test to make sure that the functionality is correct and expected.