### PR TITLE
Fix DroppedMountData message parsing and error message generation

### DIFF
--- a/sotodlib/io/bookbinder.py
+++ b/sotodlib/io/bookbinder.py
@@ -266,8 +266,8 @@ def validate_mount_field(hk_field: HkDataField, times):
             ## don't change error message without changing imprinter CLI
             err= DroppedMountData(
                 f"{hk_field.addr} dropped "
-                f"{arr[np.where(arr>MAX_DROPPED_HK)[0]].astype(int)} samples over "
-                f"{np.diff(hk_field.times)[np.where(arr>MAX_DROPPED_HK)[0]]} "
+                f"{arr[m][np.where(arr[m]>MAX_DROPPED_HK)[0]].astype(int)} samples over "
+                f"{np.diff(hk_field.times)[m][np.where(arr[m]>MAX_DROPPED_HK)[0]]} "
                 "seconds. Interpolation may be questionable."
             )
         return arr > 2, err

--- a/sotodlib/io/imprinter_cli.py
+++ b/sotodlib/io/imprinter_cli.py
@@ -242,7 +242,11 @@ class DroppedMountData(BookError):
     def fix_book(self):
         if self.dropped is None:
             self.report_error()
-
+        if self.dropped < 0:
+            raise ValueError(
+                f"Could not parse dropped sample duration for {self.book.bid}"
+                " cannot repair book."
+            )
         if self.book.type == 'obs':
             if self.dropped > self.max_drop_time_to_fix:
                 print(f"ACU readout dropped for {self.dropped} seconds. Autofixing"
@@ -259,7 +263,10 @@ class DroppedMountData(BookError):
 
     def report_error(self):
         pattern = r"dropped\s*\[(.*?)\]\s*samples over\s*\[(.*?)\]"
-        m = re.search(pattern, self.book.message.split("\n")[-2])
+        m = re.search(pattern, self.book.message, re.DOTALL)
+        if m is None:
+            self.dropped = -999
+            return f"{self.book.bid} has ACU dropout (could not parse drop duration)"
         self.dropped = sum([float(x) for x in m.group(2).split()])
         return (
             f"{self.book.bid} has the ACU dropping out {len(m.group(2).split())} time(s) "


### PR DESCRIPTION
We've been dropping enough HK data that the original message parsing broke. This fixes this and I realized the total time counting for dropped time was not matched exactly to the book length. So that is fixed too. 