### PR TITLE
fix: verbosity error

### DIFF
--- a/sotodlib/preprocess/preprocess_util.py
+++ b/sotodlib/preprocess/preprocess_util.py
@@ -275,14 +275,14 @@ def init_logger(name, announce='', verbosity=2):
 
     logger = logging.getLogger(name)
 
-    if verbosity == 0:
-        level = logging.ERROR
-    elif verbosity == 1:
+    if verbosity == 1:
         level = logging.WARNING
     elif verbosity == 2:
         level = logging.INFO
     elif verbosity == 3:
         level = logging.DEBUG
+    else:
+        level = logging.ERROR
 
     # add handler only if it doesn't exist
     if len(logger.handlers) == 0:


### PR DESCRIPTION
The preprocessing `_main` passes a value of `None` for verbosity and this showed that the logger init was only inside `if` without and `else` clause.

This fixes that and makes `ERROR` as the default behavior of the logger.