### PR TITLE
update how HK database delays are processed

### DIFF
--- a/sotodlib/io/bookbinder.py
+++ b/sotodlib/io/bookbinder.py
@@ -1576,7 +1576,10 @@ def get_hk_files(hkdir, start, stop, tbuff=10*60):
             continue
 
         subpath = os.path.join(hkdir, subdir)
-        files.extend([os.path.join(subpath, f) for f in os.listdir(subpath)])
+        files.extend([
+            os.path.join(subpath, f) for f in os.listdir(subpath)
+            if 'suprsync' not in f
+        ])
 
     files = np.array(sorted(files))
     file_times = np.array(

--- a/sotodlib/io/imprinter.py
+++ b/sotodlib/io/imprinter.py
@@ -1231,7 +1231,9 @@ class Imprinter:
             books. Useful as a debugging tool
         incomplete_timeouts: tuple
             hours passed for (attempting to complete observation, raising a error) 
-            if incomplete observations are found in the g3tsmurf database
+            if incomplete observations are found in the g3tsmurf database. Also used
+            as limits to decide if the g3tsmurf database is stale and raise warnings/
+            errors accordingly.
         """
         if not self.build_det:
             return
@@ -1262,8 +1264,20 @@ class Imprinter:
         final_time = SMURF.get_final_time(
             streams, min_ctime, max_ctime, check_control=True
         )
+        ## this will catch suprsync drops and hk/g3tsmurf databases not being updated
         if final_time < max_ctime:
+            if max_ctime - final_time > 3600*incomplete_timeouts[1]:
+                raise ValueError(
+                   f"G3tSMURF + HK databases are stale. Last updates were "
+                    f"more than {incomplete_timeouts[1]} hours in the past."
+                )
+            if max_ctime - final_time > 3600*incomplete_timeouts[0]:
+                self.logger.warning(
+                    f"G3tSMURF + HK databases are stale. Last updates were "
+                    f"more than {incomplete_timeouts[0]} hours in the past."
+                )
             max_ctime = final_time
+
         self.logger.debug(f"Searching between {min_ctime} and {max_ctime}")
 
         # check for incomplete observations in time range

--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -1467,7 +1467,7 @@ class G3tSmurf:
 
     def get_final_time(
         self, stream_ids, start=None, stop=None, check_control=True,
-        session=None
+        session=None,
     ):
         """Return the ctime to which database is finalized for a set of 
         stream_ids between ctimes start and stop. If check_control is True it 
@@ -1488,6 +1488,18 @@ class G3tSmurf:
             session = self.Session()
         
         HK = self.get_HK()
+        last_update = HK.get_last_update()
+        if stop > last_update:
+            if stop > last_update + 2*3600:
+                logger.warning(
+                    f"""
+                    HK database updates are stale. Last update 
+                    {dt.datetime.fromtimestamp(last_update, dt.timezone.utc)}. 
+                    Trying to check until 
+                    {dt.datetime.fromtimestamp(stop, dt.timezone.utc)}
+                    """
+                )
+            stop = last_update
 
         agent_list = []
         if "servers" not in self.finalize:
@@ -1517,14 +1529,7 @@ class G3tSmurf:
                 agent_list.append(server["smurf-suprsync"])
                 agent_list.append(server["timestream-suprsync"])
                 continue
-            if stop > HK.get_last_update():
-                if stop > HK.get_last_update()+3600:
-                    logger.error(f"HK database not updated recently enough to"
-                                  " check finalization time. Last update "
-                                 f"{HK.get_last_update}. Trying to check until"
-                                 f"{stop}")
-                else:
-                    stop = HK.get_last_update()
+            
             sids = pysmurf_monitor_control_list(pm, start, stop, HK)
             if np.any([s in stream_ids for s in sids]):
                 agent_list.append(server["smurf-suprsync"])

--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -1486,7 +1486,9 @@ class G3tSmurf:
             )
         if session is None:
             session = self.Session()
-        
+        if stop is None:
+            stop = dt.datetime.now().timestamp()
+            
         HK = self.get_HK()
         last_update = HK.get_last_update()
         if stop > last_update:


### PR DESCRIPTION
We had a hardcoded 1 hour delay as the acceptable limit for HK database updates compared to when imprinter was searching for new books. This is getting broken with the new HK suprsyncs.

This fixes that and moves the logic for where the error message gets thrown. We'll match the warning / error timeouts to what is used for incomplete observations. 