### PR TITLE
Fix nseg of psd and reduce warnings

### DIFF
--- a/sotodlib/tod_ops/fft_ops.py
+++ b/sotodlib/tod_ops/fft_ops.py
@@ -356,7 +356,7 @@ def calc_psd(
         if kwargs["nperseg"] > max_samples:
             nseg = 1
         else:
-            nseg = int(max(n_samps, max_samples) / kwargs["nperseg"])
+            nseg = int((stop - start) / kwargs["nperseg"])
 
         freqs, Pxx = welch(signal[:, start:stop], fs, **kwargs)
         axis_map_pxx = [(0, aman[label_axis]), (1, "nusamps")]

--- a/sotodlib/tod_ops/fft_ops.py
+++ b/sotodlib/tod_ops/fft_ops.py
@@ -364,7 +364,7 @@ def calc_psd(
         if kwargs["nperseg"] > max_samples:
             nseg = 1
         else:
-            nseg = int(max_samples / kwargs["nperseg"])
+            nseg = int(max(n_samps, max_samples) / kwargs["nperseg"])
 
         freqs, Pxx = welch(signal[:, start:stop], fs, **kwargs)
         axis_map_pxx = [(0, aman[label_axis]), (1, "nusamps")]

--- a/sotodlib/tod_ops/fft_ops.py
+++ b/sotodlib/tod_ops/fft_ops.py
@@ -353,7 +353,7 @@ def calc_psd(
                 nperseg = int(2 ** (np.around(np.log2((stop - start) / 50.0))))
             kwargs["nperseg"] = nperseg
 
-        if kwargs["nperseg"] > max_samples:
+        if kwargs["nperseg"] > stop - start:
             nseg = 1
         else:
             nseg = int((stop - start) / kwargs["nperseg"])

--- a/sotodlib/tod_ops/fft_ops.py
+++ b/sotodlib/tod_ops/fft_ops.py
@@ -313,14 +313,6 @@ def calc_psd(
     if signal is None:
         signal = aman.signal
 
-    if ("noverlap" not in kwargs) or \
-            ("noverlap" in kwargs and kwargs["noverlap"] != 0):
-        warnings.warn('calc_wn will be biased. noverlap argument of welch '
-                      'needs to be 0 to get unbiased median white noise estimate.')
-    if not full_output:
-        warnings.warn('calc_wn will be biased. full_output argument of calc_psd '
-                      'needs to be True to get unbiased median white noise estimate.')
-
     if subscan:
         if full_output:
             freqs, Pxx, nseg = _calc_psd_subscan(aman, signal=signal,
@@ -488,10 +480,11 @@ def calc_wn(aman, pxx=None, freqs=None, nseg=None, low_f=5, high_f=10, method='m
         nseg = aman.get('nseg')
 
     if nseg is None:
-        warnings.warn('white noise level estimated by median PSD is biased. '
-                      'nseg is necessary to debias. Need to use following '
-                      'arguments in calc_psd to get correct nseg. '
-                      '`noverlap=0, full_output=True`')
+        if method == 'median':
+            warnings.warn('white noise level estimated by median PSD is biased. '
+                          'nseg is necessary to debias. Need to use following '
+                          'arguments in calc_psd to get correct nseg. '
+                          '`noverlap=0, full_output=True`')
         debias = None
     else:
         if method == 'median':


### PR DESCRIPTION
FIx nseg of psd, when the samps is smaller than max_samples, the nseg was wrong.
We didn't have issue usually, because samps is longer than default max_samples ~ 1310 seconds.
Also reduced the warning of wn bias. Now it only warns when we use median method without nseg.