### PR TITLE
Change H5ContextManager to use temp files and atomic operations

### DIFF
--- a/sotodlib/core/axisman_io.py
+++ b/sotodlib/core/axisman_io.py
@@ -288,8 +288,8 @@ def _save_axisman(axisman, dest, group=None, overwrite=False, compression=None,
     if len(units):
         dest.attrs['_units'] = json.dumps(units)
 
-    if file_to_close:
-        file_to_close.close()
+    if file_to_close is not None:
+        H5ContextManager.close(file_to_close)
 
 def _get_subfields(fields, prefix):
     if fields is None:

--- a/sotodlib/core/util.py
+++ b/sotodlib/core/util.py
@@ -1,6 +1,10 @@
+import os
+import re
+import shutil
+import time
+
 import numpy as np
 import h5py
-import time
 
 
 class H5LockTimeoutError(Exception):
@@ -13,23 +17,38 @@ class H5ContextManager:
     Class to open an HDF5 file with retry logic on file locking.  This class
     can be used either as a context manager or as a regular function.
 
+    If the file is opened for writing (mode "a", "w", "r+", or "w-"), then
+    a temporary file is created in the same directory as the original and the
+    contents of the original are copied to that before modification.  The
+    temporary file is intentionally chosen to be the same suffix name (it
+    does not use the tempfile module).  This way if multiple processes are
+    trying to update the file, their access will be serialized.
+
+    After the context manager exits, the temp file is atomically moved into
+    place with the name of the original.  Any processes with the original
+    inode open will be unaffected.
+
+    Aside from the name of the file, the h5py.File constructor accepts only
+    **kwargs.  Any additional key word args passed here will be forwarded
+    to the h5py.File constructor.
+
     Examples
     --------
     As a context manager
-        with H5ContextManager("data.h5", "r") as f:
+        with H5ContextManager("data.h5", mode="r") as f:
             print(list(f.keys()))
 
     Direct function call:
-        f = H5ContextManager("data.h5", "r").open()
+        f = H5ContextManager("data.h5", mode="r").open()
         print(list(f.keys()))
-        f.close()
+        H5ContextManager.close(f)
 
     Parameters
     ----------
     filename : str
         Path to the HDF5 file.
-    *args :
-        Additional positional arguments passed to `h5py.File`.
+    mode : str, optional
+        The opening mode ('r', 'r+', 'a', 'w', or 'w-').
     max_attempts : int, optional
         Number of times to retry opening the file if it is locked.
     delay : int or float, optional
@@ -37,21 +56,51 @@ class H5ContextManager:
     **kwargs :
         Additional keyword arguments passed to `h5py.File`.
     """
-    def __init__(self, filename, *args, max_attempts=3, delay=5, **kwargs):
+
+    temp_suffix = ".temporary"
+
+    def __init__(self, filename, mode="r", max_attempts=3, delay=5, **kwargs):
         self.filename = filename
-        self.args = args
         self.kwargs = kwargs
         self.max_attempts = max_attempts
         self.delay = delay
         self.f = None
+        self.mode = mode
+        self._check_file_for_mode()
+        if self.max_attempts <= 0:
+            raise RuntimeError("max_attempts should be at least one")
+        if self.delay < 0:
+            raise RuntimeError("delay should be a positive number of seconds")
 
-        assert self.max_attempts > 0
-        assert self.delay >= 0
+    def _check_file_for_mode(self):
+        if self.mode in {"r", "r+"}:
+            # File should already exist
+            if not os.path.isfile(self.filename):
+                msg = f"Cannot open file {self.filename} with mode '{self.mode}',"
+                msg += " file does not exist"
+                raise RuntimeError(msg)
+        if self.mode == "w-":
+            # File should NOT exist
+            if os.path.isfile(self.filename):
+                msg = f"Cannot open file {self.filename} with mode '{self.mode}',"
+                msg += " file already exists"
+                raise RuntimeError(msg)
 
     def open(self):
+        temp_path = f"{self.filename}{self.temp_suffix}"
         for attempt in range(self.max_attempts):
             try:
-                self.f = h5py.File(self.filename, *self.args, **self.kwargs)
+                if self.mode == "r":
+                    # No tempfile needed
+                    self.f = h5py.File(self.filename, mode=self.mode, **self.kwargs)
+                elif self.mode == "a" or self.mode == "r+":
+                    # Copy the existing file to a temp location for modification
+                    if os.path.isfile(self.filename):
+                        shutil.copy(self.filename, temp_path)
+                    self.f = h5py.File(temp_path, mode=self.mode, **self.kwargs)
+                else:
+                    # Writing and truncating
+                    self.f = h5py.File(temp_path, mode=self.mode, **self.kwargs)
                 return self.f
             except BlockingIOError as e:
                 # If the file is locked, retry opening it after a delay
@@ -66,15 +115,32 @@ class H5ContextManager:
                 # Other errors should fail immediately
                 raise e
 
+    @classmethod
+    def close(cls, hf):
+        if hf is None:
+            return
+        path = hf.filename
+        # Is this a temp file?
+        mat = re.match(f"(.*){cls.temp_suffix}", path)
+        if mat is None:
+            # No, original file
+            hf.close()
+        else:
+            # Temp file
+            orig = mat.group(1)
+            hf.close()
+            os.rename(path, orig)
+
     def __enter__(self):
         if self.f is None:
             self.open()
         return self.f
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        if self.f:
-            self.f.close()
-            self.f = None
+        self.close(self.f)
+
+    def __delete__(self):
+        self.close(self.f)
 
 
 def tag_substr(dest, tags, max_recursion=20):

--- a/sotodlib/io/metadata.py
+++ b/sotodlib/io/metadata.py
@@ -12,7 +12,7 @@ then back to 'U' type on load from HDF5.  See
 http://docs.h5py.org/en/stable/strings.html for a little more info.
 
 """
-
+from contextlib import nullcontext
 import numpy as np
 import h5py
 
@@ -45,13 +45,13 @@ def write_dataset(data, filename, address, overwrite=False, mode='a'):
         raise TypeError("I do not know how to write type %s" % data.__class__)
 
     if isinstance(filename, str):
-        context = H5ContextManager(filename, mode).open()
+        context = H5ContextManager(filename, mode=mode)
     else:
         # Wrap in a nullcontext so that the block below doesn't
         # close the File on exit.
         fout = filename
         filename = fout.filename
-        context = _nullcontext(fout)
+        context = nullcontext(fout)
 
     with context as fout:
         if address in fout:
@@ -283,18 +283,6 @@ def _decode_array(data_in, key_map={}):
     for k, c in zip(new_dtype.names, columns):
         output[k] = c
     return output
-
-
-# Starting in Python 3.7, this can be had from contextlib.
-class _nullcontext:
-    def __init__(self, enter_result=None):
-        self.enter_result = enter_result
-
-    def __enter__(self):
-        return self.enter_result
-
-    def __exit__(self, *excinfo):
-        pass
 
 
 SuperLoader.register_metadata('DefaultHdf', DefaultHdfLoader)

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -77,12 +77,14 @@ def create_outdir(subdir=None, mpicomm=None):
     if rank == 0:
         pwd = os.path.abspath(".")
         testdir = os.path.join(pwd, "sotodlib_test_output")
+        if not os.path.isdir(testdir):
+            os.mkdir(testdir)
         retdir = testdir
         if subdir is not None:
             retdir = os.path.join(testdir, subdir)
-        if not os.path.isdir(testdir):
-            os.mkdir(testdir)
-        if not os.path.isdir(retdir):
+            if os.path.isdir(retdir):
+                # Clear any stale contents
+                shutil.rmtree(retdir)
             os.mkdir(retdir)
     if mpicomm is not None:
         retdir = mpicomm.bcast(retdir, root=0)

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -77,15 +77,11 @@ def create_outdir(subdir=None, mpicomm=None):
     if rank == 0:
         pwd = os.path.abspath(".")
         testdir = os.path.join(pwd, "sotodlib_test_output")
-        if not os.path.isdir(testdir):
-            os.mkdir(testdir)
+        os.makedirs(testdir, exist_ok=True)
         retdir = testdir
         if subdir is not None:
             retdir = os.path.join(testdir, subdir)
-            if os.path.isdir(retdir):
-                # Clear any stale contents
-                shutil.rmtree(retdir)
-            os.mkdir(retdir)
+            os.makedirs(retdir, exist_ok=True)
     if mpicomm is not None:
         retdir = mpicomm.bcast(retdir, root=0)
     return retdir

--- a/tests/test_hdf5_atomic.py
+++ b/tests/test_hdf5_atomic.py
@@ -4,8 +4,6 @@
 """
 
 import os
-import multiprocessing as mp
-import time
 
 import unittest
 from unittest import TestCase
@@ -16,6 +14,8 @@ import h5py
 from sotodlib.core.util import H5ContextManager
 
 from ._helpers import create_outdir, mpi_multi
+
+from .test_hdf5_atomic_update import main as inode_main
 
 
 @unittest.skipIf(mpi_multi(), "Running with multiple MPI processes")
@@ -112,56 +112,9 @@ class HDF5AtomicTest(TestCase):
         # after it is renamed with the original name.  Meanwhile, the reading process
         # has an open handle to the original inode, which is unmodified and not
         # deleted until it is closed.
-
-        # Spawn a new process, not fork
-        ctx = mp.get_context("spawn")
-
-        outpath = os.path.join(self.outdir, "test_inode_replace.h5")
-        n_append = 4
-
-        def _modifier_func(path):
-            # Open the file in append mode and add some datasets
-            with H5ContextManager(path, mode="a") as hf:
-                for iapp in range(n_append):
-                    _ = self.append_dataset_file(hf)
-
-        # Create initial file
-        nds = self.create_fake_file(outpath)
-
-        # Reader opens file.  Test the direct method here instead of a context.
-        hf = H5ContextManager(outpath, mode="r").open()
-
-        # File should have original number of datasets
-        self.assertTrue(self.check_file(hf, nds))
-
-        # Imagine the reader process is an rsync, and the open file is a large
-        # HDF5 metadata file.  Meanwhile the file might be opened multiple times
-        # by writing processes that append little datasets.  Try to capture
-        # that here.
-
-        # While file is open for read, append to file from separate process
-        writer = ctx.Process(target=_modifier_func(outpath))
-        writer.start()
-        writer.join()
-
-        # And again...
-        writer = ctx.Process(target=_modifier_func(outpath))
-        writer.start()
-        writer.join()
-
-        # And again...
-        writer = ctx.Process(target=_modifier_func(outpath))
-        writer.start()
-        writer.join()
-
-        # Check that our open file handle is still the same data
-        self.assertTrue(self.check_file(hf, nds))
-
-        # The classmethod to close the handle will release the inode containing
-        # the original file version, whose name has since been redirected (3 times)
-        # to different inodes.
-        H5ContextManager.close(hf)
-
-        # Starting process re-opens the file and now the contents should be updated
-        with H5ContextManager(outpath, mode="r") as hf:
-            self.assertTrue(self.check_file(hf, nds + 3 * n_append))
+        opts = [
+            "--test_dir",
+            self.outdir,
+        ]
+        ret = inode_main(opts=opts)
+        self.assertEqual(ret, 0)

--- a/tests/test_hdf5_atomic.py
+++ b/tests/test_hdf5_atomic.py
@@ -1,0 +1,167 @@
+# Copyright (c) 2026-2026 Simons Observatory.
+# Full license can be found in the top level "LICENSE" file.
+"""Test atomic modification of HDF5 files
+"""
+
+import os
+import multiprocessing as mp
+import time
+
+import unittest
+from unittest import TestCase
+
+import numpy as np
+import h5py
+
+from sotodlib.core.util import H5ContextManager
+
+from ._helpers import create_outdir, mpi_multi
+
+
+@unittest.skipIf(mpi_multi(), "Running with multiple MPI processes")
+class HDF5AtomicTest(TestCase):
+
+    def setUp(self):
+        fixture_name = os.path.splitext(os.path.basename(__file__))[0]
+        self.outdir = create_outdir(fixture_name)
+
+    def create_fake_dataset(self, grp, name):
+        shape = (10, 100)
+        rng = np.random.default_rng()
+        arr = rng.uniform(low=-1.0, high=1.0, size=shape)
+        ds = grp.create_dataset(name, shape=shape, dtype=np.float64, data=arr)
+        return ds
+
+    def create_fake_file(self, path):
+        nds = 4
+        with h5py.File(path, "w") as hf:
+            for ids in range(nds):
+                dname = f"{ids:02d}"
+                _ = self.create_fake_dataset(hf, dname)
+        return nds
+
+    def append_dataset_file(self, hf):
+        if len(hf.keys()) == 0:
+            # First dataset
+            dname = "00"
+            nnew = 1
+        else:
+            dlast = list(hf.keys())[-1]
+            idlast = int(dlast)
+            idnext = idlast + 1
+            nnew = idnext + 1
+            dname = f"{idnext:02d}"
+        _ = self.create_fake_dataset(hf, dname)
+        return nnew
+
+    def check_file(self, hf, n_expected):
+        nds = 0
+        for ids, (dname, ds) in enumerate(hf.items()):
+            dcheck = f"{ids:02d}"
+            if dname != dcheck:
+                return False
+            nds += 1
+        if nds != n_expected:
+            return False
+        return True
+
+    def test_read_only(self):
+        outpath = os.path.join(self.outdir, "test_read_only.h5")
+        nds = self.create_fake_file(outpath)
+        with H5ContextManager(outpath, "r") as hf:
+            self.assertTrue(self.check_file(hf, nds))
+
+    def test_append(self):
+        outpath = os.path.join(self.outdir, "test_append.h5")
+        nds = self.create_fake_file(outpath)
+        with H5ContextManager(outpath, mode="a") as hf:
+            nds = self.append_dataset_file(hf)
+            self.assertTrue(self.check_file(hf, nds))
+
+        # Append mode should also work if the file does not
+        # yet exist
+        os.remove(outpath)
+        with H5ContextManager(outpath, mode="a") as hf:
+            nds = self.append_dataset_file(hf)
+            self.assertTrue(self.check_file(hf, nds))
+
+    def test_write(self):
+        outpath = os.path.join(self.outdir, "test_write.h5")
+        nds = 4
+        with H5ContextManager(outpath, mode="w") as hf:
+            for ids in range(nds):
+                _ = self.append_dataset_file(hf)
+        with H5ContextManager(outpath, mode="r") as hf:
+            self.assertTrue(self.check_file(hf, nds))
+
+    def test_read_write(self):
+        outpath = os.path.join(self.outdir, "test_read_write.h5")
+        nds = self.create_fake_file(outpath)
+        nappend = 2
+        ntotal = nds + nappend
+        with H5ContextManager(outpath, mode="r+") as hf:
+            for ids in range(nappend):
+                _ = self.append_dataset_file(hf)
+        with H5ContextManager(outpath, mode="r") as hf:
+            self.assertTrue(self.check_file(hf, ntotal))
+
+    def test_inode_replace(self):
+        # Test the case where a writing process has a file open for reading and then
+        # a separate process opens the file for appending.  Since the append mode of
+        # H5ContextManager makes a temp copy, the appended file is at a new inode, even
+        # after it is renamed with the original name.  Meanwhile, the reading process
+        # has an open handle to the original inode, which is unmodified and not
+        # deleted until it is closed.
+
+        # Spawn a new process, not fork
+        ctx = mp.get_context("spawn")
+
+        outpath = os.path.join(self.outdir, "test_inode_replace.h5")
+        n_append = 4
+
+        def _modifier_func(path):
+            # Open the file in append mode and add some datasets
+            with H5ContextManager(path, mode="a") as hf:
+                for iapp in range(n_append):
+                    _ = self.append_dataset_file(hf)
+
+        # Create initial file
+        nds = self.create_fake_file(outpath)
+
+        # Reader opens file.  Test the direct method here instead of a context.
+        hf = H5ContextManager(outpath, mode="r").open()
+
+        # File should have original number of datasets
+        self.assertTrue(self.check_file(hf, nds))
+
+        # Imagine the reader process is an rsync, and the open file is a large
+        # HDF5 metadata file.  Meanwhile the file might be opened multiple times
+        # by writing processes that append little datasets.  Try to capture
+        # that here.
+
+        # While file is open for read, append to file from separate process
+        writer = ctx.Process(target=_modifier_func(outpath))
+        writer.start()
+        writer.join()
+
+        # And again...
+        writer = ctx.Process(target=_modifier_func(outpath))
+        writer.start()
+        writer.join()
+
+        # And again...
+        writer = ctx.Process(target=_modifier_func(outpath))
+        writer.start()
+        writer.join()
+
+        # Check that our open file handle is still the same data
+        self.assertTrue(self.check_file(hf, nds))
+
+        # The classmethod to close the handle will release the inode containing
+        # the original file version, whose name has since been redirected (3 times)
+        # to different inodes.
+        H5ContextManager.close(hf)
+
+        # Starting process re-opens the file and now the contents should be updated
+        with H5ContextManager(outpath, mode="r") as hf:
+            self.assertTrue(self.check_file(hf, nds + 3 * n_append))

--- a/tests/test_hdf5_atomic_update.py
+++ b/tests/test_hdf5_atomic_update.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026-2026 Simons Observatory.
+# Full license can be found in the top level "LICENSE" file.
+"""Test atomic modification of HDF5 files."""
+
+import argparse
+import os
+import multiprocessing as mp
+import shutil
+
+import numpy as np
+import h5py
+
+from sotodlib.core.util import H5ContextManager
+
+
+def create_fake_dataset(grp, name):
+    shape = (10, 100)
+    rng = np.random.default_rng()
+    arr = rng.uniform(low=-1.0, high=1.0, size=shape)
+    ds = grp.create_dataset(name, shape=shape, dtype=np.float64, data=arr)
+    return ds
+
+
+def create_fake_file(path):
+    nds = 4
+    with h5py.File(path, "w") as hf:
+        for ids in range(nds):
+            dname = f"{ids:02d}"
+            _ = create_fake_dataset(hf, dname)
+    return nds
+
+
+def append_dataset_file(hf):
+    if len(hf.keys()) == 0:
+        # First dataset
+        dname = "00"
+        nnew = 1
+    else:
+        dlast = list(hf.keys())[-1]
+        idlast = int(dlast)
+        idnext = idlast + 1
+        nnew = idnext + 1
+        dname = f"{idnext:02d}"
+    _ = create_fake_dataset(hf, dname)
+    return nnew
+
+
+def check_file(hf, n_expected):
+    nds = 0
+    for ids, (dname, ds) in enumerate(hf.items()):
+        dcheck = f"{ids:02d}"
+        if dname != dcheck:
+            return False
+        nds += 1
+    if nds != n_expected:
+        return False
+    return True
+
+
+def modifier_func(path, n_append):
+    # Open the file in append mode and add some datasets
+    with H5ContextManager(path, mode="a") as hf:
+        for iapp in range(n_append):
+            _ = append_dataset_file(hf)
+
+
+def main(opts=None):
+    parser = argparse.ArgumentParser(description="Test HDF5 atomic updates")
+
+    parser.add_argument(
+        "--test_dir",
+        required=False,
+        type=str,
+        default="test_hdf5_atomic",
+        help="The testing directory",
+    )
+
+    parser.add_argument(
+        "--n_append",
+        required=False,
+        type=int,
+        default=4,
+        help="The number of datasets to append on each worker",
+    )
+
+    args = parser.parse_args(args=opts)
+
+    outpath = os.path.join(args.test_dir, "test_inode_replace.h5")
+
+    if os.path.isdir(args.test_dir):
+        shutil.rmtree(args.test_dir)
+    os.makedirs(args.test_dir)
+
+    # Spawn a new process, not fork
+    ctx = mp.get_context("spawn")
+
+    # Create initial file
+    nds = create_fake_file(outpath)
+
+    # Reader opens file.  Test the direct method here instead of a context.
+    hf = H5ContextManager(outpath, mode="r").open()
+
+    # File should have original number of datasets
+    result = check_file(hf, nds)
+    if not result:
+        msg = f"Failed to create initial file with {nds} datasets"
+        print(msg, flush=True)
+        return 1
+
+    # Imagine the reader process is an rsync, and the open file is a large
+    # HDF5 metadata file.  Meanwhile the file might be opened multiple times
+    # by writing processes that append little datasets.  Try to capture
+    # that here.
+
+    # While file is open for read, append to file from separate process
+    writer = ctx.Process(
+        target=modifier_func,
+        args=(outpath, args.n_append),
+    )
+    writer.start()
+    writer.join()
+
+    # And again...
+    writer = ctx.Process(
+        target=modifier_func,
+        args=(outpath, args.n_append),
+    )
+    writer.start()
+    writer.join()
+
+    # And again...
+    writer = ctx.Process(
+        target=modifier_func,
+        args=(outpath, args.n_append),
+    )
+    writer.start()
+    writer.join()
+
+    # Check that our open file handle is still the same data
+    result = check_file(hf, nds)
+    if not result:
+        msg = f"Failed to preserve original file contents with {nds} datasets"
+        print(msg, flush=True)
+        return 1
+
+    # The classmethod to close the handle will release the inode containing
+    # the original file version, whose name has since been redirected (3 times)
+    # to different inodes.
+    H5ContextManager.close(hf)
+
+    # Starting process re-opens the file and now the contents should be updated
+    new_nds = nds + 3 * args.n_append
+    with H5ContextManager(outpath, mode="r") as hf:
+        result = check_file(hf, new_nds)
+    if not result:
+        msg = f"Failed to load updated file with {new_nds} datasets"
+        print(msg, flush=True)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_intensity_templates.py
+++ b/tests/test_intensity_templates.py
@@ -26,17 +26,17 @@ from ._helpers import create_outdir, close_data_and_comm, simulation_test_data
 
 
 class IntensityTemplateTest(unittest.TestCase):
+
+    def setUp(self):
+        fixture_name = os.path.splitext(os.path.basename(__file__))[0]
+        self.outdir = create_outdir(fixture_name)
+
     def test_intensity_templates(self):
         if not toast_available:
             print("toast cannot be imported- skipping unit tests", flush=True)
             return
 
         comm, procs, rank = toast.get_world()
-
-        outdir = create_outdir(
-            subdir=os.path.splitext(os.path.basename(__file__))[0],
-            mpicomm=comm,
-        )
 
         data = simulation_test_data(
             comm,
@@ -111,7 +111,7 @@ class IntensityTemplateTest(unittest.TestCase):
 
         filterbin = toast.ops.FilterBin(
             binning=binning,
-            output_dir=outdir,
+            output_dir=self.outdir,
             precomputed_templates="intensity_templates",
             precomputed_template_view="scanning",
             write_binmap=True,
@@ -124,8 +124,8 @@ class IntensityTemplateTest(unittest.TestCase):
 
         # Confirm that the filtered map is consistent with zero
 
-        fname_binned = os.path.join(outdir, "FilterBin_unfiltered_map.fits")
-        fname_filtered = os.path.join(outdir, "FilterBin_filtered_map.fits")
+        fname_binned = os.path.join(self.outdir, "FilterBin_unfiltered_map.fits")
+        fname_filtered = os.path.join(self.outdir, "FilterBin_filtered_map.fits")
         binned = hp.read_map(fname_binned, None)
         filtered = hp.read_map(fname_filtered, None)
         good = binned[0] != 0
@@ -153,10 +153,11 @@ class IntensityTemplateTest(unittest.TestCase):
 
         comm, procs, rank = toast.get_world()
 
-        outdir = create_outdir(
-            subdir=os.path.splitext(os.path.basename(__file__))[0],
-            mpicomm=comm,
-        )
+        testdir = os.path.join(self.outdir, "caching")
+        if rank == 0:
+            os.makedirs(testdir, exist_ok=True)
+        if comm is not None:
+            comm.barrier()
 
         data = simulation_test_data(
             comm,
@@ -192,7 +193,7 @@ class IntensityTemplateTest(unittest.TestCase):
 
         # Generate and cache templates
 
-        cache_dir = os.path.join(outdir, "template_cache")
+        cache_dir = testdir
         so_ops.IntensityTemplates(
             name="intensity_templates",
             fpkeys="wafer_slot,bandcenter",


### PR DESCRIPTION
Change H5ContextManager to use temp files and atomic operations

- Remove '*args' from H5ContextManager.	 The h5py.File constructor
  does not take	positional args, so there is nothing to	pass.  Explicitly
  parse	and handle the `mode` keyword arg and check that the file
  exists if required.

- Unless mode="r", open	a temporary file for modification.  Add	a
  classmethod to close an hdf5 file handle, optionally moving the temp
  file into place with a rename.

- Implement H5ContextManager tests, including for case of replacing
  file while previous inode is open.

- Update use of H5ContextManager throughout sotodlib, ensuring that
  the classmethod close() is used, which moves the temp file into place.