### PR TITLE
Change turnound flags kernel shape for two_leg turnarounds

### DIFF
--- a/sotodlib/tod_ops/flags.py
+++ b/sotodlib/tod_ops/flags.py
@@ -156,7 +156,7 @@ def get_det_bias_flags(aman, detcal=None, rfrac_range=(0.1, 0.7),
 
 def get_turnaround_flags(aman, az=None, method='scanspeed', name='turnarounds',
                          merge=True, merge_lr=True, overwrite=True, 
-                         t_buffer=2., kernel_size=400, peak_threshold=0.1, rel_distance_peaks=0.3,
+                         t_buffer=2., kernel_size=1500, peak_threshold=0.1, rel_distance_peaks=0.3,
                          truncate=False, qlim=1, merge_subscans=True, turnarounds_in_subscan=False):
     """
     Compute turnaround flags for a dataset.
@@ -229,6 +229,7 @@ def get_turnaround_flags(aman, az=None, method='scanspeed', name='turnarounds',
         # Make a step-function like matched filter. Kernel is normarized to make peak height ~1
         kernel = np.ones(kernel_size) / approx_daz / kernel_size
         kernel[kernel_size//2:] *= -1
+        kernel[kernel_size//2-kernel_size//10:kernel_size//2+kernel_size//10] *= 0
 
         # convolve signal with the kernel
         pad_init = np.ones(kernel_size//2) * daz[0]


### PR DESCRIPTION
Changed the matched filter kernel shape so the kernel shape better matches the expected shape of the az velocity in two_leg turnarounds. The current kernel shape for turnaround flags does not properly find the midpoint of turnarounds because of the new two_leg turnaround shape. Here is a comparison of the matched peak for the current and new kernels with a two_leg turnaround:
<img width="601" height="453" alt="image" src="https://github.com/user-attachments/assets/42552468-d8c6-4be6-833c-49ba3999c89f" />
<img width="601" height="453" alt="image" src="https://github.com/user-attachments/assets/b7eabacb-75ee-4865-85d5-92f9c98bc5b6" />


Here is a comparison of the kernel shapes before and after this change:

<img width="579" height="453" alt="image" src="https://github.com/user-attachments/assets/1402c92e-5df5-42fc-b98b-5d3c507e0420" />

The two changes are: 

1. Increasing the width of the kernel. 1500 samples is ~7.5 seconds, which is the approximate length of a turnaround with scan_v = 0.8 and scan_a = 0.25. We probably need to test this with many different scan speeds to make sure it works. Namely does this still work at scan_v = 0.5? Two_leg turnarounds are never run on planet scans so we may never need to look at higher acceleration scans.
2. Adding a 0 velocity center that spans ~1/5 of the turnaround (this may be larger than the 0 velocity portion of the turnaround. This 0 velocity center is vital in ensuring the flag is placed at the center of the turnaround. Otherwise the `find_peaks` function will find the center of the first/second leg and choose either "somewhat" arbitrarily. 

If the kernel size is too small (i.e. we use the original kernel_size=400 with the new kernel shape) the match will also fail:
<img width="616" height="453" alt="image" src="https://github.com/user-attachments/assets/a9b3cd0f-715e-4f70-8fcf-3924044d5730" />

Here is the comparison of matches using the new and current kernels on a standard turnaround with scan_v = 1.5.
<img width="592" height="453" alt="image" src="https://github.com/user-attachments/assets/aae64e38-c7cd-4d7b-ae37-5ee08f1fcec4" />

<img width="592" height="453" alt="image" src="https://github.com/user-attachments/assets/c9833e46-e965-4035-8bf8-fff879dce74c" />

The new kernel does move the flag by ~0.1-0.2 seconds, but that may not be a huge problem?

At scan_v = 0.8 the difference is even less noticeable:
<img width="598" height="453" alt="image" src="https://github.com/user-attachments/assets/4401cb64-526f-4214-b6c1-d823879c3e14" />
<img width="598" height="453" alt="image" src="https://github.com/user-attachments/assets/57cedd96-da5b-4ee0-b166-2a78b3d8ff9f" />

Finally, I tried this on a Jupiter scan. The new kernel does seem to have a bit of an issue with finding the center of this standard turnaround.
<img width="598" height="453" alt="image" src="https://github.com/user-attachments/assets/b64b4cbb-a2b1-4ec6-b483-63b8b1dae804" />
<img width="598" height="453" alt="image" src="https://github.com/user-attachments/assets/54d977d9-9f2f-45e4-8447-2283ddb4ed55" />

However, the new shape works perfectly fine as long as we're using the original kernel size (400 indexes instead of 1500):
<img width="662" height="453" alt="image" src="https://github.com/user-attachments/assets/16936c42-3d5b-4c98-81a5-be0a969b6f47" />

So we may want to feed in the kernel size based on the scan parameters. The kernel size should ~match the turnaround length which should always be `2 * scan_v / scan_a * 200`. This should let the new kernel shape handle even standard turnarounds. I think trying to feed in the turnaround method to switch between kernel shapes is a little overkill as we'll always have to ensure the kernel size matches the turnaround length anyways. The new kernel shape seems to do find with finding the center of standard turnarounds as long as the kernel size is correct!

Please try this out yourself and let me know if it works for you.