### PR TITLE
warn or raise error when merge/wrap inconsistent axes

### DIFF
--- a/sotodlib/core/axisman.py
+++ b/sotodlib/core/axisman.py
@@ -1079,8 +1079,10 @@ class AxisManager:
         axes_out = self.intersection_info(self, *amans)
 
         # Apply the axis-mismatch policy before modifying anything.
-        assert on_mismatch in (None, 'warn', 'error')
-        if on_mismatch is not None:
+        if on_mismatch is None:
+            on_mismatch = 'intersect'
+        assert on_mismatch in ('intersect', 'warn', 'error')
+        if on_mismatch in ('warn', 'error'):
             report = []
             for name, ax in axes_out.items():
                 for src, aman in [('self', self)] + [

--- a/sotodlib/core/axisman.py
+++ b/sotodlib/core/axisman.py
@@ -1,3 +1,4 @@
+import logging
 import numpy as np
 from collections import OrderedDict as odict
 
@@ -11,6 +12,8 @@ except ImportError:
 import so3g
 
 from .util import get_coindices
+
+logger = logging.getLogger(__name__)
 
 
 class AxisInterface:
@@ -635,7 +638,7 @@ class AxisManager:
     # Add and remove data while maintaining internal consistency.
 
     def wrap(self, name, data, axis_map=None,
-             overwrite=False, restrict_in_place=False):
+             overwrite=False, restrict_in_place=False, on_mismatch='warn'):
         """Add data into the AxisManager.
 
         Arguments:
@@ -661,6 +664,12 @@ class AxisManager:
             AxisManager may be modified and added, without a copy
             first.  This can be much faster, if there's no need to
             preserve the wrapped item.
+
+          on_mismatch (str): Policy when an axis of the new data
+            has the same name as, but different coverage than, an
+            existing axis: 'intersect', 'warn' (intersect, but log a
+            warning; default) or 'error' (raise ValueError, before
+            modifying anything).
 
         """
         if overwrite and (name in self._fields):
@@ -704,7 +713,8 @@ class AxisManager:
                 assign[index] = axis.name
         helper._fields[name] = data
         helper._assignments[name] = assign
-        return self.merge(helper, restrict_in_place=restrict_in_place)
+        return self.merge(helper, restrict_in_place=restrict_in_place,
+                          on_mismatch=on_mismatch)
 
     def wrap_new(self, name, shape=None, cls=None, **kwargs):
         """Create a new object and wrap it, with axes mapped.  The shape can
@@ -1042,9 +1052,12 @@ class AxisManager:
                         ax, False)
         return axes_out
 
-    def merge(self, *amans, restrict_in_place=False):
+    def merge(self, *amans, restrict_in_place=False, on_mismatch='warn'):
         """Merge the data from other AxisMangers into this one.  Axes with the
-        same name will be intersected.
+        same name will be intersected. The on_mismatch argument sets the policy
+        for axes that must be truncated (intersected) because amans share an
+        axis name but not its coverage: 'intersect', 'warn' (log a warning)
+        or 'error' (raise ValueError before modifying anything).
 
         If restrict_in_place=True, then the amans may be modified as
         they are added to the output objcet.  When that arg is False,
@@ -1064,6 +1077,28 @@ class AxisManager:
 
         # Get the intersected axis descriptions.
         axes_out = self.intersection_info(self, *amans)
+
+        # Apply the axis-mismatch policy before modifying anything.
+        assert on_mismatch in ('intersect', 'warn', 'error')
+        if on_mismatch != 'intersect':
+            report = []
+            for src, aman in [('self', self)] + [
+                    ('merged[%i]' % i, a) for i, a in enumerate(amans)]:
+                for ax in aman._axes.values():
+                    if ax.count is None or ax.name not in axes_out:
+                        continue
+                    new_ax = axes_out[ax.name]
+                    if new_ax.count != ax.count:
+                        report.append(
+                            "axis '%s' of %s changes %s -> %s." % (
+                                ax.name, src, repr(ax), repr(new_ax)))
+            if report:
+                msg = ('Axis mismatch on merge/wrap causes truncation: '
+                       + '; '.join(report))
+                if on_mismatch == 'error':
+                    raise ValueError(msg)
+                logger.warning(msg)
+
         # Reduce the data in self, update our axes.
         self.restrict_axes(axes_out)
         # Import the other ones.

--- a/sotodlib/core/axisman.py
+++ b/sotodlib/core/axisman.py
@@ -638,7 +638,7 @@ class AxisManager:
     # Add and remove data while maintaining internal consistency.
 
     def wrap(self, name, data, axis_map=None,
-             overwrite=False, restrict_in_place=False, on_mismatch='warn'):
+             overwrite=False, restrict_in_place=False, on_mismatch=None):
         """Add data into the AxisManager.
 
         Arguments:
@@ -665,11 +665,11 @@ class AxisManager:
             first.  This can be much faster, if there's no need to
             preserve the wrapped item.
 
-          on_mismatch (str): Policy when an axis of the new data
+          on_mismatch: Policy when an axis of the new data
             has the same name as, but different coverage than, an
-            existing axis: 'intersect', 'warn' (intersect, but log a
-            warning; default) or 'error' (raise ValueError, before
-            modifying anything).
+            existing axis. Defaults to None (intersect). 'warn'
+            (intersect, but log a warning) or 'error' (raise ValueError,
+            before modifying anything).
 
         """
         if overwrite and (name in self._fields):
@@ -1052,12 +1052,12 @@ class AxisManager:
                         ax, False)
         return axes_out
 
-    def merge(self, *amans, restrict_in_place=False, on_mismatch='warn'):
+    def merge(self, *amans, restrict_in_place=False, on_mismatch=None):
         """Merge the data from other AxisMangers into this one.  Axes with the
         same name will be intersected. The on_mismatch argument sets the policy
         for axes that must be truncated (intersected) because amans share an
-        axis name but not its coverage: 'intersect', 'warn' (log a warning)
-        or 'error' (raise ValueError before modifying anything).
+        axis name but not its coverage: 'warn' (log a warning) or 'error'
+        (raise ValueError before modifying anything).
 
         If restrict_in_place=True, then the amans may be modified as
         they are added to the output objcet.  When that arg is False,
@@ -1079,19 +1079,16 @@ class AxisManager:
         axes_out = self.intersection_info(self, *amans)
 
         # Apply the axis-mismatch policy before modifying anything.
-        assert on_mismatch in ('intersect', 'warn', 'error')
-        if on_mismatch != 'intersect':
+        assert on_mismatch in (None, 'warn', 'error')
+        if on_mismatch is not None:
             report = []
-            for src, aman in [('self', self)] + [
+            for name, ax in axes_out.items():
+                for src, aman in [('self', self)] + [
                     ('merged[%i]' % i, a) for i, a in enumerate(amans)]:
-                for ax in aman._axes.values():
-                    if ax.count is None or ax.name not in axes_out:
-                        continue
-                    new_ax = axes_out[ax.name]
-                    if new_ax.count != ax.count:
+                    if (name in aman._axes) and (aman._axes[name] != ax):
                         report.append(
                             "axis '%s' of %s changes %s -> %s." % (
-                                ax.name, src, repr(ax), repr(new_ax)))
+                                name, src, repr(aman._axes[name]), repr(ax)))
             if report:
                 msg = ('Axis mismatch on merge/wrap causes truncation: '
                        + '; '.join(report))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -489,6 +489,78 @@ class TestAxisManager(unittest.TestCase):
                 self.assertEqual(coparent.shape, (4, n))
 
 
+    def test_420_axis_mismatch_policy(self):
+        # wrap/merge intersect axes that share a name but not coverage;
+        # the on_mismatch policy controls whether that is silent
+        # ('intersect'), logged ('warn', default) or a ValueError ('error').
+        logger = core.axisman.logger
+        dets = ['det0', 'det1', 'det2']
+        n, ofs = 1000, 0
+
+        def make_tod():
+            tod = core.AxisManager(
+                core.LabelAxis('dets', dets),
+                core.OffsetAxis('samps', n, ofs))
+            tod.wrap('sig', np.zeros((len(dets), n)),
+                     [(0, 'dets'), (1, 'samps')])
+            return tod
+
+        # Default policy: shorter incoming axis logs a warning, then
+        # truncates exactly as before.
+        tod = make_tod()
+        with self.assertLogs(logger, 'WARNING'):
+            tod.wrap('x', np.zeros(n - 100),
+                     [(0, core.OffsetAxis('samps', n - 100, ofs))])
+        self.assertEqual(tod.samps.count, n - 100)
+        self.assertEqual(tod.sig.shape, (3, n - 100))
+
+        # Longer incoming axis warns too (the incoming data is cut).
+        tod = make_tod()
+        with self.assertLogs(logger, 'WARNING'):
+            tod.wrap('x', np.zeros(n + 100),
+                     [(0, core.OffsetAxis('samps', n + 100, ofs))])
+        self.assertEqual(len(tod.x), n)
+
+        # Same count but different offset warns.
+        tod = make_tod()
+        with self.assertLogs(logger, 'WARNING'):
+            tod.wrap('x', np.zeros(n),
+                     [(0, core.OffsetAxis('samps', n, ofs + 10))])
+        self.assertEqual(tod.samps.count, n - 10)
+
+        # LabelAxis truncation (dets subset via child) warns.
+        tod = make_tod()
+        child = core.AxisManager(core.LabelAxis('dets', dets[:2]))
+        with self.assertLogs(logger, 'WARNING'):
+            tod.wrap('child', child)
+        self.assertEqual(tod.dets.count, 2)
+
+        # No error with matching axes.
+        tod = make_tod()
+        tod.wrap('x', np.zeros(n),
+                 [(0, core.OffsetAxis('samps', n, ofs))],
+                 on_mismatch='error')
+
+        # on_mismatch='error' raises, leaving the target untouched.
+        tod = make_tod()
+        with self.assertRaises(ValueError):
+            tod.wrap('x', np.zeros(n - 100),
+                     [(0, core.OffsetAxis('samps', n - 100, ofs))],
+                     on_mismatch='error')
+        self.assertEqual(tod.samps.count, n)
+        self.assertEqual(tod.sig.shape, (3, n))
+        self.assertNotIn('x', tod)
+
+        # Through merge() directly.
+        tod = make_tod()
+        _tod = core.AxisManager(
+            core.LabelAxis('dets', dets + ['det3']),
+            core.OffsetAxis('samps', n, ofs - n // 2))
+        with self.assertRaises(ValueError):
+            tod.merge(_tod, on_mismatch='error')
+        self.assertEqual(tod.shape, (3, n))
+
+
     def test_500_io(self):
         # Test save/load HDF5
         dets = ['det0', 'det1', 'det2']

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -491,8 +491,8 @@ class TestAxisManager(unittest.TestCase):
 
     def test_420_axis_mismatch_policy(self):
         # wrap/merge intersect axes that share a name but not coverage;
-        # the on_mismatch policy controls whether that is silent
-        # ('intersect'), logged ('warn', default) or a ValueError ('error').
+        # the on_mismatch policy controls whether log warning ('warn') or
+        # raise ValueError ('error').
         logger = core.axisman.logger
         dets = ['det0', 'det1', 'det2']
         n, ofs = 1000, 0
@@ -505,34 +505,36 @@ class TestAxisManager(unittest.TestCase):
                      [(0, 'dets'), (1, 'samps')])
             return tod
 
-        # Default policy: shorter incoming axis logs a warning, then
-        # truncates exactly as before.
+        # on_mismatch='warn' warns shorter axis and then truncates.
         tod = make_tod()
         with self.assertLogs(logger, 'WARNING'):
             tod.wrap('x', np.zeros(n - 100),
-                     [(0, core.OffsetAxis('samps', n - 100, ofs))])
+                     [(0, core.OffsetAxis('samps', n - 100, ofs))],
+                     on_mismatch='warn')
         self.assertEqual(tod.samps.count, n - 100)
         self.assertEqual(tod.sig.shape, (3, n - 100))
 
-        # Longer incoming axis warns too (the incoming data is cut).
+        # Longer incoming axis warns.
         tod = make_tod()
         with self.assertLogs(logger, 'WARNING'):
             tod.wrap('x', np.zeros(n + 100),
-                     [(0, core.OffsetAxis('samps', n + 100, ofs))])
+                     [(0, core.OffsetAxis('samps', n + 100, ofs))],
+                     on_mismatch='warn')
         self.assertEqual(len(tod.x), n)
 
         # Same count but different offset warns.
         tod = make_tod()
         with self.assertLogs(logger, 'WARNING'):
             tod.wrap('x', np.zeros(n),
-                     [(0, core.OffsetAxis('samps', n, ofs + 10))])
+                     [(0, core.OffsetAxis('samps', n, ofs + 10))],
+                     on_mismatch='warn')
         self.assertEqual(tod.samps.count, n - 10)
 
         # LabelAxis truncation (dets subset via child) warns.
         tod = make_tod()
         child = core.AxisManager(core.LabelAxis('dets', dets[:2]))
         with self.assertLogs(logger, 'WARNING'):
-            tod.wrap('child', child)
+            tod.wrap('child', child, on_mismatch='warn')
         self.assertEqual(tod.dets.count, 2)
 
         # No error with matching axes.


### PR DESCRIPTION
Now I think this was probably intended behavior, but merge and wrap always silently intersect and restrict axes.
Added an on_mismatch to warn or raise error when the coverage of axes with same name are different.

This silent intesection/truncation caused issues in analysis several times, for example when we calculate psd with different length of trimmed data, or after downsampling.
We need to rename axes in such cases but I think default warning (or error) is helpful..

Example:
```
WARNING: sotodlib.core.axisman: Axis mismatch on merge/wrap causes truncation: axis 'dets' of self changes LabelAxis(3:np.str_('det0'),np.str_('det1'),np.str_('det2')) -> LabelAxis(2:np.str_('det0'),np.str_('det1')).
WARNING: sotodlib.core.axisman: Axis mismatch on merge/wrap causes truncation: axis 'samps' of self changes OffsetAxis(1000:None+0) -> OffsetAxis(900:None+0).
```