### PR TITLE
Fix nmat

### DIFF
--- a/sotodlib/mapmaking/noise_model.py
+++ b/sotodlib/mapmaking/noise_model.py
@@ -111,6 +111,45 @@ class NmatUncorr(Nmat):
     def from_bunch(data):
         return NmatUncorr(spacing=data.spacing, nbin=data.nbin, nmin=data.nmin, bins=data.bins, ips_binned=data.ips_binned, ivar=data.ivar, window=data.window, nwin=data.nwin)
 
+class NmatDebug(Nmat):
+    def __init__(self, ivar=None, alpha=-3, fknee=2.5, profile=None, bsize=256, downweight=1):
+        self.bsize = bsize
+        self.ivar  = ivar
+        self.alpha = alpha
+        self.fknee = fknee
+        self.profile = profile
+        self.downweight = downweight
+        self.nwin  = 0
+        self.ready = ivar is not None
+    def build(self, tod, srate, **kwargs):
+        nsamp  = tod.shape[1]
+        nblock = nsamp//self.bsize
+        var    = np.median(np.var(tod[:,:nblock*self.bsize].reshape(-1,nblock,self.bsize),-1),-1)
+        with utils.nowarn():
+            ivar = utils.without_nan(1/var)*self.downweight
+        f = np.fft.rfftfreq(nsamp, 1/srate)
+        with utils.nowarn():
+            profile = 1/(1+(f/self.fknee)**self.alpha)
+        profile /= nsamp # fft normalization
+        return NmatDebug(ivar=ivar, alpha=self.alpha, fknee=self.fknee, bsize=self.bsize, profile=profile, downweight=self.downweight)
+    def apply(self, tod, inplace=True):
+        tod = self.white(tod, inplace=inplace)
+        ft  = np.empty((tod.shape[0],tod.shape[1]//2+1),utils.complex_dtype(tod.dtype))
+        fft.rfft(tod, ft)
+        ft *= self.profile
+        fft.irfft(ft, tod)
+        return tod
+    def white(self, tod, inplace=True, nwin=None):
+        if not inplace: tod = tod.copy()
+        tod *= self.ivar[:,None]
+        return tod
+    def write(self, fname):
+        self.check_ready()
+        data = bunch.Bunch(type="NmatDebug")
+        for field in ["ivar", "alpha", "fknee", "profile", "bsize", "downweight"]:
+            data[field] = getattr(self, field)
+        bunch.write(fname, data)
+
 class NmatDetvecs(Nmat):
     def __init__(self, bin_edges=None, eig_lim=16, single_lim=0.55, mode_bins=[0.25,4.0,20],
             downweight=[], window=2, nwin=None, verbose=False, bins=None,
@@ -174,7 +213,7 @@ class NmatDetvecs(Nmat):
             b = np.maximum(1,b)
             E[bi], D[bi], Nd[bi] = measure_detvecs(ftod[:,b[0]:b[1]], vecs)
         # Optionally downweight the lowest frequency bins
-        if self.downweight != None and len(self.downweight) > 0:
+        if self.downweight is not None and len(self.downweight) > 0:
             D[:len(self.downweight)] /= np.array(self.downweight)[:,None]
         # Instead of VEV' we can have just VV' if we bake sqrt(E) into V
         V = vecs[None]*E[:,None]**0.5
@@ -187,11 +226,10 @@ class NmatDetvecs(Nmat):
         # Also compute a representative white noise level
         bsize = bins[:,1]-bins[:,0]
         ivar  = np.sum(iD*bsize[:,None],0)/np.sum(bsize)
-        # What about units? I haven't applied any fourier unit factors so far,
-        # so we're in plain power units. From the uncorrelated model I found
-        # that factor of tod.shape[1] is needed
-        iD   *= nsamp
-        iV   *= nsamp**0.5
+        # I originally normalized iD and iV here, but then undid that normalization
+        # when actually applying the model. Let's just skip that
+        #iD   *= nsamp
+        #iV   *= nsamp**0.5
         ivar *= nsamp
         # Fix dtype
         bins = np.ascontiguousarray(bins.astype(np.int32))
@@ -221,11 +259,12 @@ class NmatDetvecs(Nmat):
             for bi, b in enumerate(self.bins):
                 # Want to multiply by iD + siViV'
                 ft    = ftod[:,b[0]:b[1]]
-                iD    = self.iD[bi]/nsamp
-                iV    = self.iV[bi]/nsamp**0.5
+                iD    = self.iD[bi] #/nsamp
+                iV    = self.iV[bi] #/nsamp**0.5
                 ft[:] = iD[:,None]*ft + self.s*iV.dot(iV.T.dot(ft))
         else:
-            so3g.nmat_detvecs_apply(ftod.view(dtype), self.bins, self.iD, self.iV, float(self.s), float(nsamp))
+            # using normalization 1 instead of nsamp, since I didn't multiply by nsamp earlier
+            so3g.nmat_detvecs_apply(ftod.view(dtype), self.bins, self.iD, self.iV, float(self.s), float(1))
         # I divided by the normalization above instead of passing normalize=True
         # here to reduce the number of operations needed
 
@@ -441,7 +480,7 @@ class NmatDetvecsDCT(Nmat):
             b = np.maximum(1,b)
             E[bi], D[bi], Nd[bi] = measure_detvecs(ftod[:,b[0]:b[1]], vecs)
         # Optionally downweight the lowest frequency bins
-        if self.downweight != None and len(self.downweight) > 0:
+        if self.downweight is not None and len(self.downweight) > 0:
             D[:len(self.downweight)] /= np.array(self.downweight)[:,None]
         # Instead of VEV' we can have just VV' if we bake sqrt(E) into V
         V = vecs[None]*E[:,None]**0.5
@@ -454,11 +493,10 @@ class NmatDetvecsDCT(Nmat):
         # Also compute a representative white noise level
         bsize = bins[:,1]-bins[:,0]
         ivar  = np.sum(iD*bsize[:,None],0)/np.sum(bsize)
-        # What about units? I haven't applied any fourier unit factors so far,
-        # so we're in plain power units. From the uncorrelated model I found
-        # that factor of tod.shape[1] is needed
-        iD   *= nsamp
-        iV   *= nsamp**0.5
+        # I originally normalized iD and iV here, but then undid that normalization
+        # when actually applying the model. Let's just skip that
+        #iD   *= nsamp
+        #iV   *= nsamp**0.5
         ivar *= nsamp
         # Fix dtype
         bins = np.ascontiguousarray(bins.astype(np.int32))
@@ -486,11 +524,12 @@ class NmatDetvecsDCT(Nmat):
             for bi, b in enumerate(self.bins):
                 # Want to multiply by iD + siViV'
                 ft    = ftod[:,b[0]:b[1]]
-                iD    = self.iD[bi]/nsamp
-                iV    = self.iV[bi]/nsamp**0.5
+                iD    = self.iD[bi] #/nsamp
+                iV    = self.iV[bi] #/nsamp**0.5
                 ft[:] = iD[:,None]*ft + self.s*iV.dot(iV.T.dot(ft))
         else:
-            so3g.nmat_detvecs_apply(ftod.view(dtype), self.bins, self.iD, self.iV, float(self.s), float(nsamp), dct_binning=True)
+            # using normalization 1 instead of nsamp, since I didn't multiply by nsamp earlier
+            so3g.nmat_detvecs_apply(ftod.view(dtype), self.bins, self.iD, self.iV, float(self.s), float(1), dct_binning=True)
         # I divided by the normalization above instead of passing normalize=True
         # here to reduce the number of operations needed
 

--- a/sotodlib/mapmaking/utils.py
+++ b/sotodlib/mapmaking/utils.py
@@ -156,10 +156,13 @@ def measure_cov(d, nmax=10000):
 def project_out(d, modes): return d-modes.T.dot(modes.dot(d))
 
 def project_out_from_matrix(A, V):
-    # Used Woodbury to project out the given vectors from the covmat A
+    """This is the equivalent of deprojecting V in a timestream,
+    and then measuring the covariance of the resulting timestream.
+    It will therefore always be positive definite."""
     if V.size == 0: return A
-    Q = A.dot(V)
-    return A - Q.dot(np.linalg.solve(np.conj(V.T).dot(Q), np.conj(Q.T)))
+    AV = A.dot(V)
+    # q = a-VV'a, Q = <qq'> = A + VV'AV'V - AVV' - VV'A
+    return A + V.dot(V.T.dot(AV)).dot(V.T) - AV.dot(V.T) - V.dot(AV.T)
 
 def measure_power(d): return np.real(np.mean(d*np.conj(d),-1))
 

--- a/sotodlib/site_pipeline/make_ml_map.py
+++ b/sotodlib/site_pipeline/make_ml_map.py
@@ -35,6 +35,7 @@ def get_parser(parser=None):
     parser.add_argument("-T", "--tiled"  ,   type=int, default=1, help="0: untiled maps. Nonzero: tiled maps")
     parser.add_argument(      "--srcsamp",   type=str, default=None, help="path to mask file where True regions indicate where bright object mitigation should be applied. Mask is in equatorial coordinates. Not tiled, so should be low-res to not waste memory.")
     parser.add_argument(      "--unit",      type=str, default="uK", help="Unit of the maps")
+    parser.add_argument(      "--iunit",     type=str, default="uK", help="Unit of the raw tod")
     parser.add_argument(      "--maxcut", type=float, default=.3, help="Maximum fraction of cut samples in a detector.")
     parser.add_argument(      "--no-sidelobe", action="store_true", help="Do not mask Moon/Sun sidelobes")
     parser.add_argument(      "--sun-mask", type=str, default="/global/cfs/cdirs/sobs/users/sigurdkn/masks/sidelobe/sun.fits", help="Location of Sun sidelobe mask")
@@ -43,7 +44,8 @@ def get_parser(parser=None):
     parser.add_argument("--cut-type",        type=str, default="full")
     return parser
 
-sens_limits = {"f030":120, "f040":80, "f090":100, "f150":140, "f220":300, "f280":750}
+sens_limits = {"f030":120, "f040":80, "f090":100, "f150":140, "f220":300, "f280":750} # uK rts
+unit_defs   = {"nK":1e-9, "uK":1e-6, "mK":1e-3, "K":1.0, "kK":1e3, "MK": 1e6, "GK":1e9}
 
 def measure_rms(tod, dt=1, bsize=32, nblock=10):
     tod = tod[:,:tod.shape[1]//bsize*bsize]
@@ -279,6 +281,11 @@ def main(**args):
                 utils.deslope(obs.signal, w=5, inplace=True)
                 obs.signal = obs.signal.astype(dtype_tod)
 
+                # Convert to our target unit. But I think having the mapmaker worry about the
+                # units overcomplicates. I would prefer to add details like this to the fits files
+                # in a later step
+                obs.signal *= unit_defs[args.iunit]/unit_defs[args.unit]
+
                 if "flags" not in obs:
                     obs.wrap("flags", core.AxisManager(obs.dets, obs.samps))
 
@@ -290,12 +297,10 @@ def main(**args):
 
                 # Optionally skip all the calibration. Useful for sims.
                 if not args.nocal:
-                    # measure rms
-                    rms = measure_rms(obs.signal, dt=1/srate)
-                    if args.unit=='K':
-                        good    = sensitivity_cut(rms*1e6, sens_limits[band])
-                    elif args.unit == 'uK':
-                        good    = sensitivity_cut(rms, sens_limits[band])
+                    # measure rms, and convert to µKrts for comparison with sens_limits
+                    rms  = measure_rms(obs.signal, dt=1/srate)
+                    rms *= unit_defs[args.unit]/unit_defs["uK"]
+                    good = sensitivity_cut(rms, sens_limits[band])
                     #nrms    = np.sum(good)
                     # Cut detectors with too big a fraction of samples cut,
                     # or cuts occuring too often.

--- a/sotodlib/site_pipeline/make_ml_map.py
+++ b/sotodlib/site_pipeline/make_ml_map.py
@@ -202,6 +202,7 @@ def main(**args):
         if   args.nmat == "uncorr": noise_model = mapmaking.NmatUncorr()
         elif args.nmat == "corr":   noise_model = mapmaking.NmatDetvecs(verbose=verbose>1, window=args.window)
         elif args.nmat == "corr_dct": noise_model = mapmaking.NmatDetvecsDCT(verbose=verbose>1)
+        elif args.nmat == "debug":  noise_model = mapmaking.NmatDebug()
         else: raise ValueError("Unrecognized noise model '%s'" % args.nmat)
 
         signal_cut = mapmaking.SignalCut(comm, dtype=dtype_tod, cut_type=args.cut_type)


### PR DESCRIPTION
The main thing this does is to fix the way eigenvectors are projected out of the measured detector-detector covariance matrix, which is a step in building the noise model. It used to do A-AV(V'AV)"V'A, which is equivalent to setting those vectors to be infinitely certain. But what we actually want to do is to get the equivalent of measuring the covariance of the detector timestreams after projecting out those modes, and the effect of that on the covmat is A+VV'AVV'-AVV'-VV'A, which this pull request changes it to.

Other changes:

* Changed the internal normalization of V and iD in the noise matrix to make it simpler and bring it in line with sogma, but this doesn't have any effect on the result
* Added NmatDebug, which implementes a 1/f noise model with static f_knee and alpha
* Added an argument --iunit for specifying the unit of the TOD returned by load_and_preprocess. This is used in conjunction with the existing --unit argument to transform the loaded to the target unit. This should ideally be a separate pull request, but hopefully it's small enough to sneak through here.