### PR TITLE
Allow flag_cut_select to take int

### DIFF
--- a/sotodlib/core/flagman.py
+++ b/sotodlib/core/flagman.py
@@ -300,10 +300,10 @@ def flag_cut_select(flags, kind, invert=False):
 
     Args:
         flags (RangesMatrix): An instance of so3g.proj.RangesMatrix indicating flagged time ranges.
-        kind (str or float): One of the following:
+        kind (str or int/float): One of the following:
             - 'any': Select/cut detectors with any flagged samples.
             - 'all': Select/cut detectors with all samples flagged.
-            - float: A threshold ratio (0.0–1.0); selects/cuts detectors whose flagged ratio exceeds the threshold.
+            - int/float: A threshold ratio (0.0–1.0); selects/cuts detectors whose flagged ratio exceeds the threshold.
         intert (bool): default=False returns detectors to be excluded =True, detectors to be kept = False. If True, The logic is flipped.
 
     Returns:
@@ -320,7 +320,7 @@ def flag_cut_select(flags, kind, invert=False):
             return has_any_cuts(flags)
         elif kind == 'all':
             return has_all_cut(flags)
-        elif isinstance(kind, float):
+        elif isinstance(kind, (int, float)):
             return has_ratio_cuts(flags, ratio=kind)
         else:
             raise ValueError("kind must be 'any', 'all', or a float between 0.0 and 1.0")
@@ -329,7 +329,7 @@ def flag_cut_select(flags, kind, invert=False):
             return ~has_any_cuts(flags)
         elif kind == 'all':
             return ~has_all_cut(flags)
-        elif isinstance(kind, float):
+        elif isinstance(kind, (int, float)):
             return ~has_ratio_cuts(flags, ratio=kind)
         else:
             raise ValueError("kind must be 'any', 'all', or a float between 0.0 and 1.0")


### PR DESCRIPTION
The function `flag_cut_select` fails if the input is not a `float`, but the function it calls, `has_ratio_cuts`, accepts either an `int` or a `float`.