### PR TITLE
Add ENV variable to control atomic hdf update

### DIFF
--- a/sotodlib/core/util.py
+++ b/sotodlib/core/util.py
@@ -17,12 +17,13 @@ class H5ContextManager:
     Class to open an HDF5 file with retry logic on file locking.  This class
     can be used either as a context manager or as a regular function.
 
-    If the file is opened for writing (mode "a", "w", "r+", or "w-"), then
-    a temporary file is created in the same directory as the original and the
-    contents of the original are copied to that before modification.  The
-    temporary file is intentionally chosen to be the same suffix name (it
-    does not use the tempfile module).  This way if multiple processes are
-    trying to update the file, their access will be serialized.
+    If the file is opened for writing (mode "a", "w", "r+", or "w-"), and the
+    environment variable SOTODLIB_HDF5_ATOMIC_UPDATE is set, then a temporary
+    file is created in the same directory as the original and the contents of
+    the original are copied to that before modification.  The temporary file is
+    intentionally chosen to be the same suffix name (it does not use the tempfile
+    module).  This way if multiple processes are trying to update the file, their
+    access will be serialized.
 
     After the context manager exits, the temp file is atomically moved into
     place with the name of the original.  Any processes with the original
@@ -72,6 +73,8 @@ class H5ContextManager:
         if self.delay < 0:
             raise RuntimeError("delay should be a positive number of seconds")
 
+        self.atomic_update = os.getenv("SOTODLIB_HDF5_ATOMIC_UPDATE") is not None
+
     def _check_file_for_mode(self):
         if self.mode in {"r", "r+"}:
             # File should already exist
@@ -94,13 +97,19 @@ class H5ContextManager:
                     # No tempfile needed
                     self.f = h5py.File(self.filename, mode=self.mode, **self.kwargs)
                 elif self.mode == "a" or self.mode == "r+":
-                    # Copy the existing file to a temp location for modification
-                    if os.path.isfile(self.filename):
-                        shutil.copy(self.filename, temp_path)
-                    self.f = h5py.File(temp_path, mode=self.mode, **self.kwargs)
+                    if self.atomic_update:
+                        # Copy the existing file to a temp location for modification
+                        if os.path.isfile(self.filename):
+                            shutil.copy(self.filename, temp_path)
+                        self.f = h5py.File(temp_path, mode=self.mode, **self.kwargs)
+                    else:
+                        self.f = h5py.File(self.filename, mode=self.mode, **self.kwargs)
                 else:
                     # Writing and truncating
-                    self.f = h5py.File(temp_path, mode=self.mode, **self.kwargs)
+                    if self.atomic_update:
+                        self.f = h5py.File(temp_path, mode=self.mode, **self.kwargs)
+                    else:
+                        self.f = h5py.File(self.filename, mode=self.mode, **self.kwargs)
                 return self.f
             except BlockingIOError as e:
                 # If the file is locked, retry opening it after a delay

--- a/tests/test_hdf5_atomic.py
+++ b/tests/test_hdf5_atomic.py
@@ -112,9 +112,26 @@ class HDF5AtomicTest(TestCase):
         # after it is renamed with the original name.  Meanwhile, the reading process
         # has an open handle to the original inode, which is unmodified and not
         # deleted until it is closed.
+
+        # Set the env variable to enable atomic updating
+        os.environ["SOTODLIB_HDF5_ATOMIC_UPDATE"] = "True"
         opts = [
             "--test_dir",
             self.outdir,
         ]
         ret = inode_main(opts=opts)
         self.assertEqual(ret, 0)
+
+    def test_non_atomic_update(self):
+        # Test the same case as in test_inode_replace above but with atomic updating disabled,
+        # such that the original file is expected to be modified in place by the multiple writers
+        # even when a reader has it open.
+
+        # Ensure the atomic update env variable is unset
+        os.environ.pop("SOTODLIB_HDF5_ATOMIC_UPDATE")
+        opts = [
+            "--test_dir",
+            self.outdir,
+        ]
+        ret = inode_main(opts=opts)
+        self.assertEqual(ret, 1)

--- a/tests/test_hdf5_atomic.py
+++ b/tests/test_hdf5_atomic.py
@@ -128,7 +128,7 @@ class HDF5AtomicTest(TestCase):
         # even when a reader has it open.
 
         # Ensure the atomic update env variable is unset
-        os.environ.pop("SOTODLIB_HDF5_ATOMIC_UPDATE")
+        os.environ.pop("SOTODLIB_HDF5_ATOMIC_UPDATE", None)
         opts = [
             "--test_dir",
             self.outdir,


### PR DESCRIPTION
Adds an environment variable to control whether or not the `H5ContextManager` will do an atomic update or not.  If not set it will just overwrite the original file as it did before.

Since the `update_det_cal` flow is on compute21 with just a few other flows like `update_det_match`, `update_smurf_caldbs`, and `update_obsdb` (preprocessing is on different compute nodes), we can try setting the ENV variable on there and see how it goes.  We can also just set it directly in `update_det_cal` if `run_method` is `site`, which calls a different sub function and should keep it scoped.