### PR TITLE
Add sqlite timeout to obsdb

### DIFF
--- a/sotodlib/core/metadata/obsdb.py
+++ b/sotodlib/core/metadata/obsdb.py
@@ -57,9 +57,13 @@ class ObsDb(object):
         if isinstance(map_file, sqlite3.Connection):
             self.conn = map_file
         else:
+            connect_args = {}
+            timeout_env = os.getenv('SOTODLIB_SQLITE_TIMEOUT')
+            if timeout_env not in (None, ''):
+                connect_args['timeout'] = float(timeout_env)
             if map_file is None:
                 map_file = ':memory:'
-            self.conn = sqlite3.connect(map_file)
+            self.conn = sqlite3.connect(map_file, **connect_args)
 
         self.conn.row_factory = sqlite3.Row  # access columns by name
         if init_db:


### PR DESCRIPTION
Copies #1496 and adds the ability to specify the timeout for the `obsdb` sqlite connection through the same environment variable.  This may help alleviate the locked `obsdb` failures we are having for the `update_obsdb` Prefect flow.