### PR TITLE
Error logging for preproc lite failure

### DIFF
--- a/sotodlib/site_pipeline/preprocess_tod.py
+++ b/sotodlib/site_pipeline/preprocess_tod.py
@@ -238,7 +238,12 @@ def _main(executor: Union["MPICommExecutor", "ProcessPoolExecutor"],
             if db is not None and not overwrite:
                 x = db.inspect({'obs:obs_id': obs_id})
                 if x is not None and len(x) != 0 and len(x) != len(groups):
-                    [groups.remove([a[f'dets:{gb}'] for gb in group_by]) for a in x]
+                    try:
+                        [groups.remove([a[f'dets:{gb}'] for gb in group_by]) for a in x]
+                    except Exception as e:
+                        logger.error(f"filtering of {groups} for {obs_id} with entry {x} failed with {e}")
+                        raise
+
 
             for group in groups:
                 if 'NC' not in group:


### PR DESCRIPTION
Adds better error logging around the get_groups filtering step to get more information about preproc lite failures on LAT:

https://prefect.simonsobs.org/runs/flow-run/019dad56-59ac-72fa-948a-2752c3dc09b3

I didn't set it to skip when it fails since we want to solve it and it isn't happening every time.

These don't appear to be related to partial writes of the database since the last flow ran to completion.  The `ManifestDb` batch manager seems okay.  It seems to be related to one of the new tubes (probably LF due to the unique wafer name).