### PR TITLE
use as_completed in make_wg_cal

### DIFF
--- a/sotodlib/site_pipeline/make_wg_cal.py
+++ b/sotodlib/site_pipeline/make_wg_cal.py
@@ -186,7 +186,7 @@ def _main(
                 obs_id=job.tags['obs_id'],
                 n_split=n_split,
             ))
-        for future in futures:
+        for future in as_completed_callable(futures):
             obs_id, result = future.result()
             for job in jobs:
                 if job.tags['obs_id'] == obs_id:


### PR DESCRIPTION
We simply forgot to use `as_completed_callable`.
If we do this, we can get results in order of completion rather than submission, which is more efficient.