### PR TITLE
Sdw filter for sources pca map

### DIFF
--- a/sotodlib/coords/planets.py
+++ b/sotodlib/coords/planets.py
@@ -249,8 +249,8 @@ def get_horizon_P(tod, az, el, receiver_fixed=False, **kw):
 
 
 def filter_for_sources(tod=None, signal=None, source_flags=None,
-                       n_modes=10, low_pass=None,
-                       wrap=None, edge_guard=None):
+                       n_modes=10, low_pass=None, wrap=None, 
+                       pca_wrap=None, edge_guard=None):
     """Mask and gap-fill the signal at samples flagged by source_flags.
     Then PCA the resulting time ordered data.  Restore the flagged
     signal, remove the strongest modes from PCA.
@@ -271,6 +271,7 @@ def filter_for_sources(tod=None, signal=None, source_flags=None,
         subject to change.
       wrap (str): If specified, the result will be stored at
         tod[wrap].
+      pca_wrap (str): If specified, the PCA model modes and weights will be wrapped into tod[pca_wrap].
       edge_guard (int): Number of samples at the beginning and end of the flags to change them False.
         Default is None. (Nothing happens.)
 
@@ -339,7 +340,7 @@ def filter_for_sources(tod=None, signal=None, source_flags=None,
 
         # Get PCA model and discard the source vectors.
         pca = tod_ops.pca.get_pca_model(
-            tod, signal=signal_pca, n_modes=n_modes)
+            tod, signal=signal_pca, n_modes=n_modes, wrap=pca_wrap)
         del signal_pca
 
         # Remove the PCA model.

--- a/sotodlib/coords/planets.py
+++ b/sotodlib/coords/planets.py
@@ -271,7 +271,7 @@ def filter_for_sources(tod=None, signal=None, source_flags=None,
         subject to change.
       wrap (str): If specified, the result will be stored at
         tod[wrap].
-      pca_wrap (str): If specified, the PCA model modes and weights will be wrapped into tod[pca_wrap].
+      pca_wrap (str): If specified, the PCA model modes and weights calculated for subtraction will be wrapped into tod[pca_wrap].
       edge_guard (int): Number of samples at the beginning and end of the flags to change them False.
         Default is None. (Nothing happens.)
 

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -2382,6 +2382,7 @@ class FilterForSources(_Preprocess):
           source_flags: "source_flags"
           edge_guard: 10 # Number of samples to make the first and last flags False
           trim_samps: 100
+          pca_wrap: "pca_model" # optional, if provided, the PCA model is wrapped into proc_aman under this name
 
     .. autofunction:: sotodlib.coords.planets.filter_for_sources
     """
@@ -2400,10 +2401,11 @@ class FilterForSources(_Preprocess):
         signal = aman.get(self.signal)
         flags = aman.flags.get(self.process_cfgs.get('source_flags'))
         edge_guard = self.process_cfgs.get('edge_guard')
+        pca_wrap = self.process_cfgs.get('pca_wrap',None)
         if aman.dets.count < n_modes:
             raise ValueError(f'The number of pca modes {n_modes} is '
                              f'larger than the number of detectors {aman.dets.count}.')
-        planets.filter_for_sources(aman, signal=signal, source_flags=flags, n_modes=n_modes, edge_guard=edge_guard)
+        planets.filter_for_sources(aman, signal=signal, source_flags=flags, n_modes=n_modes, edge_guard=edge_guard, pca_wrap=pca_wrap)
         if self.process_cfgs.get("trim_samps"):
             trim = self.process_cfgs["trim_samps"]
             proc_aman.restrict('samps', (aman.samps.offset + trim,


### PR DESCRIPTION
Allows option to wrap calcualted pca modes and weights to the axis manager when calling filter_for_sources. We want this for the planet map maker so we can map the modes being removed. Also changes the process.py file accordingly to be able to use this new feature in a preprocess configuration file.