### PR TITLE
Refactor and fixes for quality reports

### DIFF
--- a/sotodlib/qa/quality_reports/plots.py
+++ b/sotodlib/qa/quality_reports/plots.py
@@ -18,38 +18,64 @@ from typing import List, Tuple, TYPE_CHECKING, Dict, Any, Optional
 from .report_data import ReportData, Footprint
 
 
-MARKER_COLORS = ["#E69F00", "#56B4E9", "#009E73",
-          "#F0E442", "#0072B2", "#D55E00"]
-MARKER_SYMBOLS = ["circle", "square", "diamond", "cross", "x", "triangle-up"]
+BASE_COLORS = [
+    '#4477AA', '#EE6677', '#228833',
+    '#CCBB44', '#66CCEE', '#AA3377',
+    '#BBBBBB'
+]
 
 
-def get_wafers(platform: str):
-    """Get wafer and tube slots"""
-    if platform  == "lat":
-        tube_slots = ["c1", "i1", "i2", "i3", "i4", "i5", "i6", "o1", "o2", "o3", "o4", "o5", "o6"]
-        wafer_slots = ["ws0", "ws1", "ws2"]
-        wafers = [f"{x}_{y}" for x in tube_slots for y in wafer_slots]
-    elif platform in ["satp1", "satp2", "satp3"]:
-        wafers = [f"ws{i} " for i in range(7)]
-    else:
-        raise ValueError(f"Uknown platform {platform}")
+MARKER_COLORS = (
+    "#E69F00", "#56B4E9", "#009E73",
+    "#F0E442", "#0072B2", "#D55E00",
+)
 
-    return wafers
+
+MARKER_SYMBOLS = (
+    "circle", "square", "diamond",
+    "cross", "x", "triangle-up",
+)
+
+
+LAT_TUBE_SLOTS = (
+    "c1", "i1", "i2", "i3", "i4", "i5", "i6",
+    "o1", "o2", "o3", "o4", "o5", "o6",
+)
+
+
+SAT_WAFER_SLOTS = tuple(f"ws{i}" for i in range(7))
+
+
+def get_wafers(platform: str) -> list[str]:
+    """Return wafer identifiers for a given platform."""
+
+    platform = platform.lower().strip()
+
+    if platform == "lat":
+        return [
+            f"{tube}_{wafer}"
+            for tube in LAT_TUBE_SLOTS
+            for wafer in ("ws0", "ws1", "ws2")
+        ]
+
+    if platform in {"satp1", "satp2", "satp3"}:
+        return list(SAT_WAFER_SLOTS)
+
+    raise ValueError(f"Unknown platform: {platform!r}")
 
 
 def get_discrete_distinct_colors(n, reverse=False):
     """Get a list of colors from a list or interpolate between them.
     First and last color are fixed for idle and CMB obs
     """
-    base_colors = ['#4477AA', '#EE6677', '#228833', '#CCBB44', '#66CCEE', '#AA3377', '#BBBBBB']
-    n_base = len(base_colors)
+    n_base = len(BASE_COLORS)
 
     if n <= n_base:
         # Use subset with fixed endpoints
-        colors = [base_colors[0]] + base_colors[1:-1][:n - 2] + [base_colors[-1]]
+        colors = [BASE_COLORS[0]] + BASE_COLORS[1:-1][:n - 2] + [BASE_COLORS[-1]]
     else:
         # Interpolate between base colors
-        base_rgb = [mcolors.to_rgb(c) for c in base_colors]
+        base_rgb = [mcolors.to_rgb(c) for c in BASE_COLORS]
         interpolated = np.linspace(0, n_base - 1, n)
         colors = []
         for i in interpolated:
@@ -86,6 +112,66 @@ class Colors:
         return f"Colors({self.colormap})"
 
 
+def obs_hover(o, exclude=None):
+    """
+    Add obs info to hover text.
+    """
+
+    if exclude is None:
+        exclude = set()
+
+    def is_empty(v):
+        if v is None:
+            return True
+
+        if isinstance(v, np.ndarray):
+            if v.size == 0:
+                return True
+
+            if np.issubdtype(v.dtype, np.number):
+                return np.all(~np.isfinite(v))
+
+            return False
+
+        if isinstance(v, (float, np.floating)):
+            return not np.isfinite(v)
+
+        if isinstance(v, (list, tuple, dict, set)):
+            return len(v) == 0
+
+        if isinstance(v, str):
+            return v.strip() == ""
+
+        return False
+
+    def fmt(v):
+        if isinstance(v, (float, np.floating)) and not isinstance(v, bool):
+            return float(np.round(v, 2))
+        return v
+
+    meta = {}
+
+    for k, v in vars(o).items():
+        if (
+            k.startswith("_")
+            or callable(v)
+            or k in exclude
+            or is_empty(v)
+        ):
+            continue
+
+        v = fmt(v)
+        meta[k] = v
+
+    lines = [f"{k}: {v}" for k, v in meta.items()]
+    return "<br>".join(lines)
+
+
+# ============================================================
+# Observation efficiency plots.
+# ============================================================
+
+
 @dataclass
 class ObsEfficiencyPlots:
     pie: go.Figure
@@ -93,32 +179,224 @@ class ObsEfficiencyPlots:
     heatmap: go.Figure
 
 
-def obsdb_scatter_plot(x, y, xlabel, ylabel, title, xlim, symbols=None, name=None, hovertext=None, fig=None):
-    """Generic function to make a Plotly scatter plot."""
+def wafer_obs_efficiency(d: ReportData, nsegs: int=2000, good_pwv_lim: float=3) -> ObsEfficiencyPlots:
+    """Plot heatmap of wafer vs time and pie chart showing observation efficiency"""
 
-    marker_symbol_map = {}
-    for i, s in enumerate(np.unique(symbols)):
-        marker_symbol_map[s] = MARKER_SYMBOLS[i]
+    def wafer_index(o, wafer, wafers, platform):
+        """Get index in data vector for wafer"""
+        if platform == "lat":
+            return np.where(np.asarray(wafers) == f"{o.obs_tube_slot}_{wafer}")[0][0]
+        return int(wafer.strip()[-1])
 
-    marker_symbols = [marker_symbol_map.get(s, "circle") for s in symbols]
+    def obs_value(o, obs_values, cal_targets):
+        """Get value for data based on obs type and subtype"""
+        if o.obs_type != "obs":
+            return obs_values[o.obs_type]
+
+        if o.obs_subtype == "cmb":
+            return obs_values["cmb"]
+
+        if o.obs_subtype == "cal":
+            for tag in o.obs_tags.split(","):
+                if tag in cal_targets:
+                    return obs_values[tag]
+            return obs_values["cal"]
+
+        return obs_values["obs"]
+
+    def fill_obs_array(arr, tstamps, d, wafers, obs_values):
+        """Populate data array with values"""
+        for o in d.obs_list:
+            mask = (tstamps > o.start_time) & (tstamps < o.stop_time)
+            value = obs_value(o, obs_values, d.cfg.cal_targets)
+
+            for wafer in o.wafer_slots_list.split(","):
+                idx = wafer_index(o, wafer, wafers, d.cfg.platform)
+                arr[idx, mask] = value
+
+    def make_pie(arr, obs_types):
+        """Create pie chart from data array"""
+        vals, counts = np.unique(arr, return_counts=True)
+        reverse = True if (arr == (len(obs_types) - 1)).all() else False
+
+        labels = [obs_types[v] for v in vals]
+        colors = Colors(names=labels, reverse=reverse)
+
+        fig = go.Figure(
+            go.Pie(
+                labels=labels,
+                values=100 * counts / counts.sum(),
+                textinfo="label+percent",
+                marker=dict(colors=[colors[l] for l in labels]),
+            )
+        )
+
+        fig.update_layout(
+            margin=dict(l=0, r=0, t=0, b=0),
+            height=300,
+        )
+
+        return fig, colors
+
+    wafers = get_wafers(d.cfg.platform)
+
+    obs_types = ["cmb", "obs", "cal", "oper", *d.cfg.cal_targets, "idle"]
+    obs_values = {k: i for i, k in enumerate(obs_types)}
+
+    # All data pie chart
+    times = pd.date_range(d.cfg.start_time, d.cfg.stop_time, nsegs)
+    tstamps = times.astype(np.int64) / 1e9
+
+    data = np.full((len(wafers), nsegs), obs_values["idle"], dtype=int)
+    fill_obs_array(data, tstamps, d, wafers, obs_values)
+    pie, colors = make_pie(data, obs_types)
+
+    # Use 10 minute segments for PWV pie chart
+    start = pd.Timestamp(d.cfg.start_time)
+    stop = pd.Timestamp(d.cfg.stop_time)
+    nsegs_pwv = int(np.ceil((stop - start).total_seconds() / 600))
+
+    # Get segments with good pwv
+    t_edges = pd.date_range(start, stop, periods=nsegs_pwv + 1)
+    t_edges = np.array([t.timestamp() for t in t_edges])
+
+    data_pwv = np.full(nsegs_pwv, np.nan)
+
+    pwv_times = d.pwv[0]
+    pwv_values = d.pwv[1]
+
+    # Average pwv for each segment
+    for i in range(nsegs_pwv):
+        m = (pwv_times >= t_edges[i]) & (pwv_times < t_edges[i + 1])
+        if np.any(m):
+            data_pwv[i] = np.mean(pwv_values[m])
+
+    good = np.isfinite(data_pwv) & (data_pwv < good_pwv_lim)
+
+    pwv_times = pd.date_range(start, stop, nsegs_pwv)
+    pwv_tstamps = pwv_times.astype(np.int64) / 1e9
+
+    data_good_pwv = np.full((len(wafers), nsegs_pwv), obs_values["idle"], dtype=int)
+    fill_obs_array(data_good_pwv, pwv_tstamps, d, wafers, obs_values)
+    pie_good_pwv, _ = make_pie(data_good_pwv[:, good], obs_types)
+
+    # Efficiency heatmap
+    unique = np.unique(data)
+    mapping = {v: i for i, v in enumerate(unique)}
+
+    z = np.vectorize(mapping.get)(data)
+
+    labels = [obs_types[v] for v in unique]
+
+    colorscale = []
+    for i, label in enumerate(labels):
+        colorscale.extend([
+            (i / len(labels), colors[label]),
+            ((i + 1) / len(labels), colors[label]),
+        ])
+
+    text = np.vectorize(dict(enumerate(labels)).get)(z)
+    hover_text = [
+        [
+            (
+                f"Time: {time}<br>"
+                f"Wafer: {wafer}<br>"
+                f"Type: {text[i, j]}"
+            )
+            for j, time in enumerate(times)
+        ]
+        for i, wafer in enumerate(wafers)
+    ]
+
+    heatmap = go.Figure(
+        data=go.Heatmap(
+            z=z,
+            x=times,
+            y=wafers,
+            text=hover_text,
+            hoverinfo="text",
+            zmin=0,
+            zmax=len(labels) - 1,
+            colorscale=colorscale,
+            colorbar=dict(
+                tickvals=list(range(len(labels))),
+                ticktext=labels,
+            ),
+            ygap=1,
+        )
+    )
+
+    height = {
+        "lat": 700,
+        "satp1": 300,
+        "satp2": 300,
+        "satp3": 300,
+    }.get(d.cfg.platform, 400)
+
+    heatmap.update_layout(
+        margin=dict(l=0, r=0, t=0, b=0),
+        height=height,
+    )
+
+    return ObsEfficiencyPlots(pie=pie, pie_good_pwv=pie_good_pwv, heatmap=heatmap)
+
+
+# ============================================================
+# Time series plots for HKDB fields and other metadata such as
+# hwp dir, boresight, and so on.
+# ============================================================
+
+
+def obsdb_scatter_plot(
+    x,
+    y,
+    xlabel,
+    ylabel,
+    title,
+    xlim,
+    symbols=None,
+    name=None,
+    hovertext=None,
+    fig=None,
+):
+    """Generic scatter plot for obsdb fields"""
+
+    x = np.asarray(x)
+    y = np.asarray(y)
+
+    if symbols is None:
+        symbols = np.full(len(x), "default")
+    else:
+        symbols = np.asarray(symbols)
+
+    uniq_symbols = np.unique(symbols)
+
+    symbol_map = {
+        s: MARKER_SYMBOLS[i % len(MARKER_SYMBOLS)]
+        for i, s in enumerate(uniq_symbols)
+    }
 
     if fig is None:
         fig = go.Figure()
-    for symbol in np.unique(symbols):
-        m = [s == symbol for s in symbols]
+
+    for s in uniq_symbols:
+        m = symbols == s
+
         fig.add_trace(
             go.Scatter(
-                x=np.array(x)[m],
-                y=np.array(y)[m],
-                mode='markers',
-                hovertext=hovertext,
-                marker=dict(size=8, symbol=np.array(marker_symbols)[m]),
-                name=f"{name}_{symbol}",
+                x=x[m],
+                y=y[m],
+                mode="markers",
+                marker=dict(
+                    size=8,
+                    symbol=symbol_map[s],
+                ),
+                hovertext=None if hovertext is None else np.asarray(hovertext)[m],
+                name=f"{name}_{s}" if name else str(s),
                 showlegend=True,
             )
         )
 
-    # layout
     fig.update_layout(
         margin=dict(l=40, r=40, t=140, b=40),
         height=550,
@@ -148,8 +426,9 @@ def obsdb_scatter_plot(x, y, xlabel, ylabel, title, xlim, symbols=None, name=Non
         showgrid=True,
         gridcolor="lightgray",
         zeroline=False,
-        range=[xlim[0], xlim[1]]
+        range=list(xlim),
     )
+
     fig.update_yaxes(
         title_text=ylabel,
         showgrid=True,
@@ -159,397 +438,230 @@ def obsdb_scatter_plot(x, y, xlabel, ylabel, title, xlim, symbols=None, name=Non
     return fig
 
 
-def boresight_vs_time(d: ReportData) -> go.Figure:
-    """Boresight angle and corotator in degrees vs time"""
-    tstamps = [o.start_time for o in d.obs_list if o.obs_type == "obs"]
-    boresight = [o.boresight if o.boresight is not None else np.nan for o in d.obs_list if o.obs_type == "obs"]
-    obs_ids = [o.obs_id for o in d.obs_list if o.obs_type == "obs"]
-    sub_types = [o.obs_subtype for o in d.obs_list if o.obs_type == "obs"]
-    boresight = np.round(boresight, 1)
+def plot_obs_timeseries(
+    d: ReportData,
+    field: str,
+    ylabel: str,
+    title: str,
+    transform=None,
+) -> go.Figure:
+    """
+    Generic observation timeseries plot.
+    """
 
-    if not tstamps:
+    obs = [o for o in d.obs_list if o.obs_type == "obs"]
+    if not obs:
         return go.Figure()
 
+    t = np.array([o.start_time for o in obs])
+    y = np.array([
+        np.nan if getattr(o, field, None) is None else getattr(o, field)
+        for o in obs
+    ])
+    sub_types = np.array([o.obs_subtype for o in obs])
+
+    hovertext = np.array([obs_hover(o) for o in obs])
+
+    if transform is not None:
+        y = transform(y)
+
+    order = np.argsort(t)
+
+    t = t[order]
+    y = y[order]
+    sub_types = sub_types[order]
+    hovertext = np.array(hovertext)[order]
+
+    x = [dt.datetime.fromtimestamp(tt) for tt in t]
+
+    return obsdb_scatter_plot(
+        x,
+        y,
+        xlabel="Time (UTC)",
+        ylabel=ylabel,
+        title=title,
+        xlim=[d.cfg.start_time, d.cfg.stop_time],
+        symbols=sub_types,
+        name=field,
+        hovertext=hovertext,
+    )
+
+
+def boresight_vs_time(d: ReportData) -> go.Figure:
+    """Boresight angle and corotator vs time."""
+
+    obs = [o for o in d.obs_list if o.obs_type == "obs"]
+    if not obs:
+        return go.Figure()
+
+    tstamps = np.array([o.start_time for o in obs])
+    boresight = np.array([
+        np.nan if o.boresight is None else o.boresight
+        for o in obs
+    ])
+    sub_types = np.array([o.obs_subtype for o in obs])
+
+    boresight = np.round(boresight, 1)
+
     if d.cfg.platform == "lat":
-        el_center = [o.el_center if o.el_center is not None else np.nan for o in d.obs_list if o.obs_type == "obs"]
-        tstamps, boresight, el_center, obs_ids, sub_types = zip(*sorted(zip(tstamps, boresight, el_center, obs_ids, sub_types)))
-        el_center = list(el_center)
+        el_center = np.array([
+            np.nan if o.el_center is None else o.el_center
+            for o in obs
+        ])
     else:
-        tstamps, boresight, obs_ids, sub_types = zip(*sorted(zip(tstamps, boresight, obs_ids, sub_types)))
-    tstamps = list(tstamps)
-    boresight = list(boresight)
-    obs_ids = list(obs_ids)
-    sub_types = list(sub_types)
-    tstamps = [
-        dt.datetime.fromtimestamp(t).strftime("%Y-%m-%d %H:%M:%S")
-        for t in tstamps
-    ]
+        el_center = None
 
-    fig = obsdb_scatter_plot(tstamps, boresight, "Time (UTC)", "Boresight [deg]", "Boresight",
-                             xlim=[d.cfg.start_time, d.cfg.stop_time], symbols=sub_types,
-                             name="bore", hovertext=obs_ids)
+    hovertext = np.array([obs_hover(o) for o in obs])
+
+    order = np.argsort(tstamps)
+
+    tstamps = tstamps[order]
+    boresight = boresight[order]
+    sub_types = sub_types[order]
+    hovertext = np.array(hovertext)[order]
+
+    if el_center is not None:
+        el_center = el_center[order]
+
+    x = [dt.datetime.fromtimestamp(t) for t in tstamps]
+
+    fig = obsdb_scatter_plot(
+        x,
+        boresight,
+        xlabel="Time (UTC)",
+        ylabel="Boresight [deg]",
+        title="Boresight",
+        xlim=[d.cfg.start_time, d.cfg.stop_time],
+        symbols=sub_types,
+        name="bore",
+        hovertext=hovertext,
+    )
 
     if d.cfg.platform == "lat":
-        corot = np.array(boresight) + np.array(el_center) - 60
+        corot = boresight + el_center - 60
 
-        marker_symbol_map = {}
-        for i, sub_type in enumerate(np.unique(sub_types)):
-            marker_symbol_map[sub_type] = MARKER_SYMBOLS[i]
+        for s in np.unique(sub_types):
+            m = sub_types == s
 
-        marker_symbols = [marker_symbol_map.get(s, "circle") for s in sub_types]
-
-        for sub_type in np.unique(sub_types):
-            m = [s == sub_type for s in sub_types]
             fig.add_trace(
                 go.Scatter(
-                    x=np.array(tstamps)[m],
-                    y=np.array(corot)[m],
-                    mode='markers',
-                    name=f"corot_{sub_type}",
-                    line=dict(color="#E69F00", width=2),
-                    marker=dict(size=8, symbol=np.array(marker_symbols)[m]),
+                    x=np.array(x)[m],
+                    y=corot[m],
+                    mode="markers",
+                    name=f"corot_{s}",
+                    marker=dict(size=8, symbol="circle"),
                     yaxis="y2",
-                    hovertext=obs_ids,
+                    hovertext=hovertext[m],
                 )
             )
 
         fig.update_layout(
-        yaxis2=dict(
-            title="Corotator [deg]",
-            overlaying="y",
-            side="right"
-        ))
+            yaxis2=dict(
+                title="Corotator [deg]",
+                overlaying="y",
+                side="right",
+            )
+        )
 
     return fig
 
 
-def el_vs_time(d: ReportData) -> go.Figure:
-    """Obs Elevation vs time"""
-    tstamps = [o.start_time for o in d.obs_list if o.obs_type == "obs"]
-    el_center = [o.el_center if o.el_center is not None else np.nan for o in d.obs_list if o.obs_type == "obs"]
-    obs_ids = [o.obs_id for o in d.obs_list if o.obs_type == "obs"]
-    sub_types = [o.obs_subtype for o in d.obs_list if o.obs_type == "obs"]
-    el_center = np.round(el_center, 2)
-
-    if not tstamps:
-        return go.Figure()
-
-    tstamps, el_center, obs_ids, sub_types = zip(*sorted(zip(tstamps, el_center, obs_ids, sub_types)))
-    tstamps = [
-        dt.datetime.fromtimestamp(t).strftime("%Y-%m-%d %H:%M:%S")
-        for t in tstamps
-    ]
-
-    return obsdb_scatter_plot(tstamps, el_center, "Time (UTC)", "Elevation [deg]", "Elevation",
-                          xlim=[d.cfg.start_time, d.cfg.stop_time], symbols=sub_types,
-                          name="el", hovertext=obs_ids)
-
-
-def temp_vs_time(d: ReportData) -> go.Figure:
-    """Ambient Temperature vs time"""
-    tstamps = [o.start_time for o in d.obs_list if o.obs_type == "obs"]
-    temp = [o.temp if o.temp is not None else np.nan for o in d.obs_list if o.obs_type == "obs"]
-    obs_ids = [o.obs_id for o in d.obs_list if o.obs_type == "obs"]
-    sub_types = [o.obs_subtype for o in d.obs_list if o.obs_type == "obs"]
-    temp = np.round(temp, 2)
-
-    if not tstamps:
-        return go.Figure()
-
-    tstamps, temp, obs_ids, sub_types = zip(*sorted(zip(tstamps, temp, obs_ids, sub_types)))
-    tstamps = [
-        dt.datetime.fromtimestamp(t).strftime("%Y-%m-%d %H:%M:%S")
-        for t in tstamps
-    ]
-
-    return obsdb_scatter_plot(tstamps, temp, "Time (UTC)", "Ambient Temperature [deg C]",
-                           "Ambient Temperature", xlim=[d.cfg.start_time, d.cfg.stop_time],
-                           symbols=sub_types, name="temp", hovertext=obs_ids)
-
-
-def uv_vs_time(d: ReportData) -> go.Figure:
-    """UV vs time"""
-    tstamps = [o.start_time for o in d.obs_list if o.obs_type == "obs"]
-    uv = [o.uv if o.uv is not None else np.nan for o in d.obs_list if o.obs_type == "obs"]
-    obs_ids = [o.obs_id for o in d.obs_list if o.obs_type == "obs"]
-    sub_types = [o.obs_subtype for o in d.obs_list if o.obs_type == "obs"]
-    uv = np.round(uv, 2)
-
-    if not tstamps:
-        return go.Figure()
-
-    tstamps, uv, obs_ids, sub_types = zip(*sorted(zip(tstamps, uv, obs_ids, sub_types)))
-    tstamps = [
-        dt.datetime.fromtimestamp(t).strftime("%Y-%m-%d %H:%M:%S")
-        for t in tstamps
-    ]
-
-    return obsdb_scatter_plot(tstamps, uv, "Time (UTC)", "UV Index",
-                              "UV Index", xlim=[d.cfg.start_time, d.cfg.stop_time],
-                              symbols=sub_types, name="uv_index", hovertext=obs_ids)
-
-
-def wind_speed_vs_time(d: ReportData) -> go.Figure:
-    """Wind speed vs time"""
-    tstamps = [o.start_time for o in d.obs_list if o.obs_type == "obs"]
-    wind_speed = [o.wind_speed if o.wind_speed is not None else np.nan for o in d.obs_list if o.obs_type == "obs"]
-    obs_ids = [o.obs_id for o in d.obs_list if o.obs_type == "obs"]
-    sub_types = [o.obs_subtype for o in d.obs_list if o.obs_type == "obs"]
-    wind_speed = np.round(wind_speed, 2)
-
-    if not tstamps:
-        return go.Figure()
-
-    tstamps, wind_speed, obs_ids, sub_types = zip(*sorted(zip(tstamps, wind_speed, obs_ids, sub_types)))
-    tstamps = [
-        dt.datetime.fromtimestamp(t).strftime("%Y-%m-%d %H:%M:%S")
-        for t in tstamps
-    ]
-
-    return obsdb_scatter_plot(tstamps, wind_speed, "Time (UTC)", "Wind Speed [km / s]",
-                           "Wind Speed", xlim=[d.cfg.start_time, d.cfg.stop_time],
-                           symbols=sub_types, name="wind_spd", hovertext=obs_ids)
-
-
-def wind_dir_vs_time(d: ReportData) -> go.Figure:
-    """Wind Direction vs time"""
-    tstamps = [o.start_time for o in d.obs_list if o.obs_type == "obs"]
-    wind_dir = [o.wind_dir if o.wind_dir is not None else np.nan for o in d.obs_list if o.obs_type == "obs"]
-    obs_ids = [o.obs_id for o in d.obs_list if o.obs_type == "obs"]
-    sub_types = [o.obs_subtype for o in d.obs_list if o.obs_type == "obs"]
-    wind_dir = np.round(wind_dir, 2)
-
-    if not tstamps:
-        return go.Figure()
-
-    tstamps, wind_dir, obs_ids, sub_types = zip(*sorted(zip(tstamps, wind_dir, obs_ids, sub_types)))
-    tstamps = [
-        dt.datetime.fromtimestamp(t).strftime("%Y-%m-%d %H:%M:%S")
-        for t in tstamps
-    ]
-
-    return obsdb_scatter_plot(tstamps, wind_dir, "Time (UTC)", "Wind Dir [deg]",
-                           "Wind Dir", xlim=[d.cfg.start_time, d.cfg.stop_time],
-                           symbols=sub_types, name="wind_dir", hovertext=obs_ids)
-
-
 def scan_type_vs_time(d: ReportData) -> go.Figure:
-    """Scan type vs time"""
+    """Scan type vs time."""
 
-    options = ["type1", "type2", "type3"]
-    tstamps = []
-    scan_types = []
-    obs_ids = []
-    sub_types = []
+    options = {"type1", "type2", "type3"}
 
+    hovertext = []
+    obs = []
     for o in d.obs_list:
         if o.obs_type != "obs":
             continue
-        matches = [item for item in o.obs_tags.split(',') if item in options]
-        if matches:
-            tstamps.append(o.start_time)
-            scan_types.append(matches[0])
-            obs_ids.append(o.obs_id)
-            sub_types.append(o.obs_subtype)
 
-    if not tstamps:
+        tags = set(o.obs_tags.split(",")) if o.obs_tags else set()
+        match = next((t for t in tags if t in options), None)
+
+        if match is not None:
+            obs.append((o.start_time, match, o.obs_subtype))
+            hovertext.append(obs_hover(o))
+
+    if not obs:
         return go.Figure()
 
-    tstamps, scan_types, obs_ids, sub_types = zip(*sorted(zip(tstamps, scan_types, obs_ids, sub_types)))
-    tstamps = [
-        dt.datetime.fromtimestamp(t).strftime("%Y-%m-%d %H:%M:%S")
-        for t in tstamps
-    ]
+    tstamps, scan_types, sub_types = map(np.array, zip(*obs))
 
-    return obsdb_scatter_plot(tstamps, scan_types, "Time (UTC)", "Scan Type", "Scan Type",
-                              xlim=[d.cfg.start_time, d.cfg.stop_time], symbols=sub_types,
-                              name="scan_type", hovertext=obs_ids)
+    order = np.argsort(tstamps)
+
+    tstamps = tstamps[order]
+    scan_types = scan_types[order]
+    sub_types = sub_types[order]
+    hovertext = np.array(hovertext)[order]
+
+    x = [dt.datetime.fromtimestamp(t) for t in tstamps]
+
+    return obsdb_scatter_plot(
+        x,
+        scan_types,
+        xlabel="Time (UTC)",
+        ylabel="Scan Type",
+        title="Scan Type",
+        xlim=[d.cfg.start_time, d.cfg.stop_time],
+        symbols=sub_types,
+        name="scan_type",
+        hovertext=hovertext,
+    )
 
 
 def hwp_freq_vs_time(d: ReportData) -> go.Figure:
-    """Mean HWP frequency vs time"""
-    if d.cfg.platform in ["satp1", "satp2", "satp3"]:
-        tstamps = [o.start_time for o in d.obs_list if o.obs_type == "obs"]
-        hwp_freq_mean = [o.hwp_freq_mean if o.hwp_freq_mean is not None else np.nan for o in d.obs_list if o.obs_type == "obs"]
-        obs_ids = [o.obs_id for o in d.obs_list if o.obs_type == "obs"]
-        sub_types = [o.obs_subtype for o in d.obs_list if o.obs_type == "obs"]
-        hwp_freq_mean = np.round(hwp_freq_mean, 2)
+    """Mean HWP frequency vs time (SAT only)."""
 
-        if not tstamps:
-            return go.Figure()
-
-        tstamps, hwp_freq_mean, obs_ids, sub_types = zip(*sorted(zip(tstamps, hwp_freq_mean, obs_ids, sub_types)))
-        tstamps = [
-            dt.datetime.fromtimestamp(t).strftime("%Y-%m-%d %H:%M:%S")
-            for t in tstamps
-        ]
-
-        return obsdb_scatter_plot(tstamps, hwp_freq_mean, "Time (UTC)", "Mean HWP Freq [Hz]", "Mean HWP Freq",
-                                  xlim=[d.cfg.start_time, d.cfg.stop_time], symbols=sub_types,
-                                  name="hwp_freq", hovertext=obs_ids)
-    else:
+    if d.cfg.platform not in {"satp1", "satp2", "satp3"}:
         return go.Figure()
 
-
-def wafer_obs_efficiency(d: ReportData, nsegs=3000) -> ObsEfficiencyPlots:
-    """Plot heatmap of wafer vs time and pie chart showing observation efficiency"""
-
-    wafers = get_wafers(d.cfg.platform)
-    nwafers = len(wafers)
-
-    times = pd.date_range(d.cfg.start_time, d.cfg.stop_time, nsegs).to_pydatetime()
-    tstamps = np.array([t.timestamp() for t in times])
-
-    obs_types = ["cmb", "obs", "cal", "oper"] + d.cfg.cal_targets + ["idle"]
-    obs_values = {k: i for i, k in enumerate(obs_types)}
-
-    data = np.ones((nwafers, nsegs), dtype=int) * (len(obs_types) - 1)
-    data_pie = np.ones((nwafers, nsegs), dtype=int) * (len(obs_types) - 1)
-
-    for o in d.obs_list:
-        m = np.logical_and.reduce([tstamps > o.start_time, tstamps < o.stop_time])
-        wafer_slots_list = o.wafer_slots_list.split(",")
-        for wafer_slot in wafer_slots_list:
-            if d.cfg.platform == "lat":
-                idx = np.where(np.array(wafers) == o.obs_tube_slot + "_" + wafer_slot)[0][0]
-            else:
-                idx = int(wafer_slot.strip()[-1])
-            if o.obs_type == "obs":
-                if o.obs_subtype == "cmb":
-                    data[idx][m] = obs_values[o.obs_subtype]
-                elif o.obs_subtype == "cal":
-                    matches = [item for item in o.obs_tags.split(',') if item in d.cfg.cal_targets]
-                    if matches:
-                        data[idx][m] = obs_values[matches[0]]
-                    else:
-                        data[idx][m] = obs_values[o.obs_subtype]
-                else:
-                    data[idx][m] = obs_values[o.obs_type]
-            else:
-                data[idx][m] = obs_values[o.obs_type]
-
-    reverse = False
-    if (data == (len(obs_types) - 1)).all():
-        reverse = True
-
-    # pwv < 3
-    for o in d.obs_list:
-        if o.pwv > 3:
-            continue
-        m = np.logical_and.reduce([tstamps > o.start_time, tstamps < o.stop_time])
-        wafer_slots_list = o.wafer_slots_list.split(",")
-        for wafer_slot in wafer_slots_list:
-            if d.cfg.platform == "lat":
-                idx = np.where(np.array(wafers) == o.obs_tube_slot + "_" + wafer_slot)[0][0]
-            else:
-                idx = int(wafer_slot.strip()[-1])
-            if o.obs_type == "obs":
-                if o.obs_subtype == "cmb":
-                    data_pie[idx][m] = obs_values[o.obs_subtype]
-                elif o.obs_subtype == "cal":
-                    matches = [item for item in o.obs_tags.split(',') if item in d.cfg.cal_targets]
-                    if matches:
-                        data_pie[idx][m] = obs_values[matches[0]]
-                    else:
-                        data_pie[idx][m] = obs_values[o.obs_subtype]
-                else:
-                    data_pie[idx][m] = obs_values[o.obs_type]
-            else:
-                data_pie[idx][m] = obs_values[o.obs_type]
-
-    pwv_interp = np.interp(tstamps, d.pwv[0], d.pwv[1])
-    good = pwv_interp < 3
-
-    pies = []
-
-    datasets = [
-        data,
-        data[:, good],
+    obs = [
+        o for o in d.obs_list
+        if o.obs_type == "obs"
     ]
 
-    for arr in datasets:
-        unique_vals, counts = np.unique(arr, return_counts=True)
-        percentages = counts / counts.sum() * 100
-        labels = [obs_types[i] for i in unique_vals]
-        COLORS = Colors(names=labels, reverse=reverse)
-        colorscale = []
+    if not obs:
+        return go.Figure()
 
-        ntypes = len(labels)
+    tstamps = np.array([o.start_time for o in obs])
+    hwp = np.array([
+        np.nan if o.hwp_freq_mean is None else o.hwp_freq_mean
+        for o in obs
+    ])
+    sub_types = np.array([o.obs_subtype for o in obs])
 
-        for i, t in enumerate(labels):
-            colorscale.extend([
-                (i / ntypes, COLORS[t]),
-                ((i + 1) / ntypes, COLORS[t])
-            ])
+    hwp = np.round(hwp, 2)
 
-        pie_colors = [COLORS[t] for t in labels]
+    hovertext = np.array([obs_hover(o) for o in obs])
 
-        colorbar = dict(
-            tickvals=list(range(len(labels))),
-            ticktext=labels,
-        )
+    order = np.argsort(tstamps)
 
-        fig = go.Figure(
-            data=go.Pie(
-                labels=labels,
-                values=percentages,
-                textinfo="label+percent",
-            ),
-        )
+    tstamps = tstamps[order]
+    hwp = hwp[order]
+    sub_types = sub_types[order]
+    hovertext = np.array(hovertext)[order]
 
-        fig.update_traces(
-            marker=dict(colors=pie_colors)
-        )
+    x = [dt.datetime.fromtimestamp(t) for t in tstamps]
 
-        fig.update_layout(
-            margin=dict(l=0, r=0, t=0, b=0),
-            height=300
-        )
-
-        pies.append(fig)
-
-    unique_sorted = np.sort(np.unique(data))
-    labels = [obs_types[i] for i in unique_vals]
-    mapping = {v: i for i, v in enumerate(unique_sorted)}
-    vectorized_map = np.vectorize(mapping.get)
-    data = vectorized_map(data)
-
-    value_to_label = {i: lbl for i, lbl in enumerate(labels)}
-    text = np.vectorize(value_to_label.get)(data)
-
-    ys = wafers
-
-    hover_text = []
-    for yi, yval in enumerate(ys):
-        row = []
-        for xi, xval in enumerate(times):
-            label = text[yi, xi]
-            row.append(f"x: {xval}<br>y: {yval}<br>z: {label}")
-        hover_text.append(row)
-
-    heatmap = go.Figure(
-        data=go.Heatmap(
-            z=data,
-            zmin=0,
-            zmax=len(labels) - 1,
-            x=times,
-            y=ys,
-            text=hover_text,
-            hoverinfo="text",
-            colorscale=colorscale,
-            colorbar=dict(tickvals=list(range(len(labels))), ticktext=labels,),
-            ygap=1,
-        ),
+    return obsdb_scatter_plot(
+        x,
+        hwp,
+        xlabel="Time (UTC)",
+        ylabel="Mean HWP Freq [Hz]",
+        title="Mean HWP Frequency",
+        xlim=[d.cfg.start_time, d.cfg.stop_time],
+        symbols=sub_types,
+        name="hwp_freq",
+        hovertext=hovertext,
     )
 
-    if d.cfg.platform == "lat":
-        height = 700
-    elif d.cfg.platform in ["satp1", "satp2", "satp3"]:
-        height = 300
 
-    heatmap.update_layout(margin=dict(l=0, r=0, t=0, b=0), height=height)
-
-    return ObsEfficiencyPlots(pie=pies[0], pie_good_pwv=pies[1], heatmap=heatmap)
+# ============================================================
+# PWV, Yield, and NEPs (array averaged and effective detector)
+# related plots.
+# ============================================================
 
 
 def pwv_vs_time(d: ReportData, fig: go.Figure, ds_factor: int=5):
@@ -594,226 +706,61 @@ def pwv_vs_time(d: ReportData, fig: go.Figure, ds_factor: int=5):
     return fig
 
 
-def pwv_and_yield_vs_time(d: "ReportData") -> go.Figure:
-    """PWV and yield as a function of time"""
+def pwv_and_timeseries_vs_time(
+    d: "ReportData",
+    mode: str,
+    field_name: str | None = None,
+) -> go.Figure:
+    """PWV and time-series plot (yield or NEP)."""
+
     fig = make_subplots(specs=[[{"secondary_y": True}]])
 
-    yields = defaultdict(list)
     times = defaultdict(list)
+    values = defaultdict(lambda: defaultdict(list))
     hover = defaultdict(list)
 
-    # build a dict keyed off of bandpass for data from all obs
     for obs in d.obs_list:
-        obs_time = dt.datetime.fromtimestamp(obs.start_time, tz=dt.timezone.utc)
-        if obs.num_valid_dets.size > 0:
+        t = dt.datetime.fromtimestamp(obs.start_time, tz=dt.timezone.utc)
+
+        if mode == "yield":
+            if obs.num_valid_dets.size == 0:
+                continue
+
             for b in obs.num_valid_dets.dtype.names:
-                times[b].append(obs_time)
-                yields[b].append(obs.num_valid_dets[b][0])
-                hover[b].append(obs.obs_id)
+                times[b].append(t)
+                values[b]["yield"].append(obs.num_valid_dets[b][0])
+                hover[b].append(obs_hover(obs))
 
-    # yield trace
-    for i, b in enumerate(sorted(yields)):
-        fig.add_trace(
-            go.Scatter(
-                x=times[b],
-                y=yields[b],
-                mode="markers",
-                name=f"Valid Dets ({b})",
-                marker=dict(
-                    color=MARKER_COLORS[i % len(MARKER_COLORS)],
-                    symbol=MARKER_SYMBOLS[i % len(MARKER_SYMBOLS)],
-                    size=8,
-                    line=dict(width=1, color="black"),
-                ),
-                hovertext=hover[b],
-            ),
-            secondary_y=False,
-        )
+        elif mode == "nep":
+            field = obs.array_nep if field_name == "array" else obs.det_nep
+            if field.size == 0:
+                continue
 
-    # PWV trace
-    fig = pwv_vs_time(d, fig)
+            for b in field.dtype.names:
+                times[b].append(t)
+                hover[b].append(obs_hover(obs))
 
-    # layout
-    fig.update_layout(
-        margin=dict(l=40, r=40, t=80, b=40),
-        height=550,
-        template="plotly_white",
-        legend=dict(
-            orientation="h",
-            yanchor="bottom",
-            y=1.02,
-            xanchor="right",
-            x=1,
-            bgcolor="rgba(255,255,255,0.8)",
-            bordercolor="lightgray",
-            borderwidth=1,
-        ),
-        title=dict(
-            text="Valid Detectors and PWV",
-            x=0.5,
-            xanchor="center",
-            y=0.97,
-            yanchor="top",
-            font=dict(size=18),
-        ),
-    )
-
-    fig.update_xaxes(
-        title_text="Time (UTC)",
-        showgrid=True,
-        gridcolor="lightgray",
-        zeroline=False,
-    )
-    fig.update_yaxes(
-        title_text="Num Valid Dets",
-        secondary_y=False,
-        showgrid=True,
-        gridcolor="lightgray",
-    )
-    fig.update_yaxes(
-        title_text="PWV [mm]",
-        secondary_y=True,
-        showgrid=True,
-    )
-
-    return fig
-
-
-def yield_vs_pwv(d: "ReportData", longterm_data: Optional["ReportData"] = None) -> go.Figure:
-    """Number of valid detectors as a function of PWV. Current interval is plotted over
-    longterm contours.
-    """
-    fig = go.Figure()
-
-    if longterm_data is not None:
-        long_yields = defaultdict(list)
-        long_pwvs = []
-        for obs in longterm_data.obs_list:
-            if obs.num_valid_dets.size > 0:
-                if np.isfinite(obs.pwv):
-                    long_pwvs.append(obs.pwv)
-                    for b in obs.num_valid_dets.dtype.names:
-                        long_yields[b].append(obs.num_valid_dets[b][0])
-
-        for i, b in enumerate(sorted(long_yields)):
-            fig.add_trace(
-                go.Histogram2dContour(
-                    x=long_pwvs,
-                    y=long_yields[b],
-                    colorscale=[[0, MARKER_COLORS[i]], [1, MARKER_COLORS[i]]],
-                    contours_coloring="lines",
-                    showscale=False,
-                    opacity=0.7,
-                    name=f"longterm {b}",
-                    showlegend=True,
-                )
-            )
-
-    yields = defaultdict(list)
-    pwvs = []
-    hover = defaultdict(list)
-
-    # build a dict keyed off of bandpass for data from all obs
-    for obs in d.obs_list:
-        if obs.num_valid_dets.size > 0:
-             if np.isfinite(obs.pwv):
-                pwvs.append(obs.pwv)
-                for b in obs.num_valid_dets.dtype.names:
-                    yields[b].append(obs.num_valid_dets[b][0])
-                    hover[b].append(obs.obs_id)
-
-    # yield and pwv trace
-    for i, b in enumerate(sorted(yields)):
-        fig.add_trace(
-            go.Scatter(
-                x=pwvs,
-                y=yields[b],
-                mode="markers",
-                name=f"Valid Dets ({b})",
-                marker=dict(
-                    color=MARKER_COLORS[i % len(MARKER_COLORS)],
-                    symbol=MARKER_SYMBOLS[i % len(MARKER_SYMBOLS)],
-                    size=8,
-                    line=dict(width=1, color="black"),
-                ),
-                hovertext=hover[b],
-            )
-        )
-
-    # layout
-    fig.update_layout(
-        margin=dict(l=40, r=40, t=80, b=40),
-        height=550,
-        template="plotly_white",
-        legend=dict(
-            orientation="h",
-            yanchor="bottom",
-            y=1.02,
-            xanchor="right",
-            x=1,
-            bgcolor="rgba(255,255,255,0.8)",
-            bordercolor="lightgray",
-            borderwidth=1,
-        ),
-        title=dict(
-            text="Valid Detectors and PWV",
-            x=0.5,
-            xanchor="center",
-            y=0.97,
-            yanchor="top",
-            font=dict(size=18),
-        ),
-    )
-
-    fig.update_xaxes(
-        title_text="PWV [mm]",
-        showgrid=True,
-        gridcolor="lightgray",
-        zeroline=False,
-    )
-    fig.update_yaxes(
-        title_text="Num Valid Dets",
-        showgrid=True,
-        gridcolor="lightgray",
-    )
-
-    return fig
-
-
-def pwv_and_nep_vs_time(d: "ReportData", field_name: str = None) -> go.Figure:
-    """PWV and NEPs as a function of time"""
-    fig = make_subplots(specs=[[{"secondary_y": True}]])
-
-    neps = defaultdict(lambda: defaultdict(list))
-    times = defaultdict(list)
-    hover = defaultdict(list)
-
-    # build a dict keyed off of bandpass for data from all obs
-    for obs in d.obs_list:
-        obs_time = dt.datetime.fromtimestamp(obs.start_time, tz=dt.timezone.utc)
-        if field_name == "array":
-            field = obs.array_nep
-        elif field_name == "det":
-            field = obs.det_nep
-        if field.size > 0:
-            for b in obs.array_nep.dtype.names:
-                times[b].append(obs_time)
-                hover[b].append(obs.obs_id)
                 for i, pol in enumerate(field[b].dtype.names):
-                    if pol not in neps[b].keys():
-                        neps[b][pol] = []
-                    neps[b][pol].append(field[b][0][i])
+                    values[b][pol].append(field[b][0][i])
 
-    # nep trace
     i = 0
-    for b in sorted(neps):
-        for pol, nep in neps[b].items():
+
+    for b in sorted(values):
+
+        for k, arr in values[b].items():
+
+            label = (
+                f"{k} ({b})"
+                if mode == "nep"
+                else f"Valid Dets ({b})"
+            )
+
             fig.add_trace(
                 go.Scatter(
                     x=times[b],
-                    y=nep,
+                    y=arr,
                     mode="markers",
-                    name=f"{pol.split('_')[-1]} ({b})",
+                    name=label,
                     marker=dict(
                         color=MARKER_COLORS[i % len(MARKER_COLORS)],
                         symbol=MARKER_SYMBOLS[i % len(MARKER_SYMBOLS)],
@@ -826,12 +773,20 @@ def pwv_and_nep_vs_time(d: "ReportData", field_name: str = None) -> go.Figure:
             )
             i += 1
 
-    # PWV trace
     fig = pwv_vs_time(d, fig)
 
-    # layout
+    if mode == "yield":
+        title = "Valid Detectors and PWV"
+        y_left = "Num Valid Dets"
+        tpad = 80
+
+    else:
+        title = f"{field_name.capitalize()} NEP and PWV"
+        y_left = r"$\rm{NEP\ [aW/\sqrt{Hz}]}$"
+        tpad = 140
+
     fig.update_layout(
-        margin=dict(l=40, r=40, t=140, b=40),
+        margin=dict(l=40, r=40, t=tpad, b=40),
         height=550,
         template="plotly_white",
         legend=dict(
@@ -845,10 +800,10 @@ def pwv_and_nep_vs_time(d: "ReportData", field_name: str = None) -> go.Figure:
             borderwidth=1,
         ),
         title=dict(
-            text=f"{field_name.capitalize()} NEP and PWV",
+            text=title,
             x=0.5,
             xanchor="center",
-            y=0.92,
+            y=0.95,
             yanchor="top",
             font=dict(size=18),
         ),
@@ -860,12 +815,14 @@ def pwv_and_nep_vs_time(d: "ReportData", field_name: str = None) -> go.Figure:
         gridcolor="lightgray",
         zeroline=False,
     )
+
     fig.update_yaxes(
-        title_text=r"$\rm{NEP\ [aW/\sqrt{Hz}]}$",
+        title_text=y_left,
         secondary_y=False,
         showgrid=True,
         gridcolor="lightgray",
     )
+
     fig.update_yaxes(
         title_text="PWV [mm]",
         secondary_y=True,
@@ -875,76 +832,114 @@ def pwv_and_nep_vs_time(d: "ReportData", field_name: str = None) -> go.Figure:
     return fig
 
 
-def nep_vs_pwv(d: "ReportData", longterm_data: Optional["ReportData"] = None,
-               field_name: str = None) -> go.Figure:
-    """NEP as a function of PWV. Current interval is plotted over longterm contours.
-    """
+def pwv_and_yield_vs_time(d):
+    return pwv_and_timeseries_vs_time(d, mode="yield")
+
+
+def pwv_and_nep_vs_time(d, field_name="array"):
+    return pwv_and_timeseries_vs_time(d, mode="nep", field_name=field_name)
+
+
+def field_vs_pwv(
+    d: "ReportData",
+    mode: str,
+    longterm_data: Optional["ReportData"] = None,
+    field_name: str | None = None,
+) -> go.Figure:
+    """Generic PWV vs field plot (yield or NEP)."""
+
     fig = go.Figure()
 
     if longterm_data is not None:
-        long_neps = defaultdict(lambda: defaultdict(list))
+
+        long_vals = defaultdict(lambda: defaultdict(list))
         long_pwvs = []
 
         for obs in longterm_data.obs_list:
-            if field_name == "array":
-                field = obs.array_nep
-            elif field_name == "det":
-                field = obs.det_nep
-            if field.size > 0:
-                if np.isfinite(obs.pwv):
-                    long_pwvs.append(obs.pwv)
-                    for b in field.dtype.names:
-                        for i, pol in enumerate(field[b].dtype.names):
-                            if pol not in long_neps[b].keys():
-                                long_neps[b][pol] = []
-                            long_neps[b][pol].append(field[b][0][i])
+            if np.isfinite(obs.pwv):
 
-        i = 0
-        for b in sorted(long_neps):
-            for pol, long_nep in long_neps[b].items():
+                if mode == "yield":
+                    field = obs.num_valid_dets
+                else:
+                    field = obs.array_nep if field_name == "array" else obs.det_nep
+
+                if field.size == 0:
+                    continue
+
+                long_pwvs.append(obs.pwv)
+
+                for b in field.dtype.names:
+                    if mode == "yield":
+                        long_vals[b]["yield"].append(field[b][0])
+                    else:
+                        for i, pol in enumerate(field[b].dtype.names):
+                            long_vals[b][pol].append(field[b][0][i])
+
+        c = 0
+        for b in sorted(long_vals):
+            for k, vals in long_vals[b].items():
+
                 fig.add_trace(
                     go.Histogram2dContour(
                         x=long_pwvs,
-                        y=long_nep,
-                        colorscale=[[0, MARKER_COLORS[i]], [1, MARKER_COLORS[i]]],
+                        y=vals,
+                        colorscale=[[0, MARKER_COLORS[c]], [1, MARKER_COLORS[c]]],
                         contours_coloring="lines",
                         showscale=False,
                         opacity=0.7,
-                        name=f"longterm {b}_{pol.split('_')[-1]}",
+                        name=f"longterm {b}_{k}",
                         showlegend=True,
                     )
                 )
-                i += 1
+                c += 1
 
-    neps = defaultdict(lambda: defaultdict(list))
+    vals = defaultdict(lambda: defaultdict(list))
     pwvs = []
     hover = defaultdict(list)
 
-    # build a dict keyed off of bandpass for data from all obs
     for obs in d.obs_list:
-        if field_name == "array":
-            field = obs.array_nep
-        elif field_name == "det":
-            field = obs.det_nep
-        if field.size > 0:
-            if np.isfinite(obs.pwv):
-                pwvs.append(obs.pwv)
-                for b in field.dtype.names:
-                    hover[b].append(obs.obs_id)
-                    for i, pol in enumerate(field[b].dtype.names):
-                        if pol not in neps[b].keys():
-                            neps[b][pol] = []
-                        neps[b][pol].append(field[b][0][i])
+        if not np.isfinite(obs.pwv):
+            continue
+
+        pwvs.append(obs.pwv)
+
+        if mode == "yield":
+            field = obs.num_valid_dets
+            if field.size == 0:
+                continue
+
+            for b in field.dtype.names:
+                if 'o3' in obs.obs_id:
+                    print(b, obs.obs_id)
+                vals[b]["yield"].append(field[b][0])
+                hover[b].append(obs_hover(obs))
+
+        else:
+            field = obs.array_nep if field_name == "array" else obs.det_nep
+            if field.size == 0:
+                continue
+
+            for b in field.dtype.names:
+                hover[b].append(obs_hover(obs))
+                for i, pol in enumerate(field[b].dtype.names):
+                    vals[b][pol].append(field[b][0][i])
 
     i = 0
-    for b in sorted(neps):
-        for pol, nep in neps[b].items():
+    for b in sorted(vals):
+        for k, arr in vals[b].items():
+
+            label = (
+                f"Valid Dets ({b})"
+                if mode == "yield"
+                else f"{k.split('_')[-1]} ({b})"
+            )
+
             fig.add_trace(
                 go.Scatter(
                     x=pwvs,
-                    y=nep,
+                    y=arr,
                     mode="markers",
-                    name=f"{pol.split('_')[-1]} ({b})",
+                    name=label,
                     marker=dict(
                         color=MARKER_COLORS[i % len(MARKER_COLORS)],
                         symbol=MARKER_SYMBOLS[i % len(MARKER_SYMBOLS)],
@@ -956,9 +951,17 @@ def nep_vs_pwv(d: "ReportData", longterm_data: Optional["ReportData"] = None,
             )
             i += 1
 
-    # layout
+    if mode == "yield":
+        title = "Valid Detectors and PWV"
+        ylab = "Num Valid Dets"
+        tpad = 80
+    else:
+        title = f"{field_name.capitalize()} NEP and PWV"
+        ylab = r"$\rm{NEP\ [aW/\sqrt{Hz}]}$"
+        tpad = 140
+
     fig.update_layout(
-        margin=dict(l=40, r=40, t=140, b=40),
+        margin=dict(l=40, r=40, t=tpad, b=40),
         height=550,
         template="plotly_white",
         legend=dict(
@@ -972,10 +975,10 @@ def nep_vs_pwv(d: "ReportData", longterm_data: Optional["ReportData"] = None,
             borderwidth=1,
         ),
         title=dict(
-            text=f"{field_name.capitalize()} NEP and PWV",
+            text=title,
             x=0.5,
             xanchor="center",
-            y=0.92,
+            y=0.95,
             yanchor="top",
             font=dict(size=18),
         ),
@@ -987,13 +990,28 @@ def nep_vs_pwv(d: "ReportData", longterm_data: Optional["ReportData"] = None,
         gridcolor="lightgray",
         zeroline=False,
     )
+
     fig.update_yaxes(
-        title_text=r"$\rm{NEP\ [aW/\sqrt{Hz}]}$",
+        title_text=ylab,
         showgrid=True,
         gridcolor="lightgray",
     )
 
     return fig
+
+
+def yield_vs_pwv(d, longterm_data=None):
+    return field_vs_pwv(d, mode="yield", longterm_data=longterm_data)
+
+
+def nep_vs_pwv(d, longterm_data=None, field_name=None):
+    return field_vs_pwv(
+        d,
+        mode="nep",
+        longterm_data=longterm_data,
+        field_name=field_name,
+    )
+
 
 def cov_map_plot(map_png_file: str, embed:bool=True) -> str:
     import base64
@@ -1001,7 +1019,7 @@ def cov_map_plot(map_png_file: str, embed:bool=True) -> str:
     if map_png_file is None or not os.path.isfile(map_png_file):
         return "<p>Coverage map not found</p>"
 
-    # Embed image as base64 (guaranteed to work)
+    # Embed image as base64
     if embed:
         with open(map_png_file, "rb") as f:
             b64 = base64.b64encode(f.read()).decode("ascii")
@@ -1018,6 +1036,13 @@ def cov_map_plot(map_png_file: str, embed:bool=True) -> str:
         f'style="max-width:100%; height:auto;" '
         f'alt="Coverage Map">'
     )
+
+
+# ============================================================
+# Source footprint plots.
+# ============================================================
+
+
 @dataclass
 class SourceFootprintPlots:
     focalplane: go.Figure
@@ -1043,23 +1068,54 @@ def source_footprints(d: "ReportData") -> go.Figure:
 
     elif d.cfg.platform == "lat":
         wafer_rad = 0.005236
-        pie_width = 0.125
-        x0s = [-0.00647517,  0.00316777,  0.00316777, -0.03335673, -0.02370855,
-               -0.02371379,  0.02070833,  0.03023957,  0.03025179,  0.0204762 ,
-                0.03025005,  0.03023957, -0.00637918,  0.00327947,  0.00325853,
-               -0.03330437, -0.02369634, -0.02370855]
+        pie_width = 0.0625
+        x0s = [
+            -0.00619278,  0.00317458,  0.00316847,
+            -0.03301884, -0.02378116, -0.02375480,
+            -0.00610289,  0.00317318,  0.00323130,
+             0.02089648,  0.03016575,  0.03018966,
+             0.02082073,  0.03019804,  0.03015737,
+            -0.00610289,  0.00323881,  0.00316568,
+            -0.03301779, -0.02374625, -0.02378954,
+            -0.02350644, -0.03283837, -0.02360279,
+             0.03350055,  0.02415571,  0.02406826,
+             0.05734820,  0.05733965,  0.04790702,
+             0.02416426,  0.03350072,  0.02405971,
+            -0.03283854, -0.02349789, -0.02361134,
+            -0.05998592, -0.05038556, -0.05038556,
+        ]
 
-        y0s = [ 0.        ,  0.00560425, -0.00560425, -0.01579872, -0.00995536,
-               -0.02117608, -0.01556659, -0.0099571 , -0.02117957,  0.01579872,
-                0.02117957,  0.0099571 ,  0.03112446,  0.03673045,  0.02551671,
-                0.01556834,  0.02117608,  0.01021716]
+        y0s = [
+             5.24e-06,  0.00548417, -0.00548732,
+            -0.01565927, -0.01019534, -0.02093994,
+            -0.03111852, -0.02575652, -0.03649641,
+            -0.01562349, -0.01019778, -0.02094709,
+             0.01557305,  0.02094255,  0.01019325,
+             0.03112830,  0.03649204,  0.02575216,
+             0.01557287,  0.02093540,  0.01019080,
+            -0.05206474, -0.04667656, -0.04128960,
+            -0.04669977, -0.05206684, -0.04129466,
+             0.00539656, -0.00540162,  4.89e-06,
+             0.05207190,  0.04668983,  0.04129973,
+             0.04668634,  0.05205968,  0.04128472,
+             3.50e-07,  0.00561629, -0.00561577,
+        ]
 
-        wafers = ['c1_ws0', 'c1_ws1', 'c1_ws2',
-                  'i1_ws0', 'i1_ws1', 'i1_ws2',
-                  'i3_ws0', 'i3_ws1', 'i3_ws2',
-                  'i4_ws0', 'i4_ws1', 'i4_ws2',
-                  'i5_ws0', 'i5_ws1', 'i5_ws2',
-                  'i6_ws0', 'i6_ws1', 'i6_ws2']
+        wafers = [
+            'c1_ws0', 'c1_ws1', 'c1_ws2',
+            'i1_ws0', 'i1_ws1', 'i1_ws2',
+            'i2_ws0', 'i2_ws1', 'i2_ws2',
+            'i3_ws0', 'i3_ws1', 'i3_ws2',
+            'i4_ws0', 'i4_ws1', 'i4_ws2',
+            'i5_ws0', 'i5_ws1', 'i5_ws2',
+            'i6_ws0', 'i6_ws1', 'i6_ws2',
+            'o1_ws0', 'o1_ws1', 'o1_ws2',
+            'o2_ws0', 'o2_ws1', 'o2_ws2',
+            'o3_ws0', 'o3_ws1', 'o3_ws2',
+            'o4_ws0', 'o4_ws1', 'o4_ws2',
+            'o5_ws0', 'o5_ws1', 'o5_ws2',
+            'o6_ws0', 'o6_ws1', 'o6_ws2',
+        ]
 
         wafer_centers = {}
         for i, wafer in enumerate(wafers):
@@ -1126,7 +1182,7 @@ def source_footprints(d: "ReportData") -> go.Figure:
 
         return norm_positions
 
-    norm_positions = get_normalized_positions(wafer_centers, x_range, y_range, 700, 700)
+    norm_positions = get_normalized_positions(wafer_centers, x_range, y_range, 900, 900)
 
     def normalize_values(values, target_total=100):
         total = sum(values)

--- a/sotodlib/qa/quality_reports/plots.py
+++ b/sotodlib/qa/quality_reports/plots.py
@@ -829,6 +829,7 @@ def pwv_and_timeseries_vs_time(
         secondary_y=False,
         showgrid=True,
         gridcolor="lightgray",
+        type="log",
     )
 
     fig.update_yaxes(

--- a/sotodlib/qa/quality_reports/plots.py
+++ b/sotodlib/qa/quality_reports/plots.py
@@ -720,6 +720,9 @@ def pwv_and_timeseries_vs_time(
     hover = defaultdict(list)
 
     for obs in d.obs_list:
+        if obs.obs_subtype != "cmb":
+            continue
+
         t = dt.datetime.fromtimestamp(obs.start_time, tz=dt.timezone.utc)
 
         if mode == "yield":
@@ -898,7 +901,10 @@ def field_vs_pwv(
     hover = defaultdict(list)
 
     for obs in d.obs_list:
-        if not np.isfinite(obs.pwv):
+        if (
+            not np.isfinite(obs.pwv)
+            or obs.obs_subtype != "cmb"
+        ):
             continue
 
         pwvs.append(obs.pwv)
@@ -909,8 +915,6 @@ def field_vs_pwv(
                 continue
 
             for b in field.dtype.names:
-                if 'o3' in obs.obs_id:
-                    print(b, obs.obs_id)
                 vals[b]["yield"].append(field[b][0])
                 hover[b].append(obs_hover(obs))
 

--- a/sotodlib/qa/quality_reports/plots.py
+++ b/sotodlib/qa/quality_reports/plots.py
@@ -46,6 +46,11 @@ LAT_TUBE_SLOTS = (
 SAT_WAFER_SLOTS = tuple(f"ws{i}" for i in range(7))
 
 
+# ============================================================
+# Helper plots for wafers, hover text, and colors.
+# ============================================================
+
+
 def get_wafers(platform: str) -> list[str]:
     """Return wafer identifiers for a given platform."""
 
@@ -660,7 +665,7 @@ def hwp_freq_vs_time(d: ReportData) -> go.Figure:
 
 # ============================================================
 # PWV, Yield, and NEPs (array averaged and effective detector)
-# related plots.
+# vs time.
 # ============================================================
 
 
@@ -843,6 +848,12 @@ def pwv_and_nep_vs_time(d, field_name="array"):
     return pwv_and_timeseries_vs_time(d, mode="nep", field_name=field_name)
 
 
+# ============================================================
+# Yield and NEPs (array averaged and effective detector)
+# vs PWV.
+# ============================================================
+
+
 def field_vs_pwv(
     d: "ReportData",
     mode: str,
@@ -1015,6 +1026,188 @@ def nep_vs_pwv(d, longterm_data=None, field_name=None):
         longterm_data=longterm_data,
         field_name=field_name,
     )
+
+
+# ============================================================
+# PWV and Yield histograms.
+# ============================================================
+
+
+import numpy as np
+import plotly.graph_objects as go
+from plotly.subplots import make_subplots
+from collections import defaultdict
+
+
+def field_hist(
+    d: "ReportData",
+    mode: str,
+    field_name: str | None = None,
+) -> go.Figure:
+    """
+    Histogram of yield or NEP values (PWV removed), plotted as band-paired subplots.
+    """
+
+    band_pairs = [
+        ("f090", "f150"),
+    ]
+
+    if d.cfg.platform in ["satp2", "lat"]:
+        band_pairs.append(("f220", "f280"))
+
+    if d.cfg.platform == "lat":
+        band_pairs.append(("f030", "f040"))
+
+    values = defaultdict(lambda: defaultdict(list))
+
+    for obs in d.obs_list:
+        if obs.obs_subtype != "cmb":
+            continue
+
+        if mode == "yield":
+            if obs.num_valid_dets.size == 0:
+                continue
+
+            for b in obs.num_valid_dets.dtype.names:
+                values[b]["yield"].append(obs.num_valid_dets[b][0])
+
+        elif mode == "nep":
+            field = obs.array_nep if field_name == "array" else obs.det_nep
+            if field.size == 0:
+                continue
+
+            for b in field.dtype.names:
+                for i, pol in enumerate(field[b].dtype.names):
+                    values[b][pol].append(field[b][0][i])
+
+    nrows = len(band_pairs)
+
+    fig = make_subplots(
+        rows=nrows,
+        cols=1,
+        shared_yaxes=True,
+        horizontal_spacing=0.08,
+        vertical_spacing=0.1,
+    )
+
+    i = 0
+
+    for r, (b1, b2) in enumerate(band_pairs, start=1):
+        # Get bins
+        arr1_list = [np.asarray(v) for v in values[b1].values() if len(v) > 0]
+        arr2_list = [np.asarray(v) for v in values[b2].values() if len(v) > 0]
+
+        if len(arr1_list) == 0 and len(arr2_list) == 0:
+            continue
+
+        arr1 = np.concatenate(arr1_list)
+        arr2 = np.concatenate(arr2_list)
+
+        arr1 = arr1[np.isfinite(arr1)]
+        arr2 = arr2[np.isfinite(arr2)]
+
+        all_arr = np.concatenate([arr1, arr2])
+
+        lo, hi = np.nanpercentile(all_arr, [1, 99])
+
+        xbins = dict(
+            start=lo,
+            end=hi,
+            size=(hi - lo) / 40
+        )
+
+        for b in [b1, b2]:
+            for k, arr in values[b].items():
+
+                arr = np.asarray(arr)
+                arr = arr[np.isfinite(arr)]
+
+                label = (
+                    f"{k} ({b})"
+                    if mode == "nep"
+                    else f"Valid Dets ({b})"
+                )
+
+                fig.add_trace(
+                    go.Histogram(
+                        x=arr,
+                        name=label,
+                        xbins=xbins,
+                        opacity=0.5,
+                        marker=dict(
+                            color=MARKER_COLORS[i % len(MARKER_COLORS)],
+                            line=dict(width=1, color="black"),
+                        ),
+                        showlegend=True,
+                    ),
+                    row=r,
+                    col=1,
+                )
+
+                i += 1
+
+    if mode == "yield":
+        title = "Valid Detector Yield"
+        xlab = "Num Valid Dets"
+    else:
+        title = f"{field_name.capitalize()} NEP"
+        xlab = r"NEP [aW / √Hz]"
+
+    fig.update_layout(
+        barmode="overlay",
+        template="plotly_white",
+        height=320 * nrows,
+        title=dict(
+            text=title,
+            x=0.5,
+            xanchor="center",
+            font=dict(size=18),
+        ),
+        margin=dict(l=40, r=40, t=140, b=40),
+        legend=dict(
+            orientation="h",
+            yanchor="bottom",
+            y=1.02,
+            xanchor="right",
+            x=1,
+            bgcolor="rgba(255,255,255,0.8)",
+            bordercolor="lightgray",
+            borderwidth=1,
+        ),
+    )
+
+    fig.update_xaxes(
+        title_text=xlab,
+        showgrid=True,
+        gridcolor="lightgray",
+        zeroline=False,
+    )
+
+    fig.update_yaxes(
+        title_text="N",
+        showgrid=True,
+        gridcolor="lightgray",
+        zeroline=False,
+    )
+
+    return fig
+
+
+def yield_hist(d):
+    return field_hist(d, mode="yield")
+
+
+def nep_hist(d, field_name=None):
+    return field_hist(
+        d,
+        mode="nep",
+        field_name=field_name,
+    )
+
+
+# ============================================================
+# Coverage map.
+# ============================================================
 
 
 def cov_map_plot(map_png_file: str, embed:bool=True) -> str:

--- a/sotodlib/qa/quality_reports/plots.py
+++ b/sotodlib/qa/quality_reports/plots.py
@@ -1034,12 +1034,6 @@ def nep_vs_pwv(d, longterm_data=None, field_name=None):
 # ============================================================
 
 
-import numpy as np
-import plotly.graph_objects as go
-from plotly.subplots import make_subplots
-from collections import defaultdict
-
-
 def field_hist(
     d: "ReportData",
     mode: str,
@@ -1056,8 +1050,8 @@ def field_hist(
     if d.cfg.platform in ["satp2", "lat"]:
         band_pairs.append(("f220", "f280"))
 
-    if d.cfg.platform == "lat":
-        band_pairs.append(("f030", "f040"))
+        if d.cfg.platform == "lat":
+            band_pairs.append(("f030", "f040"))
 
     values = defaultdict(lambda: defaultdict(list))
 
@@ -1299,21 +1293,7 @@ def source_footprints(d: "ReportData") -> go.Figure:
              3.50e-07,  0.00561629, -0.00561577,
         ]
 
-        wafers = [
-            'c1_ws0', 'c1_ws1', 'c1_ws2',
-            'i1_ws0', 'i1_ws1', 'i1_ws2',
-            'i2_ws0', 'i2_ws1', 'i2_ws2',
-            'i3_ws0', 'i3_ws1', 'i3_ws2',
-            'i4_ws0', 'i4_ws1', 'i4_ws2',
-            'i5_ws0', 'i5_ws1', 'i5_ws2',
-            'i6_ws0', 'i6_ws1', 'i6_ws2',
-            'o1_ws0', 'o1_ws1', 'o1_ws2',
-            'o2_ws0', 'o2_ws1', 'o2_ws2',
-            'o3_ws0', 'o3_ws1', 'o3_ws2',
-            'o4_ws0', 'o4_ws1', 'o4_ws2',
-            'o5_ws0', 'o5_ws1', 'o5_ws2',
-            'o6_ws0', 'o6_ws1', 'o6_ws2',
-        ]
+        wafers = get_wafers("lat")
 
         wafer_centers = {}
         for i, wafer in enumerate(wafers):

--- a/sotodlib/qa/quality_reports/plots.py
+++ b/sotodlib/qa/quality_reports/plots.py
@@ -781,7 +781,7 @@ def pwv_and_timeseries_vs_time(
     if mode == "yield":
         title = "Valid Detectors and PWV"
         y_left = "Num Valid Dets"
-        tpad = 80
+        tpad = 140
 
     else:
         title = f"{field_name.capitalize()} NEP and PWV"
@@ -958,7 +958,7 @@ def field_vs_pwv(
     if mode == "yield":
         title = "Valid Detectors and PWV"
         ylab = "Num Valid Dets"
-        tpad = 80
+        tpad = 140
     else:
         title = f"{field_name.capitalize()} NEP and PWV"
         ylab = r"$\rm{NEP\ [aW/\sqrt{Hz}]}$"

--- a/sotodlib/qa/quality_reports/report_data.py
+++ b/sotodlib/qa/quality_reports/report_data.py
@@ -618,7 +618,6 @@ class ReportData:
         for i, o in enumerate(rows):
             obs_list[i] = ObsInfo.from_obsdb_entry(o)
             obs_list[i].obs_tags = ",".join(obs_tags.get(o["obs_id"], []))
-            # obs_list[i].obs_tags = ",".join(ctx.obsdb.get(o['obs_id'], tags=True)['tags'])
 
         if cfg.longterm_obs_file is not None:
             logger.info("Getting longterm data")

--- a/sotodlib/qa/quality_reports/report_data.py
+++ b/sotodlib/qa/quality_reports/report_data.py
@@ -329,7 +329,7 @@ def load_influx_data(cfg: ReportDataConfig) -> pd.DataFrame:
     t0_str = (cfg.start_time - buff_time).isoformat().replace("+00:00", "Z")
     t1_str = (cfg.stop_time + buff_time).isoformat().replace("+00:00", "Z")
 
-    keys = ['time', 'num_valid_dets', 'bandpass', 'wafer_slot']
+    keys = ['time', 'num_valid_dets', 'bandpass', 'wafer_slot', 'tel_tube']
     if cfg.platform == "lat":
         keys += ['array_noise_T', 'det_noise_T']
     elif cfg.platform in ['satp1', 'satp2', 'satp3']:
@@ -357,14 +357,19 @@ def load_influx_data(cfg: ReportDataConfig) -> pd.DataFrame:
     return df
 
 
-def merge_influx_and_obs_list(df: pd.DataFrame, obs_list: List[ObsInfo], noise_scale_factor: float) -> None:
-    timestamps = np.array([o.start_time for o in obs_list if o.obs_type=='obs'])
-    obsids = [o.obs_id for o in obs_list if o.obs_type=='obs']
+def merge_influx_and_obs_list(df: pd.DataFrame, obs_list: List[ObsInfo], platform: str, noise_scale_factor: float) -> None:
+    # Only CMB obs will have preprocessing data
+    timestamps = np.array([o.start_time for o in obs_list if o.obs_subtype=='cmb'])
+    tube_slots = np.array([f"lat{o.obs_tube_slot}" if platform=="lat" else platform for o in obs_list if o.obs_subtype=='cmb'])
+    obsids = np.array([o.obs_id for o in obs_list if o.obs_subtype=='cmb'])
 
-    def find_obsid(ts: float) -> Optional[str]:
-        idx = np.argmin(np.abs(ts - timestamps))
-        if np.isclose(ts, timestamps[idx], atol=1e-6):
-            return obsids[idx]
+    def find_obsid(ts: float, tel_tube: str) -> Optional[str]:
+        m = tube_slots == tel_tube
+        if not np.any(m):
+            return ""
+        idx = np.argmin(np.abs(ts - timestamps[m]))
+        if np.isclose(ts, timestamps[m][idx], atol=1e-6):
+            return obsids[m][idx]
         else:
             return ""
 
@@ -383,7 +388,10 @@ def merge_influx_and_obs_list(df: pd.DataFrame, obs_list: List[ObsInfo], noise_s
         nep = nep_series[mask]
         return 1 / np.sqrt(np.sum(1 / nep**2))
 
-    df["obs_id"] = df["timestamp"].apply(find_obsid)
+    df["obs_id"] = df.apply(
+        lambda row: find_obsid(row["timestamp"], row["tel_tube"]),
+        axis=1,
+    )
 
     det_nep_cols = [c for c in df.columns if "det_noise_" in c]
     array_nep_cols = [c for c in df.columns if "array_noise_" in c]
@@ -400,16 +408,21 @@ def merge_influx_and_obs_list(df: pd.DataFrame, obs_list: List[ObsInfo], noise_s
           .agg(agg_dict)
     )
 
-    totals_dict = (
-    totals.groupby("obs_id")
-          .apply(
-              lambda g: {
-                  row["bandpass"]: {c: row[c] for c in agg_dict.keys()}
-                  for _, row in g.iterrows()
-              }
-          )
-          .to_dict()
-    )
+    totals_dict = {}
+
+    for obs_id, g in totals.groupby("obs_id"):
+        band_dict = {}
+
+        for row in g.itertuples(index=False):
+            band = getattr(row, "bandpass")
+            band_dict[band] = {
+                c: getattr(row, c)
+                for c in agg_dict.keys()
+            }
+
+        totals_dict[obs_id] = band_dict
+
+    obs_lookup = {o.obs_id: o for o in obs_list}
 
     for obs_id, band_totals in totals_dict.items():
         band_totals.pop("NC", None)
@@ -417,27 +430,43 @@ def merge_influx_and_obs_list(df: pd.DataFrame, obs_list: List[ObsInfo], noise_s
         if not obs_id:
             continue
 
-        obs_entry = obs_list[obsids.index(obs_id)]
+        obs_entry = obs_lookup[obs_id]
 
-        det_dtype = [(band, "i4") for band in band_totals.keys()]
-        row = tuple(vals["num_valid_dets"] for _, vals in band_totals.items())
-        obs_entry.num_valid_dets = np.array([row], dtype=det_dtype)
+        det_dtype = [(band, "i4") for band in band_totals]
+        det_row = tuple(vals["num_valid_dets"] for vals in band_totals.values())
+        obs_entry.num_valid_dets = np.array([det_row], dtype=det_dtype)
 
-        for key, attr_name in zip(["array_noise_", "det_noise_"], ["array_nep", "det_nep"]):
-            all_keys = sorted({
-                k
-                for vals in band_totals.values() if isinstance(vals, dict)
-                for k in vals if k.startswith(key)
-            })
+        for key, attr_name in zip(
+            ["array_noise_", "det_noise_"],
+            ["array_nep", "det_nep"],
+        ):
 
-            nep_dtype = [(band, [(k, "f8") for k in all_keys]) for band in band_totals.keys()]
+            nep_dtype = []
+            nep_row = []
 
-            nep_row = tuple(
-                tuple((noise_scale_factor * vals.get(k, np.nan)) for k in all_keys)
-                for _, vals in band_totals.items()
+            for band, vals in band_totals.items():
+
+                band_keys = sorted(
+                    k for k in vals
+                    if k.startswith(key)
+                )
+
+                nep_dtype.append(
+                    (band, [(k, "f8") for k in band_keys])
+                )
+
+                nep_row.append(
+                    tuple(
+                        noise_scale_factor * vals[k]
+                        for k in band_keys
+                    )
+                )
+
+            setattr(
+                obs_entry,
+                attr_name,
+                np.array([tuple(nep_row)], dtype=nep_dtype),
             )
-
-            setattr(obs_entry, attr_name, np.array([nep_row], dtype=nep_dtype))
 
 
 def populate_hkdb_fields(hkdb_data, pwv, obs_list):
@@ -463,7 +492,7 @@ def populate_hkdb_fields(hkdb_data, pwv, obs_list):
 
         if attr == "pwv":
             if pwv is None:
-                logger.warning("PWV data not found")
+                logger.warning("\tPWV data not found")
                 for o in obs_list:
                     o.pwv = np.nan
                 continue
@@ -482,7 +511,7 @@ def populate_hkdb_fields(hkdb_data, pwv, obs_list):
             continue
 
         if hkdb_data is None or key not in hkdb_data:
-            logger.warning(f"{attr} data not found")
+            logger.warning(f"\t{attr} data not found")
             for o in obs_list:
                 setattr(o, attr, np.nan)
             continue
@@ -574,14 +603,14 @@ class ReportData:
     def build(cls, cfg: ReportDataConfig) -> "ReportData":
         ctx = Context(cfg.ctx_path)
 
-        logger.info("Building Obs List")
+        logger.info("Building obs List")
         rows = ctx.obsdb.query(
             f"start_time >= {cfg.start_time.timestamp()} and "
             f"start_time <= {cfg.stop_time.timestamp()}"
         )
 
+        # Get tags
         obs_tags = defaultdict(list)
-
         for obs_id, tag in ctx.obsdb.conn.execute("SELECT obs_id, tag FROM tags"):
             obs_tags[obs_id].append(tag)
 
@@ -625,7 +654,7 @@ class ReportData:
 
         if influx_df is not None:
             logger.info("Merging InfluxDb data with obs list")
-            merge_influx_and_obs_list(influx_df, obs_list, cfg.noise_scale_factor)
+            merge_influx_and_obs_list(influx_df, obs_list, cfg.platform, cfg.noise_scale_factor)
         else:
             logger.warn("InfluxDb data not found")
 

--- a/sotodlib/qa/quality_reports/report_data.py
+++ b/sotodlib/qa/quality_reports/report_data.py
@@ -21,6 +21,13 @@ from sotodlib.core import Context
 from sotodlib.core.metadata import ManifestDb
 from pixell import enmap, enplot
 
+from sotodlib.io.ancil.pwv import (
+    params_250701,
+    _gaussian,
+    defeature_toco_250701,
+    apex_to_tocolin_250701,
+)
+
 
 logger = logging.getLogger(__name__)
 
@@ -44,6 +51,7 @@ class ReportDataConfig:
         start_time: Union[dt.datetime, float, str],
         stop_time: Union[dt.datetime, float, str],
         hk_cfg: Union[HkConfig, str, Dict[str, Any]],
+        load_hkdb: bool = True,
         buffer_time: float = 3600,
         influx_client_kw: Optional[Dict[str, Any]] = None,
         longterm_obs_file: Optional[str] = None,
@@ -61,6 +69,7 @@ class ReportDataConfig:
         self.longterm_obs_file: Optional[str] = longterm_obs_file
         self.preprocess_sourcedb_path: Optional[str] = preprocess_sourcedb_path
         self.load_source_footprints: bool = load_source_footprints
+        self.load_hkdb: bool = load_hkdb
         self.show_hk_pb: bool = show_hk_pb
         self.make_cov_map = make_cov_map
         self.noise_scale_factor = noise_scale_factor
@@ -127,21 +136,28 @@ class ObsInfo:
 
     @classmethod
     def from_obsdb_entry(cls, data) -> "ObsInfo":
-        obs_info = cls(
-            obs_id=data["obs_id"],
-            start_time=data["start_time"],
-            stop_time=data["stop_time"],
-            duration=data["duration"],
-            wafer_slots_list=data["wafer_slots_list"],
-            stream_ids_list=data["stream_ids_list"],
-            obs_type=data["type"],
-            obs_subtype=data["subtype"],
-            obs_tube_slot=data["tube_slot"],
-            boresight=-data["roll_center"] if data["roll_center"] is not None else np.nan,
-            el_center=data["el_center"] if data["el_center"] is not None else np.nan,
-            hwp_freq_mean=data["hwp_freq_mean"] if ("hwp_freq_mean" in data and data["hwp_freq_mean"] is not None) else np.nan,
+        get = data.get
+
+        return cls(
+            obs_id=get("obs_id"),
+            start_time=get("start_time"),
+            stop_time=get("stop_time"),
+            duration=get("duration"),
+            wafer_slots_list=get("wafer_slots_list"),
+            stream_ids_list=get("stream_ids_list"),
+            obs_type=get("type"),
+            obs_subtype=get("subtype"),
+            obs_tube_slot=get("tube_slot"),
+
+            boresight=(
+                -get("roll_center")
+                if get("roll_center") is not None
+                else np.nan
+            ),
+
+            el_center=get("el_center") or np.nan,
+            hwp_freq_mean=get("hwp_freq_mean") or np.nan,
         )
-        return obs_info
 
     def __repr__(self):
         inner = ", ".join(f"{k}={repr(v)}" for k, v in self.__dict__.items())
@@ -248,48 +264,63 @@ def load_pwv(cfg: ReportDataConfig) -> hkdb.HkResult:
         return None
 
 
-def get_and_merge_apex_pwv(cfg: ReportDataConfig, result=None):
+def get_and_merge_apex_pwv(cfg: ReportDataConfig, toco_pwv=None):
     """
-    Load the pwv from the APEX radiometer and merges.
-    Merge with Toco PWV when available.
+    Load APEX PWV measurements and merge with TOCO PWV when available.
+
+    Returns
+    -------
+    tuple[np.ndarray, np.ndarray] or None
+        (timestamps, pwv) sorted by timestamp.
     """
     try:
-        result_apex = get_apex_data(cfg)
+        apex = get_apex_data(cfg)
     except Exception as e:
-        errmsg = f'{type(e)}: {e}'
-        tb = ''.join(traceback.format_tb(e.__traceback__))
+        errmsg = f"{type(e)}: {e}"
+        tb = "".join(traceback.format_tb(e.__traceback__))
         logger.error(f"get_apex_data failed with {errmsg}\n{tb}")
-        result_apex = None
+        apex = None
 
-    if result_apex is not None:
-        result_apex['timestamps'] = np.array(result_apex['timestamps'])[result_apex['pwv'] < 999]
-        result_apex['pwv'] = np.array(result_apex['pwv'])[result_apex['pwv'] < 999]
+    if apex is not None:
+        times = np.asarray(apex["timestamps"])
+        pwv = np.asarray(apex["pwv"])
 
-        result_apex = (np.array(result_apex['timestamps']), np.array(0.03+0.84 * result_apex['pwv']))
+        m = pwv < 999
+        apex = (
+            times[m],
+            apex_to_tocolin_250701(pwv[m]),
+        )
 
-    if result is not None:
-        result = (np.array(result[0])[result[1] <= 3], np.array(result[1])[result[1] <= 3])
-        result = (np.array(result[0])[result[1] > 0], np.array(result[1])[result[1] > 0])
+    if toco_pwv is not None:
+        times = np.asarray(toco_pwv[0])
+        pwv = np.asarray(toco_pwv[1])
 
-        if result_apex is not None:
-            combined_times = np.concatenate((result[0], result_apex[0]))
-            combined_data = np.concatenate((result[1], result_apex[1]))
+        m = (pwv > 0) & (pwv <= 3)
+        toco_pwv = (
+            times[m],
+            defeature_toco_250701(pwv[m]),
+        )
 
-            sorted_indices = np.argsort(combined_times)
-            sorted_times = combined_times[sorted_indices]
-            sorted_data = combined_data[sorted_indices]
-            return (sorted_times, sorted_data)
-        else:
-            return result
-    elif result_apex is not None:
-        return result_apex
-    else:
+    if apex is None and toco_pwv is None:
         return None
 
+    if apex is None:
+        return toco_pwv
 
-def load_qds_data(cfg: ReportDataConfig) -> pd.DataFrame:
+    if toco_pwv is None:
+        return apex
+
+    times = np.concatenate([toco_pwv[0], apex[0]])
+    pwv = np.concatenate([toco_pwv[1], apex[1]])
+
+    order = np.argsort(times)
+
+    return times[order], pwv[order]
+
+
+def load_influx_data(cfg: ReportDataConfig) -> pd.DataFrame:
     """
-    Loads QDS data from influxdb.
+    Loads InfluxDb data.
 
     """
     client = InfluxDBClient(**cfg.influx_client_kw)
@@ -317,7 +348,7 @@ def load_qds_data(cfg: ReportDataConfig) -> pd.DataFrame:
     missing_keys = [key for key in keys if key not in df]
 
     if missing_keys:
-        logger.warn(f"missing keys from qds: {missing_keys}")
+        logger.warn(f"missing keys from influxdb: {missing_keys}")
         return None
 
     df["time"] = pd.to_datetime(df["time"])
@@ -326,13 +357,13 @@ def load_qds_data(cfg: ReportDataConfig) -> pd.DataFrame:
     return df
 
 
-def merge_qds_and_obs_list(df: pd.DataFrame, obs_list: List[ObsInfo], noise_scale_factor: float) -> None:
-    timestamps = np.array([o.start_time for o in obs_list])
-    obsids = [o.obs_id for o in obs_list]
+def merge_influx_and_obs_list(df: pd.DataFrame, obs_list: List[ObsInfo], noise_scale_factor: float) -> None:
+    timestamps = np.array([o.start_time for o in obs_list if o.obs_type=='obs'])
+    obsids = [o.obs_id for o in obs_list if o.obs_type=='obs']
 
     def find_obsid(ts: float) -> Optional[str]:
         idx = np.argmin(np.abs(ts - timestamps))
-        if np.isclose(ts, timestamps[idx], atol=0.1):
+        if np.isclose(ts, timestamps[idx], atol=1e-6):
             return obsids[idx]
         else:
             return ""
@@ -409,6 +440,61 @@ def merge_qds_and_obs_list(df: pd.DataFrame, obs_list: List[ObsInfo], noise_scal
             setattr(obs_entry, attr_name, np.array([nep_row], dtype=nep_dtype))
 
 
+def populate_hkdb_fields(hkdb_data, pwv, obs_list):
+    """
+    Attach weather + PWV data to obs_list.
+    """
+
+    fields = {
+        "temp": ("env-vantage.weather_data.temp_outside", None),
+        "uv": ("env-vantage.weather_data.UV", None),
+        "wind_speed": ("env-vantage.weather_data.wind_speed", None),
+        "wind_dir": ("env-vantage.weather_data.wind_dir", None),
+        "pwv": (None, lambda v: (-0.1 < v) & (v < 4.0)),
+    }
+
+    def compute_timeseries(times, values, obs):
+        m = (times >= obs.start_time) & (times <= obs.stop_time)
+        if not np.any(m):
+            return np.nan
+        return np.nanmean(values[m])
+
+    for attr, (key, post_mask) in fields.items():
+
+        if attr == "pwv":
+            if pwv is None:
+                logger.warning("PWV data not found")
+                for o in obs_list:
+                    o.pwv = np.nan
+                continue
+
+            t, v = pwv
+            t = np.asarray(t)
+            v = np.asarray(v)
+
+            for o in obs_list:
+                val = compute_timeseries(t, v, o)
+                if np.isfinite(val) and post_mask(val):
+                    o.pwv = val
+                else:
+                    o.pwv = np.nan
+
+            continue
+
+        if hkdb_data is None or key not in hkdb_data:
+            logger.warning(f"{attr} data not found")
+            for o in obs_list:
+                setattr(o, attr, np.nan)
+            continue
+
+        t, v = hkdb_data[key]
+        t = np.asarray(t)
+        v = np.asarray(v)
+
+        for o in obs_list:
+            setattr(o, attr, compute_timeseries(t, v, o))
+
+
 @dataclass
 class Footprint:
     """
@@ -466,7 +552,7 @@ class ReportData:
         Configuration object used to generate the report
     obs_list: List[ObsInfo]
         List of observation info for each observation in the configured time range.
-        This contains data from the ObsDb, HkDb, and QDS database.
+        This contains data from the ObsDb, HkDb, and InfluxDb database.
     pwv: np.ndarray
         PWV throughout the specified time range. This is a 2D array where
         the first element is an array of timestamps, and the second element is
@@ -489,16 +575,21 @@ class ReportData:
         ctx = Context(cfg.ctx_path)
 
         logger.info("Building Obs List")
-        obs_list = [
-            ObsInfo.from_obsdb_entry(o)
-            for o in ctx.obsdb.query(
-                f"start_time >= {cfg.start_time.timestamp()} and "
-                f"start_time <= {cfg.stop_time.timestamp()}"
-            )
-        ]
+        rows = ctx.obsdb.query(
+            f"start_time >= {cfg.start_time.timestamp()} and "
+            f"start_time <= {cfg.stop_time.timestamp()}"
+        )
 
-        for i, o in enumerate(obs_list):
-            o.obs_tags = ",".join(ctx.obsdb.get(o.obs_id, tags=True)['tags'])
+        obs_tags = defaultdict(list)
+
+        for obs_id, tag in ctx.obsdb.conn.execute("SELECT obs_id, tag FROM tags"):
+            obs_tags[obs_id].append(tag)
+
+        obs_list = [None] * len(rows)
+        for i, o in enumerate(rows):
+            obs_list[i] = ObsInfo.from_obsdb_entry(o)
+            obs_list[i].obs_tags = ",".join(obs_tags.get(o["obs_id"], []))
+            # obs_list[i].obs_tags = ",".join(ctx.obsdb.get(o['obs_id'], tags=True)['tags'])
 
         if cfg.longterm_obs_file is not None:
             logger.info("Getting longterm data")
@@ -506,99 +597,40 @@ class ReportData:
         else:
             longterm_obs_df = None
 
-        try:
-            hkdb_data = load_hkdb(cfg)
-        except Exception as e:
-            logger.error(f"load_hkdb failed with {e}")
+        # hkdb
+        if cfg.load_hkdb:
+            try:
+                logger.info("Getting hkdb data")
+                hkdb_data = load_hkdb(cfg)
+            except Exception as e:
+                logger.error(f"load_hkdb failed with {e}")
+                hkdb_data = None
+        else:
             hkdb_data = None
 
-        if hkdb_data is not None and "env-radiometer-class.pwvs.pwv" in hkdb_data.keys():
+        # Toco PWV
+        if (
+            hkdb_data is not None and
+            "env-radiometer-class.pwvs.pwv" in hkdb_data.keys()
+        ):
             toco_pwv = hkdb_data["env-radiometer-class.pwvs.pwv"]
         else:
             toco_pwv = None
 
-        logger.info("Loading PWV data")
+        logger.info("Merging Toco and APEX PWV")
         pwv = get_and_merge_apex_pwv(cfg, toco_pwv)
 
-        logger.info("Loading QDS data")
-        qds_df = load_qds_data(cfg)
+        logger.info("Loading Influx data")
+        influx_df = load_influx_data(cfg)
 
-        if qds_df is not None:
-            logger.info("Merging QDS data with obs list")
-            merge_qds_and_obs_list(qds_df, obs_list, cfg.noise_scale_factor)
+        if influx_df is not None:
+            logger.info("Merging InfluxDb data with obs list")
+            merge_influx_and_obs_list(influx_df, obs_list, cfg.noise_scale_factor)
         else:
-            logger.warn("QDS data not found")
+            logger.warn("InfluxDb data not found")
 
-        # Add PWV data to obs_list
-        if pwv is not None:
-            for o in obs_list:
-                m = np.logical_and.reduce([pwv[0] >= o.start_time, pwv[0] <= o.stop_time])
-                _pwv = np.nanmean(pwv[1][m])
-                if -0.1 < _pwv < 4.0:
-                    o.pwv = _pwv
-        else:
-            logger.warn("pwv data not found")
-            for o in obs_list:
-                o.pwv = np.nan
-
-        # temperature
-        if (
-            hkdb_data is not None and
-            "env-vantage.weather_data.temp_outside" in hkdb_data.keys()
-           ):
-            temp = hkdb_data["env-vantage.weather_data.temp_outside"]
-            for o in obs_list:
-                m = np.logical_and.reduce([temp[0] >= o.start_time, temp[0] <= o.stop_time])
-                _temp = np.nanmean(temp[1][m])
-                o.temp = _temp
-        else:
-            logger.warn("temperature data not found")
-            for o in obs_list:
-                o.temp = np.nan
-        # uv
-        if (
-            hkdb_data is not None and
-            "env-vantage.weather_data.UV" in hkdb_data.keys()
-           ):
-            uv = hkdb_data["env-vantage.weather_data.UV"]
-            for o in obs_list:
-                m = np.logical_and.reduce([uv[0] >= o.start_time, uv[0] <= o.stop_time])
-                _uv = np.nanmean(uv[1][m])
-                o.uv = _uv
-        else:
-            logger.warn("UV data not found")
-            for o in obs_list:
-                o.uv = np.nan
-
-        # wind speed
-        if (
-            hkdb_data is not None and
-            "env-vantage.weather_data.wind_speed" in hkdb_data.keys()
-           ):
-            wind_speed = hkdb_data["env-vantage.weather_data.wind_speed"]
-            for o in obs_list:
-                m = np.logical_and.reduce([wind_speed[0] >= o.start_time, wind_speed[0] <= o.stop_time])
-                _wind_speed = np.nanmean(wind_speed[1][m])
-                o.wind_speed = _wind_speed
-        else:
-            logger.warn("wind speed data not found")
-            for o in obs_list:
-                o.wind_speed = np.nan
-
-        # wind direction
-        if (
-            hkdb_data is not None and
-            "env-vantage.weather_data.wind_dir" in hkdb_data.keys()
-           ):
-            wind_dir = hkdb_data["env-vantage.weather_data.wind_dir"]
-            for o in obs_list:
-                m = np.logical_and.reduce([wind_dir[0] >= o.start_time, wind_dir[0] <= o.stop_time])
-                _wind_dir = np.nanmean(wind_dir[1][m])
-                o.wind_dir = _wind_dir
-        else:
-            logger.warn("wind direction data not found")
-            for o in obs_list:
-                o.wind_dir = np.nan
+        # Get hkdb params for each obs
+        populate_hkdb_fields(hkdb_data, pwv, obs_list)
 
         data: "ReportData" = cls(
             cfg=cfg, obs_list=obs_list, pwv=pwv, longterm_obs_df=longterm_obs_df
@@ -629,8 +661,6 @@ class ReportData:
 
             if "cfg" not in hdf.attrs:
                 hdf.attrs["cfg"] = json.dumps(d)
-            # if self.pwv is not None and "pwv" not in hdf:
-            #     hdf.create_dataset("pwv", data=self.pwv)
 
             for obs in self.obs_list:
                 if obs.obs_id not in hdf:

--- a/sotodlib/site_pipeline/generate_reports.py
+++ b/sotodlib/site_pipeline/generate_reports.py
@@ -329,6 +329,25 @@ def render_report(
     env = Environment(loader=FileSystemLoader(template_dir))
     template = env.get_template("report.html")
 
+    time_plots = {
+        "el_vs_time": ("el_center", "Elevation [deg]", "Elevation", lambda x: np.round(x, 2)),
+        "temp_vs_time": ("temp", "Ambient Temperature [°C]", "Ambient Temperature", lambda x: np.round(x, 2)),
+        "uv_vs_time": ("uv", "UV Index", "UV Index", None),
+        "wind_speed_vs_time": ("wind_speed", "Wind Speed [m/s]", "Wind Speed", None),
+        "wind_dir_vs_time": ("wind_dir", "Wind Direction [deg]", "Wind Direction", None),
+    }
+
+    time_figs = {
+        name: plots.plot_obs_timeseries(
+            data,
+            field=field,
+            ylabel=ylabel,
+            title=title,
+            transform=transform,
+        )
+        for name, (field, ylabel, title, transform) in time_plots.items()
+    }
+
     obs_efficiency_plots = plots.wafer_obs_efficiency(data)
     source_footprint_plots = plots.source_footprints(data)
     figures: Dict[str, go.Figure] = {
@@ -336,11 +355,6 @@ def render_report(
         "obs_efficiency_pie": obs_efficiency_plots.pie,
         "obs_efficiency_pie_pwv": obs_efficiency_plots.pie_good_pwv,
         "boresight_vs_time": plots.boresight_vs_time(data),
-        "el_vs_time": plots.el_vs_time(data),
-        "temp_vs_time": plots.temp_vs_time(data),
-        "uv_vs_time": plots.uv_vs_time(data),
-        "wind_speed_vs_time": plots.wind_speed_vs_time(data),
-        "wind_dir_vs_time": plots.wind_dir_vs_time(data),
         "scan_type_vs_time": plots.scan_type_vs_time(data),
         "hwp_freq_vs_time": plots.hwp_freq_vs_time(data),
         "yield_vs_pwv": plots.yield_vs_pwv(data, longterm_data=longterm_data),
@@ -352,6 +366,7 @@ def render_report(
         "source_focalplane": source_footprint_plots.focalplane,
         "source_table": source_footprint_plots.table,
         "map_png": plots.cov_map_plot(map_png_file),
+        **time_figs,
     }
 
     html_kw = dict(full_html=False, include_plotlyjs=False)
@@ -373,28 +388,52 @@ def render_report(
             # keep only observations and not operations
             if o.obs_type != "obs":
                 continue
-            is_close = any(abs(o.start_time - start_time) <= 20 for start_time in start_times)
+            is_close = any(abs(o.start_time - start_time) <= 60 for start_time in start_times)
             if not is_close:
                 unique_obs.append(o)
                 start_times.append(o.start_time)
     else:
         unique_obs = [o for o in data.obs_list if o.obs_type == "obs"]
 
-    total_time = (dt.datetime.fromisoformat(stop_time_str) - dt.datetime.fromisoformat(start_time_str)).total_seconds() / 3600
+    start = dt.datetime.fromisoformat(start_time_str)
+    stop = dt.datetime.fromisoformat(stop_time_str)
+
+    total_time_hrs = (stop - start).total_seconds() / 3600
+    # 10 minute time chunks
+    NSEG = int(np.ceil(total_time_hrs / 6))
 
     if data.pwv is not None:
-        mask = data.pwv[1] < 3
-        timediff = np.diff(data.pwv[0][mask])
-        # prevent gaps from adding time unnecessarily
-        mask = timediff < 120
-        good_time = np.sum(timediff[mask]) / 3600
-    else:
-        good_time = 0.
 
-    cmb_good_pwvtime = np.sum(np.array([o.duration for o in unique_obs if o.obs_subtype == "cmb" and o.pwv < 3])) / 3600
-    cmb_all_pwvtime = np.sum(np.array([o.duration for o in unique_obs if o.obs_subtype == "cmb" and o.pwv])) / 3600
-    idle_good_time = good_time - cmb_good_pwvtime
-    idle_all_time = total_time - cmb_all_pwvtime
+        t = np.asarray(data.pwv[0])
+        pwv = np.asarray(data.pwv[1])
+
+        t0 = start.timestamp()
+        t1 = stop.timestamp()
+
+        edges = np.linspace(t0, t1, NSEG + 1)
+
+        good = 0
+
+        for i in range(NSEG):
+            m = (t >= edges[i]) & (t < edges[i + 1])
+
+            if np.any(m):
+                mean_pwv = np.mean(pwv[m])
+            else:
+                continue
+
+            if mean_pwv < 3:
+                good += 1
+
+        good_pwv_time_hrs = total_time_hrs * (good / NSEG)
+
+    else:
+        good_pwv_time_hrs = 0
+
+    cmb_good_pwv_time_hrs = np.sum(np.array([o.duration for o in unique_obs if o.obs_subtype == "cmb" and o.pwv < 3])) / 3600
+    cmb_all_pwv_time_hrs = np.sum(np.array([o.duration for o in unique_obs if o.obs_subtype == "cmb" and o.pwv])) / 3600
+    idle_good_pwv_time_hrs = good_pwv_time_hrs - cmb_good_pwv_time_hrs
+    idle_all_pwv_time_hrs = total_time_hrs - cmb_all_pwv_time_hrs
 
     jinja_data = {
         "data": data,
@@ -412,10 +451,10 @@ def render_report(
             "Number of Cal Observations": len([o for o in unique_obs if o.obs_subtype == "cal"]),
             "Time Spent on CMB Observations (hrs)": np.round(np.sum(np.array([o.duration for o in unique_obs if o.obs_subtype == "cmb"])) / 3600, 1),
             "Time Spent on Cal Observations (hrs)": np.round(np.sum(np.array([o.duration for o in unique_obs if o.obs_subtype == "cal"])) / 3600, 1),
-            "Percentage of Time on CMB Observations (Any slot | PWV < 3):": np.round(100 * cmb_good_pwvtime / good_time, 2),
-            "Percentage of Time on CMB Observations (Any slot):": np.round(100 * cmb_all_pwvtime / total_time, 2),
-            "Percentage of Time spent not observing CMB (Any slot | PWV < 3):": np.round(100 * idle_good_time / good_time, 2),
-            "Percentage of Time spent not observing CMB (Any slot):": np.round(100 * idle_all_time / total_time, 2),
+            "Percentage of Time on CMB Observations (Any slot | PWV < 3):": np.round(100 * cmb_good_pwv_time_hrs / good_pwv_time_hrs, 2),
+            "Percentage of Time on CMB Observations (Any slot):": np.round(100 * cmb_all_pwv_time_hrs / total_time_hrs, 2),
+            "Percentage of Time spent not observing CMB (Any slot | PWV < 3):": np.round(100 * idle_good_pwv_time_hrs / good_pwv_time_hrs, 2),
+            "Percentage of Time spent not observing CMB (Any slot):": np.round(100 * idle_all_pwv_time_hrs / total_time_hrs, 2),
             "Average Duration of CMB Observations (hrs)": np.round(np.nanmean(v) / 3600, 2) if (v := [o.duration for o in unique_obs if o.obs_subtype == "cmb"]) else 0,
             "Average Duration of Cal Observations (hrs)": np.round(np.nanmean(v) / 3600, 2) if (v := [o.duration for o in unique_obs if o.obs_subtype == "cal"]) else 0,
             "Average Obs PWV (mm)": np.round(np.nanmean([o.pwv for o in unique_obs]), 3),

--- a/sotodlib/site_pipeline/generate_reports.py
+++ b/sotodlib/site_pipeline/generate_reports.py
@@ -359,10 +359,13 @@ def render_report(
         "hwp_freq_vs_time": plots.hwp_freq_vs_time(data),
         "yield_vs_pwv": plots.yield_vs_pwv(data, longterm_data=longterm_data),
         "pwv_yield_vs_time": plots.pwv_and_yield_vs_time(data),
+        "yield_hist": plots.yield_hist(data),
         "pwv_and_array_nep_vs_time": plots.pwv_and_nep_vs_time(data, field_name="array"),
         "array_nep_vs_pwv": plots.nep_vs_pwv(data, longterm_data=longterm_data, field_name="array"),
+        "array_nep_hist": plots.nep_hist(data, field_name="array"),
         "pwv_and_det_nep_vs_time": plots.pwv_and_nep_vs_time(data, field_name="det"),
         "det_nep_vs_pwv": plots.nep_vs_pwv(data, longterm_data=longterm_data, field_name="det"),
+        "det_nep_hist": plots.nep_hist(data, field_name="det"),
         "source_focalplane": source_footprint_plots.focalplane,
         "source_table": source_footprint_plots.table,
         "map_png": plots.cov_map_plot(map_png_file),
@@ -400,7 +403,7 @@ def render_report(
 
     total_time_hrs = (stop - start).total_seconds() / 3600
     # 10 minute time chunks
-    NSEG = int(np.ceil(total_time_hrs / 6))
+    NSEG = int(np.ceil(total_time_hrs * 6))
 
     if data.pwv is not None:
 
@@ -416,11 +419,10 @@ def render_report(
 
         for i in range(NSEG):
             m = (t >= edges[i]) & (t < edges[i + 1])
-
-            if np.any(m):
-                mean_pwv = np.mean(pwv[m])
-            else:
+            if not np.any(m):
                 continue
+
+            mean_pwv = np.mean(pwv[m])
 
             if mean_pwv < 3:
                 good += 1

--- a/sotodlib/site_pipeline/generate_reports.py
+++ b/sotodlib/site_pipeline/generate_reports.py
@@ -437,6 +437,18 @@ def render_report(
     idle_good_pwv_time_hrs = good_pwv_time_hrs - cmb_good_pwv_time_hrs
     idle_all_pwv_time_hrs = total_time_hrs - cmb_all_pwv_time_hrs
 
+    # get number of 20 min gaps (det setup time) and longest gap between obs_ids with obs type
+    gaps = []
+    longest_gap = 0
+    unique_obs_sorted = sorted(unique_obs, key=lambda o: o.start_time)
+    unique_obs_sorted = [o for o in unique_obs_sorted if o.obs_type == "obs"]
+    for prev, curr in zip(unique_obs_sorted[:-1], unique_obs_sorted[1:]):
+        gap = curr.start_time - prev.stop_time
+        if gap > 1200:
+            gaps.append(gap)
+        if gap > longest_gap:
+            longest_gap = gap
+
     jinja_data = {
         "data": data,
         "report_interval": cfg.report_interval.capitalize(),
@@ -451,6 +463,8 @@ def render_report(
             "Number of Observations": len([o for o in unique_obs]),
             "Number of CMB Observations": len([o for o in unique_obs if o.obs_subtype == "cmb"]),
             "Number of Cal Observations": len([o for o in unique_obs if o.obs_subtype == "cal"]),
+            "Number of > 20 min Gaps Between Obs": len(gaps),
+            "Longest Gap Between Obs (hrs)": np.round(longest_gap / 3600, 2),
             "Time Spent on CMB Observations (hrs)": np.round(np.sum(np.array([o.duration for o in unique_obs if o.obs_subtype == "cmb"])) / 3600, 1),
             "Time Spent on Cal Observations (hrs)": np.round(np.sum(np.array([o.duration for o in unique_obs if o.obs_subtype == "cal"])) / 3600, 1),
             "Percentage of Time on CMB Observations (Any slot | PWV < 3):": np.round(100 * cmb_good_pwv_time_hrs / good_pwv_time_hrs, 2),
@@ -460,6 +474,8 @@ def render_report(
             "Average Duration of CMB Observations (hrs)": np.round(np.nanmean(v) / 3600, 2) if (v := [o.duration for o in unique_obs if o.obs_subtype == "cmb"]) else 0,
             "Average Duration of Cal Observations (hrs)": np.round(np.nanmean(v) / 3600, 2) if (v := [o.duration for o in unique_obs if o.obs_subtype == "cal"]) else 0,
             "Average Obs PWV (mm)": np.round(np.nanmean([o.pwv for o in unique_obs]), 3),
+            "Median Obs PWV (mm)": np.round(np.nanmedian([o.pwv for o in unique_obs]), 3),
+            "Stddev Obs PWV (mm)": np.round(np.std([o.pwv for o in unique_obs]), 3),
         }
     }
 


### PR DESCRIPTION
Some updates to the quality reports.

- Refactor many functions for cleanliness.
- Speed up obsdb query.
- Increase gap for LAT unique `obs_id` starting time to 60 seconds to account for longer stream start/stop time of ASO.
- Fix a bug where obs_ids were mismatched to influxdb data due to LAT obs_ids starting at the same time.
- Added all `obs_info` to hover text so you can see what the observation actually was doing.
- Rework PWV calculation to use larger bins to reduce the effect of bad PWV values.
- Use `obsdb_ancil` PWV rescaling functions.
- Add yield and NEP histograms.
- Switch NEP/Yield vs time plots to log scale.  Cannot set the vs PWV ones to log scale because Plotly Histogram2d doesn't work with it.
- Add number of gaps that are longer than 20 mins and the duration of the longest gap.
- Add median and standard deviation of PWV.

Example: https://site.simonsobs.org/~mmccrackan/qr/satp1/weekly/20260614_20260621/report.html