### PR TITLE
Only log in the cases of unexpected exceptions (not TypeErrors) for g3thk loop

### DIFF
--- a/sotodlib/io/g3thk_db.py
+++ b/sotodlib/io/g3thk_db.py
@@ -192,10 +192,11 @@ class G3tHk:
 
         data = arc.simple(hkfs)
 
-        for field in data:
+        for index, field in enumerate(data):
             time = field[0]
             starts.append(time[0])
             stops.append(time[-1])
+
             try:
                 medians.append(np.median(field[1]))
                 means.append(np.mean(field[1]))
@@ -203,7 +204,10 @@ class G3tHk:
                 max_vals.append(np.max(field[1]))
                 stds.append(np.std(field[1]))
             except Exception as e:
-                logger.warning(f"Error processing field {field}: {e}, setting to nan")
+                if not isinstance(e, TypeError):
+                    # TypeErrors are expected from attempting to take the median of a list of strings.
+                    logger.warning(f"Error processing field {index} for {hk_path}, setting to nan")
+
                 medians.append(np.nan)
                 means.append(np.nan)
                 min_vals.append(np.nan)

--- a/sotodlib/io/g3thk_db.py
+++ b/sotodlib/io/g3thk_db.py
@@ -206,7 +206,7 @@ class G3tHk:
             except Exception as e:
                 if not isinstance(e, TypeError):
                     # TypeErrors are expected from attempting to take the median of a list of strings.
-                    logger.warning(f"Error processing field {index} for {hk_path}, setting to nan")
+                    logger.warning(f"Error processing field {index} for {hk_path}, setting to nan (Error: {e})")
 
                 medians.append(np.nan)
                 means.append(np.nan)


### PR DESCRIPTION
We're getting lots of noise in the logs from expected failures in the core g3thk loop: https://prefect.simonsobs.org/runs/flow-run/019edeae-5d86-74c2-a0e2-977b1d66c382.

This PR adds an explicit check for the `TypeError` that we know will occur when we attempt to take a median of a list of strings. In other cases we still raise the warning but I also made it more helpful (printing the filename and index rather than the entire data structure).