### PR TITLE
Ignore archive by default when running site preproc in toast load

### DIFF
--- a/sotodlib/toast/ops/load_context.py
+++ b/sotodlib/toast/ops/load_context.py
@@ -166,7 +166,7 @@ class LoadContext(Operator):
     )
 
     ignore_preprocess_archive = Bool(
-        False,
+        True,
         help="If True alway compute preprocess on the fly, don't load from archive.",
     )
 


### PR DESCRIPTION
This has caused many headaches when loading data into toast with site preproc configs that specify an archive.  In most cases we want to run that preproc on the fly.  Default to that case.