### PR TITLE
Push loop over fields for HK down into so3g to avoid duplicate file reads

### DIFF
--- a/sotodlib/io/g3thk_db.py
+++ b/sotodlib/io/g3thk_db.py
@@ -190,18 +190,20 @@ class G3tHk:
         max_vals = []
         stds = []
 
-        for i in range(len(hkfs)):
-            data = arc.simple(hkfs[i])
-            time = data[0]
+        data = arc.simple(hkfs)
+
+        for field in data:
+            time = field[0]
             starts.append(time[0])
             stops.append(time[-1])
             try:
-                medians.append(np.median(data[1]))
-                means.append(np.mean(data[1]))
-                min_vals.append(np.min(data[1]))
-                max_vals.append(np.max(data[1]))
-                stds.append(np.std(data[1]))
-            except:
+                medians.append(np.median(field[1]))
+                means.append(np.mean(field[1]))
+                min_vals.append(np.min(field[1]))
+                max_vals.append(np.max(field[1]))
+                stds.append(np.std(field[1]))
+            except Exception as e:
+                logger.warning(f"Error processing field {field}: {e}, setting to nan")
                 medians.append(np.nan)
                 means.append(np.nan)
                 min_vals.append(np.nan)


### PR DESCRIPTION
We were only providing `HKArchive.simple` a single field at a time, and each time it had to read the entire `.g3` file. This PR pushes the fields down as a list so they can all be extracted in a single file read. It provides binary-identical results in my testing.