### PR TITLE
mapmaking: Allow comment lines in query file

### DIFF
--- a/sotodlib/mapmaking/utils.py
+++ b/sotodlib/mapmaking/utils.py
@@ -318,7 +318,7 @@ def get_subids_query(query, context):
 
 def get_subids_file(fname, context=None):
     with open(fname, "r") as fname:
-        sub_ids = [line.split()[0] for line in fname]
+        sub_ids = [line.split()[0] for line in fname if line.strip() and not line.strip().startswith("#")]
     sub_ids = expand_ids(sub_ids, context=context)
     return sub_ids
 


### PR DESCRIPTION
This allow query file passed to `sotodlib/site_pipeline/make_ml_map.py` contains comment lines and empty lines.