### PR TITLE
Make bin_signal compatible with 1d-array

### DIFF
--- a/sotodlib/tod_ops/binning.py
+++ b/sotodlib/tod_ops/binning.py
@@ -93,7 +93,7 @@ def bin_signal(aman, bin_by, signal=None,
         if (not is_1d) and flags.shape == (aman.dets.count, aman.samps.count):
             flag_is_2d = True
             m_2d = base_valid[None, :] & ~flags.mask()
-        elif is_id and flags.shape == (aman.samps.count, ):
+        elif flags.shape == (aman.samps.count, ):
             flag_is_2d = False
             m = base_valid & ~flags.mask()
         else:
@@ -106,25 +106,27 @@ def bin_signal(aman, bin_by, signal=None,
 
         # prepare binned signal array
         binned_signal = np.full(nbins, np.nan, signal_dtype)
+        binned_signal_squared_mean = np.full(nbins, np.nan, signal_dtype)
         binned_signal_sigma = np.full(nbins, np.nan, signal_dtype)
 
-        bin_counts = np.bincount(
+        bin_counts_dets = np.bincount(
             bin_indices[m], weights=weight_for_signal[m], minlength=nbins)
-        mcnts = bin_counts > 0
+        mcnts = bin_counts_dets > 0
         binned_signal[mcnts] = np.bincount(
             bin_indices[m], weights=signal[m] * weight_for_signal[m], minlength=nbins
-        )[mcnts] / bin_counts[mcnts]
-        binned_signal_squared_mean = np.bincount(
+        )[mcnts] / bin_counts_dets[mcnts]
+        binned_signal_squared_mean[mcnts] = np.bincount(
             bin_indices[m], weights=(signal[m] * weight_for_signal[m]) ** 2,
             minlength=nbins
-        )[mcnts] / bin_counts[mcnts]
+        )[mcnts] / bin_counts_dets[mcnts]
         binned_signal_sigma[mcnts] = np.sqrt(
-            np.abs(binned_signal_squared_mean - binned_signal[mcnts] ** 2)
-        ) / np.sqrt(bin_counts[mcnts])
+            np.abs(binned_signal_squared_mean[mcnts] - binned_signal[mcnts] ** 2)
+        ) / np.sqrt(bin_counts_dets[mcnts])
 
     else:
         # prepare binned signal array
         binned_signal = np.full([aman.dets.count, nbins], np.nan, signal_dtype)
+        binned_signal_squared_mean = np.full([aman.dets.count, nbins], np.nan, signal_dtype)
         binned_signal_sigma = np.full([aman.dets.count, nbins], np.nan, signal_dtype)
         bin_counts_dets = np.full([aman.dets.count, nbins], np.nan)
 

--- a/sotodlib/tod_ops/binning.py
+++ b/sotodlib/tod_ops/binning.py
@@ -16,6 +16,7 @@ def bin_signal(aman, bin_by, signal=None,
         The array by which signal is binned. It should has the same samps as aman.
     signal : str, optional
         The name of the signal to be binned. Defaults to aman.signal if not specified.
+        Either 1D array of shape ``(samps,)`` or 2D array of shape ``(dets, samps)``.
     range : list or None
         A list specifying the bin range ([min, max]). Default is None, which means bin range
         is set to [min(bin_by), max(bin_by)].
@@ -42,6 +43,22 @@ def bin_signal(aman, bin_by, signal=None,
     """
     if signal is None:
         signal = aman.signal
+    elif isinstance(signal, str):
+        signal = aman.get(signal)
+
+    if signal.ndim == 1:
+        is_1d = True
+    elif signal.ndim == 2:
+        is_1d = False
+    else:
+        raise ValueError(
+            f"signal must be 1D (samps,) or 2D (dets, samps); got ndim={signal.ndim}")
+
+    if signal.shape[-1] != aman.samps.count:
+        raise ValueError(
+            f"signal last axis ({signal.shape[-1]}) does not match "
+            f"aman.samps.count ({aman.samps.count})")
+
     if range is None:
         range = (np.nanmin(bin_by), np.nanmax(bin_by))
 
@@ -55,42 +72,61 @@ def bin_signal(aman, bin_by, signal=None,
     bin_centers = (bin_edges[1] - bin_edges[0])/2. + bin_edges[:-1] # edge to center
     nbins = len(bin_centers)
     
-    # prepare binned signal array
-    binned_signal = np.full([aman.dets.count, nbins], np.nan, signal_dtype)
-    binned_signal_squared_mean = np.full([aman.dets.count, nbins], np.nan, signal_dtype)
-    binned_signal_sigma = np.full([aman.dets.count, nbins], np.nan, signal_dtype)
-    
     # get bin indices
     bin_indices = np.digitize(bin_by, bin_edges) - 1
     bin_indices = np.clip(bin_indices, 0, nbins-1)
-        
-    # bin tod
-    if flags is None:
-        bin_counts, _ = np.histogram(bin_by, bins=bins, range=range, weights = weight_for_signal)
-        mcnts = bin_counts > 0
-        
-        for i, dets in enumerate(aman.dets.vals):      
-            binned_signal[i][mcnts] = np.bincount(bin_indices, weights=signal[i]*weight_for_signal, minlength=nbins
-                                                 )[mcnts]/bin_counts[mcnts]
-            binned_signal_squared_mean[i][mcnts] = np.bincount(bin_indices, weights=(signal[i]*weight_for_signal)**2, minlength=nbins
-                                                 )[mcnts]/bin_counts[mcnts]
-            
-        binned_signal_sigma[:, mcnts] = np.sqrt(np.abs(binned_signal_squared_mean[:,mcnts] - binned_signal[:,mcnts]**2)
-                                      ) / np.sqrt(bin_counts[mcnts])
-        bin_counts_dets = np.tile(bin_counts, (aman.dets.count, 1))
 
+    # Drop NaN bin_by and out-of-range samples so that np.digitize + np.clip
+    # do not silently pile them into the first/last bin.
+    base_valid = (
+        np.isfinite(bin_by)
+        & (bin_by >= range[0])
+        & (bin_by <= range[1])
+    )
+
+    if flags is None:
+        flag_is_2d = False
+        m = base_valid
     else:
-        bin_counts_dets = np.full([aman.dets.count, nbins], np.nan)
         if isinstance(flags, str):
             flags = aman.flags.get(flags)
-        if flags.shape == (aman.dets.count, aman.samps.count):
+        if (not is_1d) and flags.shape == (aman.dets.count, aman.samps.count):
             flag_is_2d = True
-            m_2d = ~flags.mask()
-        elif flags.shape == (aman.samps.count, ):
+            m_2d = base_valid[None, :] & ~flags.mask()
+        elif is_id and flags.shape == (aman.samps.count, ):
             flag_is_2d = False
-            m = ~flags.mask()
+            m = base_valid & ~flags.mask()
         else:
             raise ValueError('flags should have shape of (`dets`, `samps`) or (`samps`,)')
+
+    if is_1d:
+        if weight_for_signal.shape != (aman.samps.count,):
+            raise ValueError(
+                'weight_for_signal should have shape of (`samps`,) when signal is 1D')
+
+        # prepare binned signal array
+        binned_signal = np.full(nbins, np.nan, signal_dtype)
+        binned_signal_sigma = np.full(nbins, np.nan, signal_dtype)
+
+        bin_counts = np.bincount(
+            bin_indices[m], weights=weight_for_signal[m], minlength=nbins)
+        mcnts = bin_counts > 0
+        binned_signal[mcnts] = np.bincount(
+            bin_indices[m], weights=signal[m] * weight_for_signal[m], minlength=nbins
+        )[mcnts] / bin_counts[mcnts]
+        binned_signal_squared_mean = np.bincount(
+            bin_indices[m], weights=(signal[m] * weight_for_signal[m]) ** 2,
+            minlength=nbins
+        )[mcnts] / bin_counts[mcnts]
+        binned_signal_sigma[mcnts] = np.sqrt(
+            np.abs(binned_signal_squared_mean - binned_signal[mcnts] ** 2)
+        ) / np.sqrt(bin_counts[mcnts])
+
+    else:
+        # prepare binned signal array
+        binned_signal = np.full([aman.dets.count, nbins], np.nan, signal_dtype)
+        binned_signal_sigma = np.full([aman.dets.count, nbins], np.nan, signal_dtype)
+        bin_counts_dets = np.full([aman.dets.count, nbins], np.nan)
 
         for i, dets in enumerate(aman.dets.vals):
             if flag_is_2d:

--- a/sotodlib/tod_ops/binning.py
+++ b/sotodlib/tod_ops/binning.py
@@ -2,6 +2,7 @@ import numpy as np
 import logging
 logger = logging.getLogger(__name__)
 
+
 def bin_signal(aman, bin_by, signal=None,
                range=None, bins=100, flags=None,
                weight_for_signal=None):
@@ -37,7 +38,7 @@ def bin_signal(aman, bin_by, signal=None,
     Dictionary:
         - **bin_edges** (dict key): float array of bin edges length(bin_centers)+1.
         - **bin_centers** (dict key): center of each bin.
-        - **bin_counts** (dict key): counts of binned samples. 
+        - **bin_counts** (dict key): counts of binned samples.
         - **binned_signal** (dict key): binned signal.
         - **binned_signal_sigma** (dict key): estimated sigma of binned signal.
     """
@@ -79,8 +80,8 @@ def bin_signal(aman, bin_by, signal=None,
     # do not silently pile them into the first/last bin.
     base_valid = (
         np.isfinite(bin_by)
-        & (bin_by >= range[0])
-        & (bin_by <= range[1])
+        & (bin_by >= bin_edges[0])
+        & (bin_by <= bin_edges[-1])
     )
 
     if flags is None:
@@ -125,12 +126,15 @@ def bin_signal(aman, bin_by, signal=None,
 
         bin_counts[i] = np.bincount(bin_indices[m], weights=w[m], minlength=nbins)
         mcnts = bin_counts[i] > 0
-        binned_signal[i][mcnts] = np.bincount(bin_indices[m], weights=signal[i][m]*w[m], minlength=nbins
-                                             )[mcnts]/bin_counts[i][mcnts]
-        binned_signal_squared_mean[i][mcnts] = np.bincount(bin_indices[m], weights=(signal[i][m]*w[m])**2, minlength=nbins
-                                             )[mcnts]/bin_counts[i][mcnts]
-        binned_signal_sigma[i][mcnts] = np.sqrt(np.abs(binned_signal_squared_mean[i,mcnts] - binned_signal[i,mcnts]**2)
-                                             ) / np.sqrt(bin_counts[i][mcnts])
+        binned_signal[i][mcnts] = np.bincount(
+            bin_indices[m], weights=signal[i][m]*w[m], minlength=nbins
+        )[mcnts]/bin_counts[i][mcnts]
+        binned_signal_squared_mean[i][mcnts] = np.bincount(
+            bin_indices[m], weights=(signal[i][m]*w[m])**2, minlength=nbins
+        )[mcnts]/bin_counts[i][mcnts]
+        binned_signal_sigma[i][mcnts] = np.sqrt(
+            np.abs(binned_signal_squared_mean[i, mcnts] - binned_signal[i, mcnts]**2)
+        )/np.sqrt(bin_counts[i][mcnts])
 
     if is_1d:
         binned_signal = binned_signal[0]

--- a/sotodlib/tod_ops/binning.py
+++ b/sotodlib/tod_ops/binning.py
@@ -14,7 +14,8 @@ def bin_signal(aman, bin_by, signal=None,
     aman : TOD
         The Axismanager object to be binned.
     bin_by : array-like
-        The array by which signal is binned. It should has the same samps as aman.
+        The array by which signal is binned. Any length is allowed, but it must be consistent
+        with `signal` (and `flags` and `weight_for_signal`, if specified).
     signal : str or array-like optional
         signal to be binned or its name. Defaults to aman.signal if not specified.
         Either 1D array or 2D array with shape ``(nsamps)`` or``(dets, nsamps)``,

--- a/sotodlib/tod_ops/binning.py
+++ b/sotodlib/tod_ops/binning.py
@@ -14,8 +14,8 @@ def bin_signal(aman, bin_by, signal=None,
         The Axismanager object to be binned.
     bin_by : array-like
         The array by which signal is binned. It should has the same samps as aman.
-    signal : str, optional
-        The name of the signal to be binned. Defaults to aman.signal if not specified.
+    signal : str or array-like optional
+        signal to be binned or its name. Defaults to aman.signal if not specified.
         Either 1D array of shape ``(samps,)`` or 2D array of shape ``(dets, samps)``.
     range : list or None
         A list specifying the bin range ([min, max]). Default is None, which means bin range
@@ -45,33 +45,32 @@ def bin_signal(aman, bin_by, signal=None,
         signal = aman.signal
     elif isinstance(signal, str):
         signal = aman.get(signal)
+    signal = np.asarray(signal)
 
-    if signal.ndim == 1:
-        is_1d = True
-    elif signal.ndim == 2:
-        is_1d = False
-    else:
+    if signal.ndim not in [1, 2]:
         raise ValueError(
             f"signal must be 1D (samps,) or 2D (dets, samps); got ndim={signal.ndim}")
+    is_1d = signal.ndim == 1
+    signal = np.atleast_2d(signal)
+    ndets = signal.shape[0]
 
     if signal.shape[-1] != aman.samps.count:
         raise ValueError(
             f"signal last axis ({signal.shape[-1]}) does not match "
             f"aman.samps.count ({aman.samps.count})")
 
+    bin_by = np.asarray(bin_by)
+
     if range is None:
         range = (np.nanmin(bin_by), np.nanmax(bin_by))
 
     signal_dtype = signal.dtype
-    
-    if weight_for_signal is None:
-        weight_for_signal = np.ones(aman.samps.count, signal_dtype)
-        
+
     # get bin_edges
     bin_edges = np.histogram_bin_edges(bin_by, bins=bins, range=range,)
     bin_centers = (bin_edges[1] - bin_edges[0])/2. + bin_edges[:-1] # edge to center
     nbins = len(bin_centers)
-    
+
     # get bin indices
     bin_indices = np.digitize(bin_by, bin_edges) - 1
     bin_indices = np.clip(bin_indices, 0, nbins-1)
@@ -85,70 +84,58 @@ def bin_signal(aman, bin_by, signal=None,
     )
 
     if flags is None:
-        flag_is_2d = False
-        m = base_valid
+        mask = np.broadcast_to(base_valid, (ndets, aman.samps.count))
     else:
         if isinstance(flags, str):
             flags = aman.flags.get(flags)
         if (not is_1d) and flags.shape == (aman.dets.count, aman.samps.count):
-            flag_is_2d = True
-            m_2d = base_valid[None, :] & ~flags.mask()
+            mask = base_valid[None, :] & ~flags.mask()
         elif flags.shape == (aman.samps.count, ):
-            flag_is_2d = False
-            m = base_valid & ~flags.mask()
+            mask = np.broadcast_to(base_valid & ~flags.mask(),
+                                   (ndets, aman.samps.count))
         else:
             raise ValueError('flags should have shape of (`dets`, `samps`) or (`samps`,)')
+
+    if weight_for_signal is None:
+        weight_for_signal = np.ones(aman.samps.count, signal_dtype)
+    weight_for_signal = np.asarray(weight_for_signal)
 
     if is_1d:
         if weight_for_signal.shape != (aman.samps.count,):
             raise ValueError(
                 'weight_for_signal should have shape of (`samps`,) when signal is 1D')
-
-        # prepare binned signal array
-        binned_signal = np.full(nbins, np.nan, signal_dtype)
-        binned_signal_squared_mean = np.full(nbins, np.nan, signal_dtype)
-        binned_signal_sigma = np.full(nbins, np.nan, signal_dtype)
-
-        bin_counts_dets = np.bincount(
-            bin_indices[m], weights=weight_for_signal[m], minlength=nbins)
-        mcnts = bin_counts_dets > 0
-        binned_signal[mcnts] = np.bincount(
-            bin_indices[m], weights=signal[m] * weight_for_signal[m], minlength=nbins
-        )[mcnts] / bin_counts_dets[mcnts]
-        binned_signal_squared_mean[mcnts] = np.bincount(
-            bin_indices[m], weights=(signal[m] * weight_for_signal[m]) ** 2,
-            minlength=nbins
-        )[mcnts] / bin_counts_dets[mcnts]
-        binned_signal_sigma[mcnts] = np.sqrt(
-            np.abs(binned_signal_squared_mean[mcnts] - binned_signal[mcnts] ** 2)
-        ) / np.sqrt(bin_counts_dets[mcnts])
-
+        weights = np.atleast_2d(weight_for_signal)
+    elif weight_for_signal.shape == (aman.dets.count, aman.samps.count):
+        weights = weight_for_signal
+    elif weight_for_signal.shape == (aman.samps.count, ):
+        weights = np.broadcast_to(weight_for_signal,
+                                  (ndets, aman.samps.count))
     else:
-        # prepare binned signal array
-        binned_signal = np.full([aman.dets.count, nbins], np.nan, signal_dtype)
-        binned_signal_squared_mean = np.full([aman.dets.count, nbins], np.nan, signal_dtype)
-        binned_signal_sigma = np.full([aman.dets.count, nbins], np.nan, signal_dtype)
-        bin_counts_dets = np.full([aman.dets.count, nbins], np.nan)
+        raise ValueError('weight_for_signal should have shape of (`dets`, `samps`) or (`samps`,)')
 
-        for i, dets in enumerate(aman.dets.vals):
-            if flag_is_2d:
-                m = m_2d[i]
+    # prepare binned signal array
+    binned_signal = np.full([ndets, nbins], np.nan, signal_dtype)
+    binned_signal_squared_mean = np.full([ndets, nbins], np.nan, signal_dtype)
+    binned_signal_sigma = np.full([ndets, nbins], np.nan, signal_dtype)
+    bin_counts = np.full([ndets, nbins], np.nan)
 
-            if weight_for_signal.shape == (aman.dets.count, aman.samps.count):
-                weight_for_signal_det = weight_for_signal[i]
-            elif weight_for_signal.shape == (aman.samps.count, ):
-                weight_for_signal_det = weight_for_signal
-            else:
-                raise ValueError('weight_for_signal should have shape of (`dets`, `samps`) or (`samps`,)')
+    for i in np.arange(ndets):
+        m = mask[i]
+        w = weights[i]
 
-            bin_counts_dets[i] = np.bincount(bin_indices[m], weights=weight_for_signal_det[m], minlength=nbins)
-            mcnts = bin_counts_dets[i] > 0
-            binned_signal[i][mcnts] = np.bincount(bin_indices[m], weights=signal[i][m]*weight_for_signal_det[m], minlength=nbins
-                                                 )[mcnts]/bin_counts_dets[i][mcnts]
-            binned_signal_squared_mean[i][mcnts] = np.bincount(bin_indices[m], weights=(signal[i][m]*weight_for_signal_det[m])**2, minlength=nbins
-                                                 )[mcnts]/bin_counts_dets[i][mcnts]
-            binned_signal_sigma[i][mcnts] = np.sqrt(np.abs(binned_signal_squared_mean[i,mcnts] - binned_signal[i,mcnts]**2)
-                                                 ) / np.sqrt(bin_counts_dets[i][mcnts])
+        bin_counts[i] = np.bincount(bin_indices[m], weights=w[m], minlength=nbins)
+        mcnts = bin_counts[i] > 0
+        binned_signal[i][mcnts] = np.bincount(bin_indices[m], weights=signal[i][m]*w[m], minlength=nbins
+                                             )[mcnts]/bin_counts[i][mcnts]
+        binned_signal_squared_mean[i][mcnts] = np.bincount(bin_indices[m], weights=(signal[i][m]*w[m])**2, minlength=nbins
+                                             )[mcnts]/bin_counts[i][mcnts]
+        binned_signal_sigma[i][mcnts] = np.sqrt(np.abs(binned_signal_squared_mean[i,mcnts] - binned_signal[i,mcnts]**2)
+                                             ) / np.sqrt(bin_counts[i][mcnts])
 
-    return {'bin_edges': bin_edges, 'bin_centers': bin_centers, 'bin_counts': bin_counts_dets,
+    if is_1d:
+        binned_signal = binned_signal[0]
+        binned_signal_sigma = binned_signal_sigma[0]
+        bin_counts = bin_counts[0]
+
+    return {'bin_edges': bin_edges, 'bin_centers': bin_centers, 'bin_counts': bin_counts,
             'binned_signal': binned_signal, 'binned_signal_sigma': binned_signal_sigma}

--- a/sotodlib/tod_ops/binning.py
+++ b/sotodlib/tod_ops/binning.py
@@ -17,7 +17,8 @@ def bin_signal(aman, bin_by, signal=None,
         The array by which signal is binned. It should has the same samps as aman.
     signal : str or array-like optional
         signal to be binned or its name. Defaults to aman.signal if not specified.
-        Either 1D array of shape ``(samps,)`` or 2D array of shape ``(dets, samps)``.
+        Either 1D array or 2D array with shape ``(nsamps)`` or``(dets, nsamps)``,
+        where nsamps is length of bin_by.
     range : list or None
         A list specifying the bin range ([min, max]). Default is None, which means bin range
         is set to [min(bin_by), max(bin_by)].
@@ -50,17 +51,16 @@ def bin_signal(aman, bin_by, signal=None,
 
     if signal.ndim not in [1, 2]:
         raise ValueError(
-            f"signal must be 1D (samps,) or 2D (dets, samps); got ndim={signal.ndim}")
+            f"signal must be 1D or 2D; got ndim={signal.ndim}")
     is_1d = signal.ndim == 1
     signal = np.atleast_2d(signal)
     ndets = signal.shape[0]
 
-    if signal.shape[-1] != aman.samps.count:
-        raise ValueError(
-            f"signal last axis ({signal.shape[-1]}) does not match "
-            f"aman.samps.count ({aman.samps.count})")
-
     bin_by = np.asarray(bin_by)
+    nsamps = len(bin_by)
+
+    if signal.shape[-1] != nsamps:
+        raise ValueError("signal shape does not match bin_by")
 
     if range is None:
         range = (np.nanmin(bin_by), np.nanmax(bin_by))
@@ -85,34 +85,29 @@ def bin_signal(aman, bin_by, signal=None,
     )
 
     if flags is None:
-        mask = np.broadcast_to(base_valid, (ndets, aman.samps.count))
+        mask = np.broadcast_to(base_valid, (ndets, nsamps))
     else:
         if isinstance(flags, str):
             flags = aman.flags.get(flags)
-        if (not is_1d) and flags.shape == (aman.dets.count, aman.samps.count):
+        if (not is_1d) and flags.shape == (aman.dets.count, nsamps):
             mask = base_valid[None, :] & ~flags.mask()
-        elif flags.shape == (aman.samps.count, ):
+        elif flags.shape == (nsamps, ):
             mask = np.broadcast_to(base_valid & ~flags.mask(),
-                                   (ndets, aman.samps.count))
+                                   (ndets, nsamps))
         else:
-            raise ValueError('flags should have shape of (`dets`, `samps`) or (`samps`,)')
+            raise ValueError('shape of flags does not match')
 
     if weight_for_signal is None:
-        weight_for_signal = np.ones(aman.samps.count, signal_dtype)
+        weight_for_signal = np.ones(nsamps, signal_dtype)
     weight_for_signal = np.asarray(weight_for_signal)
 
-    if is_1d:
-        if weight_for_signal.shape != (aman.samps.count,):
-            raise ValueError(
-                'weight_for_signal should have shape of (`samps`,) when signal is 1D')
-        weights = np.atleast_2d(weight_for_signal)
-    elif weight_for_signal.shape == (aman.dets.count, aman.samps.count):
+    if (not is_1d) and weight_for_signal.shape == (aman.dets.count, nsamps):
         weights = weight_for_signal
-    elif weight_for_signal.shape == (aman.samps.count, ):
+    elif weight_for_signal.shape == (nsamps, ):
         weights = np.broadcast_to(weight_for_signal,
-                                  (ndets, aman.samps.count))
+                                  (ndets, nsamps))
     else:
-        raise ValueError('weight_for_signal should have shape of (`dets`, `samps`) or (`samps`,)')
+        raise ValueError('shape of weight_for_signal does not match')
 
     # prepare binned signal array
     binned_signal = np.full([ndets, nbins], np.nan, signal_dtype)
@@ -127,14 +122,14 @@ def bin_signal(aman, bin_by, signal=None,
         bin_counts[i] = np.bincount(bin_indices[m], weights=w[m], minlength=nbins)
         mcnts = bin_counts[i] > 0
         binned_signal[i][mcnts] = np.bincount(
-            bin_indices[m], weights=signal[i][m]*w[m], minlength=nbins
-        )[mcnts]/bin_counts[i][mcnts]
+            bin_indices[m], weights=signal[i][m] * w[m], minlength=nbins
+        )[mcnts] / bin_counts[i][mcnts]
         binned_signal_squared_mean[i][mcnts] = np.bincount(
-            bin_indices[m], weights=(signal[i][m]*w[m])**2, minlength=nbins
-        )[mcnts]/bin_counts[i][mcnts]
+            bin_indices[m], weights=(signal[i][m] * w[m])**2, minlength=nbins
+        )[mcnts] / bin_counts[i][mcnts]
         binned_signal_sigma[i][mcnts] = np.sqrt(
             np.abs(binned_signal_squared_mean[i, mcnts] - binned_signal[i, mcnts]**2)
-        )/np.sqrt(bin_counts[i][mcnts])
+        ) / np.sqrt(bin_counts[i][mcnts])
 
     if is_1d:
         binned_signal = binned_signal[0]

--- a/sotodlib/tod_ops/binning.py
+++ b/sotodlib/tod_ops/binning.py
@@ -16,7 +16,7 @@ def bin_signal(aman, bin_by, signal=None,
     bin_by : array-like
         The array by which signal is binned. Any length is allowed, but it must be consistent
         with `signal` (and `flags` and `weight_for_signal`, if specified).
-    signal : str or array-like optional
+    signal : str or array-like of float, optional
         signal to be binned or its name. Defaults to aman.signal if not specified.
         Either 1D array or 2D array with shape ``(nsamps)`` or``(dets, nsamps)``,
         where nsamps is length of bin_by.
@@ -70,7 +70,7 @@ def bin_signal(aman, bin_by, signal=None,
 
     # get bin_edges
     bin_edges = np.histogram_bin_edges(bin_by, bins=bins, range=range,)
-    bin_centers = (bin_edges[1] - bin_edges[0])/2. + bin_edges[:-1] # edge to center
+    bin_centers = (bin_edges[1:] + bin_edges[:-1]) / 2.
     nbins = len(bin_centers)
 
     # get bin indices
@@ -90,7 +90,7 @@ def bin_signal(aman, bin_by, signal=None,
     else:
         if isinstance(flags, str):
             flags = aman.flags.get(flags)
-        if (not is_1d) and flags.shape == (aman.dets.count, nsamps):
+        if (not is_1d) and flags.shape == (ndets, nsamps):
             mask = base_valid[None, :] & ~flags.mask()
         elif flags.shape == (nsamps, ):
             mask = np.broadcast_to(base_valid & ~flags.mask(),
@@ -102,7 +102,7 @@ def bin_signal(aman, bin_by, signal=None,
         weight_for_signal = np.ones(nsamps, signal_dtype)
     weight_for_signal = np.asarray(weight_for_signal)
 
-    if (not is_1d) and weight_for_signal.shape == (aman.dets.count, nsamps):
+    if (not is_1d) and weight_for_signal.shape == (ndets, nsamps):
         weights = weight_for_signal
     elif weight_for_signal.shape == (nsamps, ):
         weights = np.broadcast_to(weight_for_signal,

--- a/tests/test_binning.py
+++ b/tests/test_binning.py
@@ -1,0 +1,86 @@
+import unittest
+
+import numpy as np
+import so3g
+
+from sotodlib import core
+from sotodlib.tod_ops.binning import bin_signal
+
+
+def _make_aman(ndets=3, nsamps=1000, signal=None):
+    """
+    Build a minimal AxisManager with ``dets`` and ``samps`` axes and an
+    optional 2D ``signal`` field. ``signal`` defaults to zeros.
+    """
+    dets = [f'det{i}' for i in range(ndets)]
+    aman = core.AxisManager(
+        core.LabelAxis('dets', dets),
+        core.OffsetAxis('samps', nsamps),
+    )
+    if signal is None:
+        signal = np.zeros((ndets, nsamps), dtype='float32')
+    aman.wrap('signal', signal, [(0, 'dets'), (1, 'samps')])
+    return aman
+
+
+class TestBinSignal(unittest.TestCase):
+    """Tests for ``sotodlib.tod_ops.binning.bin_signal``."""
+
+    def test_2d(self):
+        ndets, nsamps, nbins = 2, 500, 10
+        v = 7.
+        aman = _make_aman(ndets, nsamps)
+        signal = np.full((ndets, nsamps), v)
+        bin_by = np.linspace(-1, 1, nsamps)
+        out = bin_signal(aman, bin_by=bin_by, signal=None)
+        out = bin_signal(aman, bin_by=bin_by, signal=None, bins=nbins)
+        out = bin_signal(aman, bin_by=bin_by, signal='signal', bins=nbins)
+        out = bin_signal(aman, bin_by=bin_by, signal=signal, bins=nbins)
+        out = bin_signal(aman, bin_by=bin_by, signal=signal, range=(0,1), bins=nbins)
+
+        # shape
+        self.assertEqual(out['binned_signal'].shape, (ndets, nbins))
+        self.assertEqual(out['binned_signal_sigma'].shape, (ndets, nbins))
+        self.assertEqual(out['bin_counts'].shape, (ndets, nbins))
+        self.assertEqual(out['bin_centers'].shape, (nbins,))
+        self.assertEqual(out['bin_edges'].shape, (nbins + 1,))
+
+        # numerical
+        ok = ~np.isnan(out['binned_signal'])
+        np.testing.assert_allclose(out['binned_signal'][ok], v)
+        np.testing.assert_allclose(
+            out['binned_signal_sigma'][ok], 0.0, atol=1e-12)
+
+        # flags
+        flags = so3g.proj.RangesMatrix.zeros((ndets, nsamps))
+        out = bin_signal(aman, bin_by=bin_by, flags=flags)
+        flags = so3g.proj.Ranges(nsamps)
+        out = bin_signal(aman, bin_by=bin_by, flags=flags)
+
+    def test_1d(self):
+        ndets, nsamps, nbins = 2, 500, 10
+        v = 7.
+        aman = _make_aman(ndets, nsamps)
+        signal = np.full(nsamps, v)
+        bin_by = np.linspace(-1, 1, nsamps)
+        out = bin_signal(aman, bin_by=bin_by, signal=None)
+        out = bin_signal(aman, bin_by=bin_by, signal=signal, bins=nbins)
+        out = bin_signal(aman, bin_by=bin_by, signal=signal, range=(0,1), bins=nbins)
+
+        # shape
+        self.assertEqual(out['binned_signal'].shape, (nbins,))
+        self.assertEqual(out['binned_signal_sigma'].shape, (nbins,))
+        self.assertEqual(out['bin_counts'].shape, (nbins,))
+
+        # numerical
+        ok = ~np.isnan(out['binned_signal'])
+        np.testing.assert_allclose(out['binned_signal'][ok], v)
+        np.testing.assert_allclose(
+            out['binned_signal_sigma'][ok], 0.0, atol=1e-12)
+
+        # flags
+        flags = so3g.proj.RangesMatrix.zeros((ndets, nsamps))
+        with self.assertRaises(ValueError):
+            out = bin_signal(aman, bin_by=bin_by, signal=signal, flags=flags)
+        flags = so3g.proj.Ranges(nsamps)
+        out = bin_signal(aman, bin_by=bin_by, signal=signal, flags=flags)

--- a/tests/test_binning.py
+++ b/tests/test_binning.py
@@ -26,7 +26,8 @@ def _make_aman(ndets=3, nsamps=1000, signal=None):
 class TestBinSignal(unittest.TestCase):
     """Tests for ``sotodlib.tod_ops.binning.bin_signal``."""
 
-    def test_2d(self):
+    def test_100_2d_binning(self):
+        """ test 2d binning """
         ndets, nsamps, nbins = 2, 500, 10
         v = 7.
         aman = _make_aman(ndets, nsamps)
@@ -36,7 +37,8 @@ class TestBinSignal(unittest.TestCase):
         out = bin_signal(aman, bin_by=bin_by, signal=None, bins=nbins)
         out = bin_signal(aman, bin_by=bin_by, signal='signal', bins=nbins)
         out = bin_signal(aman, bin_by=bin_by, signal=signal, bins=nbins)
-        out = bin_signal(aman, bin_by=bin_by, signal=signal, range=(0,1), bins=nbins)
+        out = bin_signal(aman, bin_by=bin_by, signal=signal, range=(0, 1),
+                         bins=nbins)
 
         # shape
         self.assertEqual(out['binned_signal'].shape, (ndets, nbins))
@@ -57,7 +59,8 @@ class TestBinSignal(unittest.TestCase):
         flags = so3g.proj.Ranges(nsamps)
         out = bin_signal(aman, bin_by=bin_by, flags=flags)
 
-    def test_1d(self):
+    def test_200_1d_binning(self):
+        """ test 1d binning """
         ndets, nsamps, nbins = 2, 500, 10
         v = 7.
         aman = _make_aman(ndets, nsamps)
@@ -65,7 +68,8 @@ class TestBinSignal(unittest.TestCase):
         bin_by = np.linspace(-1, 1, nsamps)
         out = bin_signal(aman, bin_by=bin_by, signal=None)
         out = bin_signal(aman, bin_by=bin_by, signal=signal, bins=nbins)
-        out = bin_signal(aman, bin_by=bin_by, signal=signal, range=(0,1), bins=nbins)
+        out = bin_signal(aman, bin_by=bin_by, signal=signal, range=(0, 1),
+                         bins=nbins)
 
         # shape
         self.assertEqual(out['binned_signal'].shape, (nbins,))
@@ -84,3 +88,51 @@ class TestBinSignal(unittest.TestCase):
             out = bin_signal(aman, bin_by=bin_by, signal=signal, flags=flags)
         flags = so3g.proj.Ranges(nsamps)
         out = bin_signal(aman, bin_by=bin_by, signal=signal, flags=flags)
+
+    def test_300_out_of_range_sample_robustness(self):
+        """ test robustness to values in out of binning range """
+        ndets, nsamps, nbins = 2, 500, 10
+        v = 7.
+        aman = _make_aman(ndets, nsamps)
+        signal = np.full((ndets, nsamps), v)
+        bin_by = np.linspace(-1, 1, nsamps)
+
+        # inject outlier in out of range
+        signal[:, bin_by < 0] = 1e10
+        out = bin_signal(aman, bin_by=bin_by, signal=signal, range=(0, 1),
+                         bins=nbins)
+
+        # numerical
+        ok = ~np.isnan(out['binned_signal'])
+        np.testing.assert_allclose(out['binned_signal'][ok], v)
+        np.testing.assert_allclose(
+            out['binned_signal_sigma'][ok], 0.0, atol=1e-12)
+
+    def test_400_arbitrary_length_of_signal(self):
+        """ test binning arbitrary length of signal which has consistent
+        shape as bin_by
+        """
+        ndets, nsamps, nbins = 2, 500, 10
+        signal_nsamps = 200
+        v = 7.
+        aman = _make_aman(ndets, nsamps)
+
+        # 1d
+        signal = np.full(signal_nsamps, v)
+        bin_by = np.linspace(-1, 1, signal_nsamps)
+        out = bin_signal(aman, bin_by=bin_by, signal=signal, bins=nbins)
+
+        self.assertEqual(out['binned_signal'].shape, (nbins,))
+        self.assertEqual(out['binned_signal_sigma'].shape, (nbins,))
+        self.assertEqual(out['bin_counts'].shape, (nbins,))
+
+        # 2d
+        signal = np.full((ndets, signal_nsamps), v)
+        bin_by = np.linspace(-1, 1, signal_nsamps)
+        out = bin_signal(aman, bin_by=bin_by, signal=signal, bins=nbins)
+
+        self.assertEqual(out['binned_signal'].shape, (ndets, nbins))
+        self.assertEqual(out['binned_signal_sigma'].shape, (ndets, nbins))
+        self.assertEqual(out['bin_counts'].shape, (ndets, nbins))
+        self.assertEqual(out['bin_centers'].shape, (nbins,))
+        self.assertEqual(out['bin_edges'].shape, (nbins + 1,))


### PR DESCRIPTION
This is for binning 1d-array such as thermometer data to az.
This doesn't affect binning of 2d array.

There was an issue where, when the range was narrower than the bin_by value, the edge bins returned the wrong value due to np.digitize and np.clip. 
This PR also fixes this issue. This error should not impact most analyses.

Added unit test for binning.
