### PR TITLE
Errors as values update book plan

### DIFF
--- a/sotodlib/io/bookbinder.py
+++ b/sotodlib/io/bookbinder.py
@@ -1576,7 +1576,10 @@ def get_hk_files(hkdir, start, stop, tbuff=10*60):
             continue
 
         subpath = os.path.join(hkdir, subdir)
-        files.extend([os.path.join(subpath, f) for f in os.listdir(subpath)])
+        files.extend([
+            os.path.join(subpath, f) for f in os.listdir(subpath)
+            if 'suprsync' not in f
+        ])
 
     files = np.array(sorted(files))
     file_times = np.array(

--- a/sotodlib/io/g3thk_db.py
+++ b/sotodlib/io/g3thk_db.py
@@ -298,6 +298,8 @@ class G3tHk:
             update_last_file=update_last_file,
         )
 
+        logger.info(f"Adding {len(file_list)} files to hkfiles database")
+
         for path in tqdm(sorted(file_list), disable=(not show_pb)):
             try:
                 root, filename = os.path.split(path)
@@ -322,6 +324,7 @@ class G3tHk:
                 logger.warning(f"Failed on file {filename}:\n{e}")
 
     def add_file(self, path, overwrite=False):
+        logger.debug(f"Adding file {path} to database")
         db_file = (
             self.session.query(HKFiles)
             .filter(
@@ -331,6 +334,7 @@ class G3tHk:
         )
 
         if db_file is not None and not overwrite:
+            logger.debug(f"File {path} already exists in database")
             return
         if db_file is None:
             db_file = HKFiles(path=path)

--- a/sotodlib/io/imprinter.py
+++ b/sotodlib/io/imprinter.py
@@ -164,7 +164,7 @@ class Books(Base):
 
 # convenient decorator to repeat a method over all data sources
 def loop_over_tubes(method):
-    def wrapper(self, *args, **kwargs) -> :
+    def wrapper(self, *args, **kwargs) -> tuple[list | None, list[tuple[str, Exception]] | None]:
         outs = []
         errors = []
         for tube in self.tubes:

--- a/sotodlib/io/imprinter.py
+++ b/sotodlib/io/imprinter.py
@@ -1231,7 +1231,9 @@ class Imprinter:
             books. Useful as a debugging tool
         incomplete_timeouts: tuple
             hours passed for (attempting to complete observation, raising a error) 
-            if incomplete observations are found in the g3tsmurf database
+            if incomplete observations are found in the g3tsmurf database. Also used
+            as limits to decide if the g3tsmurf database is stale and raise warnings/
+            errors accordingly.
         """
         if not self.build_det:
             return
@@ -1262,8 +1264,20 @@ class Imprinter:
         final_time = SMURF.get_final_time(
             streams, min_ctime, max_ctime, check_control=True
         )
+        ## this will catch suprsync drops and hk/g3tsmurf databases not being updated
         if final_time < max_ctime:
+            if max_ctime - final_time > 3600*incomplete_timeouts[1]:
+                raise ValueError(
+                   f"G3tSMURF + HK databases are stale. Last updates were "
+                    f"more than {incomplete_timeouts[1]} hours in the past."
+                )
+            if max_ctime - final_time > 3600*incomplete_timeouts[0]:
+                self.logger.warning(
+                    f"G3tSMURF + HK databases are stale. Last updates were "
+                    f"more than {incomplete_timeouts[0]} hours in the past."
+                )
             max_ctime = final_time
+
         self.logger.debug(f"Searching between {min_ctime} and {max_ctime}")
 
         # check for incomplete observations in time range

--- a/sotodlib/io/imprinter.py
+++ b/sotodlib/io/imprinter.py
@@ -164,14 +164,30 @@ class Books(Base):
 
 # convenient decorator to repeat a method over all data sources
 def loop_over_tubes(method):
-    def wrapper(self, *args, **kwargs):
+    def wrapper(self, *args, **kwargs) -> :
         outs = []
+        errors = []
         for tube in self.tubes:
-            x = method(self, tube, *args, **kwargs)
+            try:
+                x = method(self, tube, *args, **kwargs)
+            except ValueError as e:
+                # We want to try the other tubes even if we do error out on one.
+                # Return errors as values here and taise them at the end of the script.
+                # It's the callers responsibility to handle those errors.
+                self.logger.error(f"Error in {method.__name__} for tube {tube}: {e}, skipping tube")
+                errors.append((tube, e))
+                continue
             if x is not None:
                 outs.extend(x)
-        if len(outs)>0:
-            return outs        
+
+        if not outs:
+            outs = None
+        
+        if not errors:
+            errors = None
+
+        return outs, errors
+        
     return wrapper
 
 

--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -1467,7 +1467,7 @@ class G3tSmurf:
 
     def get_final_time(
         self, stream_ids, start=None, stop=None, check_control=True,
-        session=None
+        session=None,
     ):
         """Return the ctime to which database is finalized for a set of 
         stream_ids between ctimes start and stop. If check_control is True it 
@@ -1488,6 +1488,18 @@ class G3tSmurf:
             session = self.Session()
         
         HK = self.get_HK()
+        last_update = HK.get_last_update()
+        if stop > last_update:
+            if stop > last_update + 2*3600:
+                logger.warning(
+                    f"""
+                    HK database updates are stale. Last update 
+                    {dt.datetime.fromtimestamp(last_update, dt.timezone.utc)}. 
+                    Trying to check until 
+                    {dt.datetime.fromtimestamp(stop, dt.timezone.utc)}
+                    """
+                )
+            stop = last_update
 
         agent_list = []
         if "servers" not in self.finalize:
@@ -1517,14 +1529,7 @@ class G3tSmurf:
                 agent_list.append(server["smurf-suprsync"])
                 agent_list.append(server["timestream-suprsync"])
                 continue
-            if stop > HK.get_last_update():
-                if stop > HK.get_last_update()+3600:
-                    logger.error(f"HK database not updated recently enough to"
-                                  " check finalization time. Last update "
-                                 f"{HK.get_last_update}. Trying to check until"
-                                 f"{stop}")
-                else:
-                    stop = HK.get_last_update()
+            
             sids = pysmurf_monitor_control_list(pm, start, stop, HK)
             if np.any([s in stream_ids for s in sids]):
                 agent_list.append(server["smurf-suprsync"])

--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -1486,7 +1486,9 @@ class G3tSmurf:
             )
         if session is None:
             session = self.Session()
-        
+        if stop is None:
+            stop = dt.datetime.now().timestamp()
+            
         HK = self.get_HK()
         last_update = HK.get_last_update()
         if stop > last_update:

--- a/sotodlib/site_pipeline/update_book_plan.py
+++ b/sotodlib/site_pipeline/update_book_plan.py
@@ -136,7 +136,8 @@ def main(
         record_book_counts(monitor, imprinter)
 
     if update_errors is not None:
-        logger.error(f"Errors updating book database: {update_errors}")
+        for tube, error in update_errors:
+            logger.error(f"Errors updating book database: error in tube {tube}: {error}")
         raise ValueError(f"Errors updating book database: {update_errors}")
     
 

--- a/sotodlib/site_pipeline/update_book_plan.py
+++ b/sotodlib/site_pipeline/update_book_plan.py
@@ -85,7 +85,7 @@ def main(
 
     # obs and oper books
     logger.info("Registering obs/oper Books")
-    imprinter.update_bookdb_from_g3tsmurf(
+    _, update_errors = imprinter.update_bookdb_from_g3tsmurf(
         min_ctime=min_ctime, max_ctime=max_ctime,
         ignore_singles=False,
         stream_ids=stream_ids,
@@ -134,11 +134,15 @@ def main(
     if monitor is not None:
         logger.info("Sending Updates to monitor")
         record_book_counts(monitor, imprinter)
+
+    if update_errors is not None:
+        logger.error(f"Errors updating book database: {update_errors}")
+        raise ValueError(f"Errors updating book database: {update_errors}")
     
 
 def record_book_counts(monitor, imprinter):
     """Send a record of the current book count status to the InfluxDb
-    site-pipeline montir
+    site-pipeline monitor
     """
     tags = [{"telescope" : imprinter.config["monitor"]["telescope"]}]
     log_tags = {}

--- a/sotodlib/site_pipeline/update_g3thk_database.py
+++ b/sotodlib/site_pipeline/update_g3thk_database.py
@@ -4,6 +4,8 @@ is specifically designed to work when the data is dynamically coming in. Meaning
 is designed to work from something like a cronjob. 
 """
 import os
+from typing import Optional
+from pathlib import Path
 import yaml
 import datetime as dt
 import numpy as np
@@ -14,7 +16,7 @@ from sqlalchemy import not_, or_, and_, desc
 from sotodlib.io.g3thk_db import G3tHk, HKFiles, logger
 
 
-def main(config=None, from_scratch=False, verbosity=2):
+def core(config: Optional[str]=None, from_scratch: bool=False, verbosity: int=2):
 
     show_pb = True if verbosity > 1 else False
 
@@ -36,9 +38,35 @@ def main(config=None, from_scratch=False, verbosity=2):
         ## start at the last file in the database
         last_file = HK.session.query(HKFiles)
         last_file = last_file.order_by(desc(HKFiles.global_start_time)).first()
+
+        logger.info(f"Starting from last file in database: {last_file.filename}")
         min_time = last_file.global_start_time - 10
+        logger.debug(f"Setting minium time to {min_time}")
 
     HK.add_hkfiles(min_ctime=min_time, show_pb=show_pb)
+
+def main(config: Optional[str]=None, from_scratch: bool=False, verbosity: int=2,
+         profile: bool=False, profile_output: Optional[Path]=None):
+
+    if profile:
+        import pyinstrument
+        timestamp = dt.datetime.now(dt.timezone.utc).strftime('%Y%m%d_%H%M%S')
+        filename = f"update_g3thk_database_{timestamp}.html"
+        output_filename = profile_output / filename if profile_output is not None else filename
+        profiler = pyinstrument.Profiler()
+        profiler.start()
+    
+    try:
+        core(
+            config=config, from_scratch=from_scratch, verbosity=verbosity
+        )
+    finally:
+        if profile:
+            profiler.stop()
+            if profile_output is not None:
+                with open(output_filename, "w") as f:
+                    f.write(profiler.output_html())
+
 
 def get_parser(parser=None):
     if parser is None:
@@ -48,8 +76,11 @@ def get_parser(parser=None):
                         action="store_true")
     parser.add_argument("--verbosity", help="increase output verbosity. 0:Error, 1:Warning, 2:Info(default), 3:Debug",
                        default=2, type=int)
+    parser.add_argument("--profile", help="Run with pyinstrument profiling", action="store_true")
+    parser.add_argument("--profile-output", help="Directory to output pyinstrument profiling results to, if --profile is set", 
+                        type=Path, default=Path("/data/data-package/profiles"))
+    
     return parser
-
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Allows progress on other tubes for `update_book_plan` even when we error out for a specific tube. Fixes #1650.

Also includes updates from [monitor-and-profile-update_g3thk_database](https://github.com/simonsobs/sotodlib/compare/master...monitor-and-profile-update_g3thk_database) which allows for monitoring and profiling of the g3thk_database flow.