### PR TITLE
Fix reindexing of fixed tones

### DIFF
--- a/sotodlib/core/axisman.py
+++ b/sotodlib/core/axisman.py
@@ -877,7 +877,7 @@ class AxisManager:
                         shape.append(s)
 
                 new_v = np.empty(shape, dtype=v.dtype)
-                if isinstance(v.dtype, float):
+                if v.dtype == float:
                     # Fill any float arrays with nans
                     # Non float arrays may have weird
                     # behavior for newly added indexes. 

--- a/sotodlib/core/axisman.py
+++ b/sotodlib/core/axisman.py
@@ -882,7 +882,11 @@ class AxisManager:
                     # Non float arrays may have weird
                     # behavior for newly added indexes. 
                     # Oh well.
-                    new_v *= np.nan  
+                    new_v = np.full(shape, np.nan)
+                elif v.dtype == int:
+                    # Fill with -1 values which generally
+                    # correspond ot unassigned (e.g. bias lines)
+                    new_v = np.full(shape, -1)
 
                 for i, index in enumerate(indexes):
                     if np.isnan(index) or not (0 <= index < len(v)):

--- a/sotodlib/core/axisman.py
+++ b/sotodlib/core/axisman.py
@@ -876,7 +876,6 @@ class AxisManager:
                     for s in np.shape(v)[1:]:
                         shape.append(s)
 
-                new_v = np.empty(shape, dtype=v.dtype)
                 if v.dtype == float:
                     # Fill any float arrays with nans
                     # Non float arrays may have weird
@@ -887,6 +886,8 @@ class AxisManager:
                     # Fill with -1 values which generally
                     # correspond ot unassigned (e.g. bias lines)
                     new_v = np.full(shape, -1)
+                else:
+                    new_v = np.zeros(shape, dtype=v.dtype)
 
                 for i, index in enumerate(indexes):
                     if np.isnan(index) or not (0 <= index < len(v)):

--- a/sotodlib/core/context.py
+++ b/sotodlib/core/context.py
@@ -356,21 +356,25 @@ class Context(odict):
 
             # Both tones and det_info exist.
             else:
-                # Grab all band and channel info for dets + tdets
+                # Grab all stream, band, and channel info for dets + tdets
+                det_streams = aman.det_info.stream_id
                 det_bands = aman.det_info.smurf.band
                 det_channels = aman.det_info.smurf.channel
+                tdet_streams = aman.tones.stream_id
                 tdet_bands = aman.tones.band
                 tdet_channels = aman.tones.channel
     
                 # Create a sorted array of dets + tdets
-                special_band_ch = [(b, c) for b, c in zip(tdet_bands, tdet_channels)]
-                normal_band_ch = [(b, c) for b, c in zip(det_bands, det_channels)]
-                band_ch = np.array(sorted(normal_band_ch + special_band_ch))
+                special_band_ch = [(s, b, c) for s, b, c in zip(tdet_streams, tdet_bands, tdet_channels)]
+                normal_band_ch = [(s, b, c) for s, b, c in zip(det_streams, det_bands, det_channels)]
+                band_ch = sorted(normal_band_ch + special_band_ch)
     
                 # Grab the det idxs from the det band + channels
                 det_indexes = np.full(len(band_ch), np.nan)
-                for i, (b, c) in enumerate(band_ch):
-                    w = np.where((det_bands == b) & (det_channels == c))[0]
+                for i, (s, b, c) in enumerate(band_ch):
+                    w = np.where((det_streams == s) & \
+                                 (det_bands == b) & \
+                                 (det_channels == c))[0]
                     if len(w) == 0:
                         continue
     
@@ -378,8 +382,10 @@ class Context(odict):
     
                 # Grab the tdet idxs from the tdet band + channels
                 tdet_indexes = np.full(len(band_ch), np.nan)
-                for i, (b, c) in enumerate(band_ch):
-                    w = np.where((tdet_bands == b) & (tdet_channels == c))[0]
+                for i, (s, b, c) in enumerate(band_ch):
+                    w = np.where((tdet_streams == s) & \
+                                 (tdet_bands == b) & \
+                                 (tdet_channels == c))[0]
                     if len(w) == 0:
                         continue
     
@@ -398,6 +404,7 @@ class Context(odict):
                         continue
     
                     aman.signal[i] = aman.tones.signal[int(tidx)]
+                    aman.det_info.stream_id[i] = aman.tones.stream_id[int(tidx)]
                     aman.det_info.smurf.channel[i] = aman.tones.channel[int(tidx)]
                     aman.det_info.smurf.band[i] = aman.tones.band[int(tidx)]
     


### PR DESCRIPTION
Loading an observation with fixed tones (`special_channels`) and reindexing was broken because multiple UFMs (`stream_id`s) could share the same band/channel numbers. This fixes that, and fixes a bug where NaNs were not propagated in the reindexing.