### PR TITLE
Fix numpy failure case in det_cal

### DIFF
--- a/sotodlib/site_pipeline/update_det_cal.py
+++ b/sotodlib/site_pipeline/update_det_cal.py
@@ -626,7 +626,7 @@ def get_cal_resset(cfg: DetCalCfg, obs_info: ObsInfo,
                 continue
 
             ridx = np.where((iva.bands == band) & (iva.channels == chan))[0]
-            if not ridx:  # Channel doesn't exist in IV analysis
+            if ridx.size == 0:  # Channel doesn't exist in IV analysis
                 continue
 
             ridx = ridx[0]
@@ -704,7 +704,7 @@ def get_cal_resset(cfg: DetCalCfg, obs_info: ObsInfo,
                 continue
 
             ridx = np.where((bsa.bands == band) & (bsa.channels == chan))[0]
-            if not ridx:  # Channel doesn't exist in bias step analysis
+            if ridx.size == 0:  # Channel doesn't exist in bias step analysis
                 continue
 
             if cfg.apply_cal_correction:


### PR DESCRIPTION
Some obs_ids are silently failing on the LAT with the following error:

```
obs_1782017305_lati3_111: "Traceback (most recent call last):\n  File \"/usr/local/lib/python3.12/site-packages/sotodlib/site_pipeline/update_det_cal.py\"\
  , line 629, in get_cal_resset\n    if not ridx:  # Channel doesn't exist in IV analysis\n\
  \           ^^^^\nValueError: The truth value of an empty array is ambiguous. Use\
  \ `array.size > 0` to check that an array is not empty.\n"
```

This just adds a fix so that it will continue and not fail as was done for `update_smurf_caldbs` in #1619.