### PR TITLE
Data Packaging: More improvements

### DIFF
--- a/sotodlib/io/imprinter.py
+++ b/sotodlib/io/imprinter.py
@@ -1247,10 +1247,11 @@ class Imprinter:
             if True, return the list of observation sets instead of registering
             books. Useful as a debugging tool
         delay_warning: float, optional
-            if max_ctime - SMURF.final time > delay_warning: print warning about stale 
+            if max_ctime - SMURF.final_time > delay_warning: print warning about stale 
             databases. Additionally, for any incomplete observations (obs), if max_ctime 
             - obs.timestamp > delay_warning: look to see if a new stream has been started 
             for obs.stream_id and force completion of the earlier obs.
+            delay_warning is specified in hours.
         delay_error: float, optional
             if max_ctime - SMURF.final time > delay_error: raise an error about stale 
             databases. Additionally, for any incomplete observations (obs), if max_ctime 

--- a/sotodlib/io/imprinter.py
+++ b/sotodlib/io/imprinter.py
@@ -1221,8 +1221,8 @@ class Imprinter:
         stream_ids=None,
         force_single_stream=False,
         return_obsset=False,
-        delay_warning = None,
-        delay_error = None,
+        delay_warning = 3,
+        delay_error = 6,
     ):
         """Update bdb with new observations from g3tsmurf db.
 
@@ -1260,11 +1260,6 @@ class Imprinter:
         """
         if not self.build_det:
             return
-
-        if delay_warning is None:
-            delay_warning = 3
-        if delay_error is None:
-            delay_error = 6
 
         session, SMURF = self.get_g3tsmurf_session(return_archive=True)
         # set sensible ctime range is none is given

--- a/sotodlib/io/imprinter.py
+++ b/sotodlib/io/imprinter.py
@@ -1221,7 +1221,8 @@ class Imprinter:
         stream_ids=None,
         force_single_stream=False,
         return_obsset=False,
-        incomplete_timeouts = (3,6),
+        delay_warning = None,
+        delay_error = None,
     ):
         """Update bdb with new observations from g3tsmurf db.
 
@@ -1245,14 +1246,24 @@ class Imprinter:
         return_obsset: boolean
             if True, return the list of observation sets instead of registering
             books. Useful as a debugging tool
-        incomplete_timeouts: tuple
-            hours passed for (attempting to complete observation, raising a error) 
-            if incomplete observations are found in the g3tsmurf database. Also used
-            as limits to decide if the g3tsmurf database is stale and raise warnings/
-            errors accordingly.
+        delay_warning: float, optional
+            if max_ctime - SMURF.final time > delay_warning: print warning about stale 
+            databases. Additionally, for any incomplete observations (obs), if max_ctime 
+            - obs.timestamp > delay_warning: look to see if a new stream has been started 
+            for obs.stream_id and force completion of the earlier obs.
+        delay_error: float, optional
+            if max_ctime - SMURF.final time > delay_error: raise an error about stale 
+            databases. Additionally, for any incomplete observations (obs), if max_ctime 
+            - obs.timestamp > delay_error: raise error about incomplete obseravtions.
         """
         if not self.build_det:
             return
+
+        if delay_warning is None:
+            delay_warning = 3
+        if delay_error is None:
+            delay_error = 6
+
         session, SMURF = self.get_g3tsmurf_session(return_archive=True)
         # set sensible ctime range is none is given
         if min_ctime is None:
@@ -1282,15 +1293,15 @@ class Imprinter:
         )
         ## this will catch suprsync drops and hk/g3tsmurf databases not being updated
         if final_time < max_ctime:
-            if max_ctime - final_time > 3600*incomplete_timeouts[1]:
+            if max_ctime - final_time > 3600*delay_error:
                 raise ValueError(
                    f"G3tSMURF + HK databases are stale. Last updates were "
-                    f"more than {incomplete_timeouts[1]} hours in the past."
+                    f"more than {delay_error} hours in the past."
                 )
-            if max_ctime - final_time > 3600*incomplete_timeouts[0]:
+            if max_ctime - final_time > 3600*delay_warning:
                 self.logger.warning(
                     f"G3tSMURF + HK databases are stale. Last updates were "
-                    f"more than {incomplete_timeouts[0]} hours in the past."
+                    f"more than {delay_warning} hours in the past."
                 )
             max_ctime = final_time
 
@@ -1304,10 +1315,10 @@ class Imprinter:
         if q_incomplete.count() > 0:
             incomplete_obs = q_incomplete.all()
             new_ctime = min([obs.timestamp for obs in incomplete_obs])
-            if max_ctime - new_ctime > 3600*incomplete_timeouts[0]:
+            if max_ctime - new_ctime > 3600*delay_warning:
                 self.logger.warning(
                     f"Found {q_incomplete.count()} incomplete observations "
-                    f"more than {incomplete_timeouts[0]} hours in the past."
+                    f"more than {delay_warning} hours in the past."
                     " Will attempt to complete these observations"
                 )
                 self._attempt_incomplete_fix(incomplete_obs)
@@ -1317,13 +1328,13 @@ class Imprinter:
         # bookbind any observations overlapping the incomplete ones.
         if q_incomplete.count() > 0:
             new_ctime = min([obs.timestamp for obs in q_incomplete.all()])
-            if max_ctime - new_ctime > 3600*incomplete_timeouts[1]:
+            if max_ctime - new_ctime > 3600*delay_error:
                 raise ValueError(
                     f"Found {q_incomplete.count()} incomplete observations. "
                     f"New max ctime would be {new_ctime}. More than "
-                    f"{incomplete_timeouts[1]} hours in the past."
+                    f"{delay_error} hours in the past."
                 )
-            elif max_ctime - new_ctime > 3600*incomplete_timeouts[0]:
+            elif max_ctime - new_ctime > 3600*delay_warning:
                 level = self.logger.warning
             else:
                 level = self.logger.debug

--- a/sotodlib/io/imprinter.py
+++ b/sotodlib/io/imprinter.py
@@ -1253,9 +1253,10 @@ class Imprinter:
             for obs.stream_id and force completion of the earlier obs.
             delay_warning is specified in hours.
         delay_error: float, optional
-            if max_ctime - SMURF.final time > delay_error: raise an error about stale 
+            if max_ctime - SMURF.final_time > delay_error: raise an error about stale 
             databases. Additionally, for any incomplete observations (obs), if max_ctime 
             - obs.timestamp > delay_error: raise error about incomplete obseravtions.
+            delay_error is specified in hours.
         """
         if not self.build_det:
             return

--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -886,6 +886,7 @@ class G3tSmurf:
             session,
             calibration=(status.tags[0] == "oper"),
             session_id=status.session_id,
+            status=status,
         )
 
     def add_new_observation(
@@ -897,6 +898,7 @@ class G3tSmurf:
         calibration,
         session_id=None,
         max_early=5,
+        status=None,
     ):
         """Add new entry to the observation table. Called by the
         index_metadata function.
@@ -916,6 +918,9 @@ class G3tSmurf:
             session id, if known, for timestream files that should go with the observations
         max_early : int (optional)
             Buffer time to allow the g3 file to be earlier than the smurf action
+        status: SmurfStatus (optional)
+            We're often making observations straight from a status object so 
+            this can be used to prevent reloading that status object
         """
 
         if session_id is None:
@@ -952,6 +957,7 @@ class G3tSmurf:
         )
         logger.debug(f"Observations {obs_id} already exists")
 
+        ## if observation does not exist, create one
         if obs is None:
             db_file = session.query(Files)
             db_file = db_file.filter(
@@ -967,7 +973,9 @@ class G3tSmurf:
                     return
             
             # Verify the files we found match with Observation
-            status = SmurfStatus.from_file(db_file.name)
+            if status is None:
+                status = SmurfStatus.from_file(db_file.name)
+            
             if status.action is not None:
                 assert status.action == action_name
                 assert status.action_timestamp == action_ctime
@@ -1003,6 +1011,7 @@ class G3tSmurf:
                 obs,
                 session,
                 max_early=max_early,
+                status=status,
             )
 
     def update_observation_files(
@@ -1012,6 +1021,7 @@ class G3tSmurf:
         max_early=5, 
         force=False, 
         force_stop=False,
+        status=None,
     ):
         """Update existing observation. A separate function to make it easier
         to deal with partial data transfers. See add_new_observation for args
@@ -1030,6 +1040,9 @@ class G3tSmurf:
             of the current file list. Useful for completing observations where
             computer systems crashed/restarted during the observations so no end
             frames were written.
+        status: SmurfStatus (optional)
+            We're often making and updating observations straight from a status object so 
+            this can be used to prevent reloading that status object
         """
 
         if not force and obs.stop is not None:
@@ -1056,7 +1069,10 @@ class G3tSmurf:
         obs.start = flist[0].start
 
         ## Load Status Information
-        status = SmurfStatus.from_file(flist[0].name)
+        if status is None:
+            status = SmurfStatus.from_file(flist[0].name)
+        assert status.session_id == obs.timestamp, "status does not match observation"
+        assert status.stream_id  == obs.stream_id, "status does not match observation"
 
         # Add any tags from the status
         if len(status.tags) > 0:
@@ -1457,7 +1473,7 @@ class G3tSmurf:
                 if len(x) < 1:
                     logger.error(
                         f"No data points before update time for agent "
-                        f"{agent} in file {db_agent.hkfile.filename}?"
+                        f"{agent} in file {db_field.hkfile.filename}?"
                     )
                 max_time = max(data[db_field.field][1][x])
             else:

--- a/sotodlib/site_pipeline/update_book_plan.py
+++ b/sotodlib/site_pipeline/update_book_plan.py
@@ -31,6 +31,8 @@ def main(
     max_ctime_timecodes: Optional[float] = None,
     from_scratch: bool = False,
     use_monitor: bool = False,
+    delay_warning: Optional[float] = None, 
+    delay_error: Optional[float] = None,
     ):
     """
     Update the book plan database with new data from the g3tsmurf database.
@@ -63,6 +65,11 @@ def main(
     use_monitor : bool
         if True, will send monitor information to influx, set to false by
         default so we can use identical config files for development
+    delay_warning: float, optional
+        if max_ctime - SMURF.final time > delay_warning: print warning about stale databases. Additionally, for any incomplete observations (obs), if max_ctime - obs.timestamp > delay_warning: look to see if a new stream has been started for obs.stream_id and force completion of the earlier obs.
+    delay_error: float, optional
+        if max_ctime - SMURF.final time > delay_error: raise an error about stale 
+        databases. Additionally, for any incomplete observations (obs), if max_ctime - obs.timestamp > delay_error: raise error about incomplete obseravtions.
     """
     if stream_ids is not None:
         stream_ids = stream_ids.split(",")
@@ -89,7 +96,9 @@ def main(
         min_ctime=min_ctime, max_ctime=max_ctime,
         ignore_singles=False,
         stream_ids=stream_ids,
-        force_single_stream=force_single_stream
+        force_single_stream=force_single_stream,
+        delay_warning=delay_warning, 
+        delay_error=delay_error,
     )
 
     ## over-ride timecode book making if specific values given
@@ -223,6 +232,16 @@ def get_parser(parser=None):
         '--update-delay', type=float, 
         help="Days to subtract from now to set as minimum ctime",
         default=1
+    )
+    parser.add_argument(
+        '--delay_warning', type=float, 
+        help="Hours before incomplete observation fixes and database warnings are issued",
+        default=3,
+    )
+    parser.add_argument(
+        '--delay_error', type=float, 
+        help="Hours before incomplete observation fixes and database errors are issued",
+        default=6,
     )
     parser.add_argument(
         '--from-scratch', help="Builds or updates database from scratch",

--- a/sotodlib/site_pipeline/update_book_plan.py
+++ b/sotodlib/site_pipeline/update_book_plan.py
@@ -31,8 +31,8 @@ def main(
     max_ctime_timecodes: Optional[float] = None,
     from_scratch: bool = False,
     use_monitor: bool = False,
-    delay_warning: Optional[float] = None, 
-    delay_error: Optional[float] = None,
+    delay_warning: float = 3, 
+    delay_error: float = 6,
     ):
     """
     Update the book plan database with new data from the g3tsmurf database.

--- a/sotodlib/site_pipeline/update_book_plan.py
+++ b/sotodlib/site_pipeline/update_book_plan.py
@@ -70,10 +70,12 @@ def main(
         databases. Additionally, for any incomplete observations (obs), if max_ctime - 
         obs.timestamp > delay_warning: look to see if a new stream has been started for 
         obs.stream_id and force completion of the earlier obs.
+        delay_warning is specified in hours.
     delay_error: float, optional
         if max_ctime - SMURF.final time > delay_error: raise an error about stale 
         databases. Additionally, for any incomplete observations (obs), if max_ctime - 
         obs.timestamp > delay_error: raise error about incomplete obseravtions.
+        delay_error is specified in hours.
     """
     if stream_ids is not None:
         stream_ids = stream_ids.split(",")

--- a/sotodlib/site_pipeline/update_book_plan.py
+++ b/sotodlib/site_pipeline/update_book_plan.py
@@ -66,10 +66,14 @@ def main(
         if True, will send monitor information to influx, set to false by
         default so we can use identical config files for development
     delay_warning: float, optional
-        if max_ctime - SMURF.final time > delay_warning: print warning about stale databases. Additionally, for any incomplete observations (obs), if max_ctime - obs.timestamp > delay_warning: look to see if a new stream has been started for obs.stream_id and force completion of the earlier obs.
+        if max_ctime - SMURF.final time > delay_warning: print warning about stale 
+        databases. Additionally, for any incomplete observations (obs), if max_ctime - 
+        obs.timestamp > delay_warning: look to see if a new stream has been started for 
+        obs.stream_id and force completion of the earlier obs.
     delay_error: float, optional
         if max_ctime - SMURF.final time > delay_error: raise an error about stale 
-        databases. Additionally, for any incomplete observations (obs), if max_ctime - obs.timestamp > delay_error: raise error about incomplete obseravtions.
+        databases. Additionally, for any incomplete observations (obs), if max_ctime - 
+        obs.timestamp > delay_error: raise error about incomplete obseravtions.
     """
     if stream_ids is not None:
         stream_ids = stream_ids.split(",")

--- a/sotodlib/site_pipeline/update_g3tsmurf_db.py
+++ b/sotodlib/site_pipeline/update_g3tsmurf_db.py
@@ -20,6 +20,7 @@ from sotodlib.io.datapkg_utils import load_configs
 def core(
     config: Optional[str] = None, update_delay: float = 2,
     from_scratch: bool = False, verbosity: int = 2,
+    min_ctime: Optional[float]=None, max_ctime: Optional[float]=None,
     index_via_actions: bool=False, checked_file: Optional[str]=None, 
 ):
     """
@@ -36,34 +37,56 @@ def core(
     elif verbosity == 3:
         logger.setLevel(logging.DEBUG)
 
+    make_db = False
     if from_scratch:
         logger.info("Building Database from Scratch, May take awhile")
-        min_time = dt.datetime.utcfromtimestamp(int(1.6e9))
+        min_ctime = int(1.6e9)
         make_db = True
-    else:
-        min_time = dt.datetime.now() - dt.timedelta(days=update_delay)
-        make_db = False
+    if min_ctime is None:
+        min_ctime = (dt.datetime.now() - dt.timedelta(days=update_delay)).timestamp()
 
     cfgs = load_configs( config )
     SMURF = G3tSmurf.from_configs(cfgs, make_db=make_db)
 
     updates_start = dt.datetime.now().timestamp()
+    if max_ctime is not None:
+        assert max_ctime > min_ctime, "max_ctime is before min_ctime"
+        ## if we're setting a maximum ctime then we need to be sure we don't 
+        ## believe the database is more updated than that.
+        updates_start = max_ctime
+    
+    ## make sure we don't have a gap between currently finalized time and when we're 
+    ## starting updates now
+    current_time = SMURF.last_update
+    assert min_ctime <= current_time, "min_ctime is higher than current database coverage"
+    logger.info(
+        f"G3tSmurf is updated through {current_time}. Beginning updates"
+        f" from {min_ctime} to {max_ctime}"
+    )
 
     session = SMURF.Session()
-    SMURF.index_metadata(min_ctime=min_time.timestamp(), session=session)
+    SMURF.index_metadata(
+        min_ctime=min_ctime, 
+        max_ctime=max_ctime, 
+        session=session
+    )
+
     logger.info("Starting to index files")
     SMURF.index_archive(
-        min_ctime=min_time.timestamp(),
+        min_ctime=min_ctime,
+        max_ctime=max_ctime,
         show_pb=show_pb,
         session=session
     )
     if index_via_actions:
         SMURF.index_action_observations(
-            min_ctime=min_time.timestamp(),
+            min_ctime=min_ctime,
+            max_ctime=max_ctime,
             session=session
         )
     SMURF.index_timecodes(
-        min_ctime=min_time.timestamp(),
+        min_ctime=min_ctime,
+        max_ctime=max_ctime,
         session=session
     )
     logger.info("Starting Finialization Update")
@@ -73,7 +96,11 @@ def core(
     
     new_obs = session.query(Observations).filter(
         or_(
-            Observations.start >= min_time,
+            ## the replace nonsense is because g3tsmurf is timezone naive. longer
+            ## term thing to deal with.
+            Observations.start >= dt.datetime.fromtimestamp(
+                min_ctime, tz=dt.timezone.utc
+            ).replace(tzinfo=None),
             Observations.start == None,
         )
     ).all()
@@ -130,6 +157,7 @@ def core(
 
 def main(config: Optional[str] = None, update_delay: float = 2,
          from_scratch: bool = False, verbosity: int = 2,
+         min_ctime: Optional[float]=None, max_ctime: Optional[float]=None,
          index_via_actions: bool=False, checked_file: Optional[str]=None,
          profile: bool=False, profile_output: Optional[Path]=None):
     """
@@ -172,6 +200,7 @@ def main(config: Optional[str] = None, update_delay: float = 2,
         core(
             config=config, update_delay=update_delay, from_scratch=from_scratch,
             verbosity=verbosity, index_via_actions=index_via_actions,
+            min_ctime=min_ctime, max_ctime=max_ctime,
             checked_file=checked_file
         )
     finally:
@@ -197,6 +226,14 @@ def get_parser(parser=None):
                         action="store_true")
     parser.add_argument("--checked-file",
         help="Filename of file containing a list of observations that are problematic but have been manually acknowledged")
+    parser.add_argument("--min_ctime",
+        help="minimum ctime to start search, overrides time set by update-delay",
+        default=None, type=int
+    )
+    parser.add_argument("--max_ctime",
+        help="maximum ctime to search, otherwise searches through 'now'",
+        default=None, type=int
+    )
     parser.add_argument("--profile", help="Run with pyinstrument profiling", action="store_true")
     parser.add_argument("--profile-output", help="Directory to output pyinstrument profiling results to, if --profile is set", 
                         type=Path)

--- a/sotodlib/site_pipeline/update_g3tsmurf_db.py
+++ b/sotodlib/site_pipeline/update_g3tsmurf_db.py
@@ -40,7 +40,7 @@ def core(
     make_db = False
     if from_scratch:
         logger.info("Building Database from Scratch, May take awhile")
-        min_ctime = int(1.6e9)
+        min_ctime = 1.6e9
         make_db = True
     if min_ctime is None:
         min_ctime = (dt.datetime.now() - dt.timedelta(days=update_delay)).timestamp()

--- a/sotodlib/site_pipeline/update_g3tsmurf_db.py
+++ b/sotodlib/site_pipeline/update_g3tsmurf_db.py
@@ -58,7 +58,11 @@ def core(
     ## make sure we don't have a gap between currently finalized time and when we're 
     ## starting updates now
     current_time = SMURF.last_update
-    assert min_ctime <= current_time, "min_ctime is higher than current database coverage"
+    if min_ctime > current_time:
+        raise ValueError(
+            f"min_ctime {min_ctime} is higher than current database coverage"
+            f" {current_time}"
+        )
     logger.info(
         f"G3tSmurf is updated through {current_time}. Beginning updates"
         f" from {min_ctime} to {max_ctime}"


### PR DESCRIPTION
Three big changes

1. Have update_g3tsmurf_db accept minimum and maximum ctimes because that makes custom runs easier. Also adds some additional printing about current update times in the logs.
2. Expose the delay_warning and delay_error variable to argparse in update_book_plan so we can do custom runs of those in prefect. (helpful when g3tsmurf is more than 6 hours behind...)
3. Pass the already loaded SmurfStatus object through the different functions that are called during g3tsmurf updates. This was the last of the obviously long file loads from the last profiling runs. 