### PR TITLE
Support crosstalk sims with real observations

### DIFF
--- a/sotodlib/toast/ops/__init__.py
+++ b/sotodlib/toast/ops/__init__.py
@@ -21,7 +21,7 @@ from .sim_stimulator import SimStimulator
 from .save_books import SaveBooks
 from .load_books import LoadBooks
 from .sim_readout import SimReadout
-from .sim_mumux_crosstalk import SimMuMUXCrosstalk
+from .sim_mumux_crosstalk import SimMuMUXCrosstalk, jbolo_available
 from .splits import Splits
 from .mumux_crosstalk_util import detmap_available, pos_to_chi
 from .load_context import LoadContext

--- a/sotodlib/toast/ops/mumux_crosstalk_util.py
+++ b/sotodlib/toast/ops/mumux_crosstalk_util.py
@@ -9,74 +9,102 @@ import numpy as np
 try:
     import pandas as pd
     from detmap.data_io.solution_select import AvailableSolutions
+
     available_solutions = AvailableSolutions()
     detmap_available = True
-except:
+except ImportError:
     detmap_available = False
 
-mappings = {}
 
-# SAT1 MF wafers  = w25-w31
-# SAT2 MF wafers  = w32-w38
-# SAT3 HF wafers  = w06-w12
-# SAT4 LF wafers  = w42-w48
-# LAT LF wafers  = w39-w41
-# LAT MF wafers  = w13-w24
-# LAT HF wafers  = w00-w05
+def wafer_chis(dets, pos, freq, is_north, mux_band, bond_pad, alpha, collision):
+    """Given detector properties on one wafer, compute the crosstalk.
 
-# Arbitrary mapping between wafer slots and array names
-wafer_to_array = {
-    "dummy00" : "Cv4",  # LAT
-    "dummy01" : "Cv5",
-    "w13" : "Mv6",   # LAT  1/12
-    "w14" : "Mv7",   # LAT  2/12
-    "dummy04" : "Mv9",
-    "w15" : "Mv11",  # LAT  3/12
-    "w16" : "Mv12",  # LAT  4/12
-    "w25" : "Mv13",  # SAT1 1/7
-    "w26" : "Mv14",  # SAT1 2/7
-    # "Mv15",  # LAT (missing)
-    "w17" : "Mv17",  # LAT  5/12
-    "w27" : "Mv18",  # SAT1 3/7
-    "w28" : "Mv19",  # SAT1 4/7
-    "w29" : "Mv22",  # SAT1 5/7
-    "w30" : "Mv23",  # SAT1 6/7
-    "w31" : "Mv24",  # SAT1 7/7
-    "w18" : "Mv25",  # LAT  6/12
-    "w19" : "Mv26",  # LAT  7/12
-    "w20" : "Mv27",  # LAT  8/12
-    "w21" : "Mv28",  # LAT  9/12
-    "w22" : "Mv29",  # LAT 10/12
-    "w23" : "Mv32",  # LAT 11/12
-    "w24" : "Mv33",  # LAT 12/12
-    "dummy05" : "Sv5",
-    "w06" : "Uv31", # Only one SAT HF wafer in DetMap
-    "w07" : "Uv31", # Only one SAT HF wafer in DetMap
-    "w08" : "Uv31", # Only one SAT HF wafer in DetMap
-    "w09" : "Uv31", # Only one SAT HF wafer in DetMap
-    "w10" : "Uv31", # Only one SAT HF wafer in DetMap
-    "w11" : "Uv31", # Only one SAT HF wafer in DetMap
-    "w12" : "Uv31", # Only one SAT HF wafer in DetMap
-    "w00" : "Uv8",  # Only one LAT HF wafer in DetMap
-    "w01" : "Uv8",  # Only one LAT HF wafer in DetMap
-    "w02" : "Uv8",  # Only one LAT HF wafer in DetMap
-    "w03" : "Uv8",  # Only one LAT HF wafer in DetMap
-    "w04" : "Uv8",  # Only one LAT HF wafer in DetMap
-    "w05" : "Uv8",  # Only one LAT HF wafer in DetMap
-}
+    Args:
+        dets (list):  The list of detector names
+        pos (list):  The list of tuple x, y postitions
+        is_north (array):  Array of 'N' / 'S' values
+        mux_band (array):  The mux band for each det
+        bond_pad (array):  The bond pad for each det
+        alpha (float):  The crosstalk prefactor
+        collision (float):  Collistion threshold
 
+    Returns:
+        (dict):  Wafer chi values.
 
-
-def pos_to_ind(pos, bp, pol, mapping, tol=1.0, verbose=False):
     """
-        Match position to a detector index on the UFM
+    ndet = len(dets)
+    wchis = {}
+    for idet1, det1 in enumerate(dets):
+        x1, y1 = pos[idet1]
+        freq1 = freq[idet1]
+        if freq1 == 0:
+            # Detector was not found in the mapping and
+            # there is no resonator frequency
+            continue
+        is_north1 = is_north[idet1]
+        mux_band1 = mux_band[idet1]
+        bond_pad1 = bond_pad[idet1]
+        for idet2 in range(idet1 + 1, ndet):
+            freq2 = freq[idet2]
+            if freq2 == 0:
+                # Detector was not found in the mapping and
+                # there is no resonator frequency
+                continue
+            det2 = dets[idet2]
+            is_north2 = is_north[idet2]
+            mux_band2 = mux_band[idet2]
+            bond_pad2 = bond_pad[idet2]
+            # Short-circuit chi-calculation if the detectors
+            # cannot cross-talk
+            if is_north1 != is_north2:
+                continue
+            if mux_band1 != mux_band2:
+                continue
+            if np.abs(bond_pad1 - bond_pad2) != 4:
+                continue
+            # Check that this truly is the nearly frequency neighbor
+            neighbors = np.argwhere(
+                (is_north == is_north1) & (mux_band == mux_band1)
+            ).flatten()
+            freq_neighbors = np.argsort(np.abs(freq[neighbors] - freq1)).flatten()
+            if idet2 not in neighbors[freq_neighbors[1:3]]:
+                # freq_neighbors[0] is idet1
+                # frequency neighbors on either side
+                continue
+            x2, y2 = pos[idet2]
+            # Translate frequencies to chi
+            df = freq1 - freq2
+            avg_f = (freq1 + freq2) / 2
+            chi = alpha * np.power(avg_f, 4) * np.power(df, -2) * 1e12
+            # Check for anomalously high chi in absense of resonator collision
+            if chi > 1 and np.abs(df) > collision:
+                msg = "Anomalously high chi at"
+                msg += f" {det1}@({x1}, {y1}), {det2}@({x2}, {y2})"
+                msg += f" df: {df}"
+                msg += f" : {chi}"
+                raise RuntimeError(msg)
+            # Check for resonator collision, if so set flag to zero TOD
+            if np.abs(df) < collision:
+                chi = np.nan
+            wchis[(det1, det2)] = chi
+            wchis[(det2, det1)] = chi
+    return wchis
 
-        pos: x, y coordinates (tuple) of first detector (mm) relative to UFM center
-        bp: detector bandpass (int)
-        pol: detector polarization (string), 'A' or 'B'
-        mapping: pandas object from DetMap CSV of UFM characteristics
+
+def pos_to_detmap_ind(pos, bp, pol, mapping, tol=1.0, verbose=False):
+    """Match position to a detector index on the synthetic UFM.
+
+    Args:
+        pos (tuple): x, y coordinates of first detector (mm) relative to UFM center
+        bp (int): detector bandpass
+        pol (str): detector polarization, 'A' or 'B'
+        mapping (object): pandas object from DetMap CSV of UFM characteristics
         tol (float):  Maximum allowed distance between provided and
             matched detector positions.
+
+    Returns:
+        (int):  The index.
+
     """
 
     # Compute Pythagorean distances to all detectors in the mapping
@@ -84,7 +112,7 @@ def pos_to_ind(pos, bp, pol, mapping, tol=1.0, verbose=False):
     dist = np.sqrt(np.square(mapping["det_x"] - x) + np.square(mapping["det_y"] - y))
 
     # Send all out of bandpass and polarization distances to infinity
-    dist[np.logical_or(mapping['bandpass'] != str(bp), mapping['pol'] != pol)] = np.inf
+    dist[np.logical_or(mapping["bandpass"] != str(bp), mapping["pol"] != pol)] = np.inf
 
     # Match detector to position
     ind = dist.argmin()
@@ -104,36 +132,95 @@ def pos_to_ind(pos, bp, pol, mapping, tol=1.0, verbose=False):
     return ind
 
 
-def pos_to_chi(focalplane, dets, alpha=9.64e-30, tol=1.0, collision=1.0):
-    """
-        Calculate magnitude of crosstalk for all detector pairs given
-        their physical positions and mapping
+def chi_simulated_obs(focalplane, dets, alpha, tol, collision):
+    """Compute the crosstalk magnitude for a synthetic focalplane.
 
+    This takes a hardcoded mapping from synthetic wafer slot to UFM name
+    that is compatible with the conventions used in DetMap files.
+
+    It uses DetMap to obtain the various parameters needed for the calcuation.
+
+    Args:
         focalplane (SOFocalplane):  Focalplane object
         dets (iterable):  detector names to consider
         alpha:  crosstalk prefactor (Hz^-2), from John Groh (via FastHenry),
             valid for nearest physical neighbors
         tol (float):  Maximum allowed distance between provided and
             matched detector positions.
+        collision (float):  The threshold to consider a resonator collision.
+
+    Returns:
+        (dict):  The chi for every detector pair.
+
     """
-    if not detmap_available:
-        raise RuntimeError("Cannot evaluate chi -- no DetMap available")
+    # SAT1 MF wafers  = w25-w31
+    # SAT2 MF wafers  = w32-w38
+    # SAT3 HF wafers  = w06-w12
+    # SAT4 LF wafers  = w42-w48
+    # LAT LF wafers  = w39-w41
+    # LAT MF wafers  = w13-w24
+    # LAT HF wafers  = w00-w05
+
+    # Arbitrary mapping between wafer slots and array names
+    wafer_to_array = {
+        "dummy00": "Cv4",  # LAT
+        "dummy01": "Cv5",
+        "w13": "Mv6",  # LAT  1/12
+        "w14": "Mv7",  # LAT  2/12
+        "dummy04": "Mv9",
+        "w15": "Mv11",  # LAT  3/12
+        "w16": "Mv12",  # LAT  4/12
+        "w25": "Mv13",  # SAT1 1/7
+        "w26": "Mv14",  # SAT1 2/7
+        # "Mv15",  # LAT (missing)
+        "w17": "Mv17",  # LAT  5/12
+        "w27": "Mv18",  # SAT1 3/7
+        "w28": "Mv19",  # SAT1 4/7
+        "w29": "Mv22",  # SAT1 5/7
+        "w30": "Mv23",  # SAT1 6/7
+        "w31": "Mv24",  # SAT1 7/7
+        "w18": "Mv25",  # LAT  6/12
+        "w19": "Mv26",  # LAT  7/12
+        "w20": "Mv27",  # LAT  8/12
+        "w21": "Mv28",  # LAT  9/12
+        "w22": "Mv29",  # LAT 10/12
+        "w23": "Mv32",  # LAT 11/12
+        "w24": "Mv33",  # LAT 12/12
+        "dummy05": "Sv5",
+        "w06": "Uv31",  # Only one SAT HF wafer in DetMap
+        "w07": "Uv31",  # Only one SAT HF wafer in DetMap
+        "w08": "Uv31",  # Only one SAT HF wafer in DetMap
+        "w09": "Uv31",  # Only one SAT HF wafer in DetMap
+        "w10": "Uv31",  # Only one SAT HF wafer in DetMap
+        "w11": "Uv31",  # Only one SAT HF wafer in DetMap
+        "w12": "Uv31",  # Only one SAT HF wafer in DetMap
+        "w00": "Uv8",  # Only one LAT HF wafer in DetMap
+        "w01": "Uv8",  # Only one LAT HF wafer in DetMap
+        "w02": "Uv8",  # Only one LAT HF wafer in DetMap
+        "w03": "Uv8",  # Only one LAT HF wafer in DetMap
+        "w04": "Uv8",  # Only one LAT HF wafer in DetMap
+        "w05": "Uv8",  # Only one LAT HF wafer in DetMap
+    }
 
     # Get the bandpass, polarization and position for every detector
     bandpasses = []
     pols = []
     positions = []
     wafers = []
+
     for det in dets:
         wafers.append(focalplane[det]["wafer_slot"])
         bandpasses.append(int(focalplane[det]["band"][-3:]))
         pols.append(focalplane[det]["pol"])
-        positions.append((
-            focalplane[det]["wafer_x"].to_value(u.mm),
-            focalplane[det]["wafer_y"].to_value(u.mm)
-        ))
+        positions.append(
+            (
+                focalplane[det]["wafer_x"].to_value(u.mm),
+                focalplane[det]["wafer_y"].to_value(u.mm),
+            )
+        )
 
     # Load the appropriate mappings
+    mappings = {}
     wafer_set = set(wafers)
     for wafer in wafer_set:
         if wafer not in wafer_to_array:
@@ -145,7 +232,7 @@ def pos_to_chi(focalplane, dets, alpha=9.64e-30, tol=1.0, collision=1.0):
             datafile = available_solutions.get_solution_file(array)
         except ValueError as e:
             msg = f"{array} does not appear to be a valid DetMap name:\n{e}\n "
-            msg += f"Perhaps wafer_to_array is out of date?"
+            msg += "Perhaps wafer_to_array is out of date?"
         mappings[wafer] = pd.read_csv(datafile)
 
     # chi for every detector pair
@@ -154,7 +241,7 @@ def pos_to_chi(focalplane, dets, alpha=9.64e-30, tol=1.0, collision=1.0):
         # Collect detector and positions that match wafer
         m = mappings[wafer]
         if len(m) == 0:
-            msg = f"No match in DetMap."
+            msg = "No match in DetMap."
             raise RuntimeError(msg)
         detector_subset = []
         position_subset = []
@@ -166,7 +253,7 @@ def pos_to_chi(focalplane, dets, alpha=9.64e-30, tol=1.0, collision=1.0):
             if w == wafer:
                 detector_subset.append(d)
                 position_subset.append(pos)
-                ind = pos_to_ind(pos, b, p, m, tol=tol)
+                ind = pos_to_detmap_ind(pos, b, p, m, tol=tol)
                 if ind is not None:
                     # Get resonator frequency
                     freq_subset.append(m.iloc[ind]["freq_mhz"])
@@ -181,65 +268,130 @@ def pos_to_chi(focalplane, dets, alpha=9.64e-30, tol=1.0, collision=1.0):
                     is_north_subset.append(None)
                     mux_band_subset.append(None)
                     bond_pad_subset.append(None)
+
         # Convert to numpy objects
-        freq_subset     = np.array(freq_subset)
+        freq_subset = np.array(freq_subset)
         is_north_subset = np.array(is_north_subset)
         mux_band_subset = np.array(mux_band_subset)
         bond_pad_subset = np.array(bond_pad_subset)
-        # Compute chi for all detector pairs in this subset
-        ndet = len(detector_subset)
-        for idet1, det1 in enumerate(detector_subset):
-            x1, y1 = position_subset[idet1]
-            freq1 = freq_subset[idet1]
-            if freq1 == 0:
-                # Detector was not found in the mapping and
-                # there is no resonator frequency
-                continue
-            is_north1 = is_north_subset[idet1]
-            mux_band1 = mux_band_subset[idet1]
-            bond_pad1 = bond_pad_subset[idet1]
-            for idet2 in range(idet1 + 1, ndet):
-                freq2 = freq_subset[idet2]
-                if freq2 == 0:
-                    # Detector was not found in the mapping and
-                    # there is no resonator frequency
-                    continue
-                det2 = detector_subset[idet2]
-                is_north2 = is_north_subset[idet2]
-                mux_band2 = mux_band_subset[idet2]
-                bond_pad2 = bond_pad_subset[idet2]
-                # Short-circuit chi-calculation if the detectors
-                # cannot cross-talk
-                if is_north1 != is_north2:
-                    continue
-                if mux_band1 != mux_band2:
-                    continue
-                if np.abs(bond_pad1 - bond_pad2) != 4:
-                    continue
-                # Check that this truly is the nearly frequency neighbor
-                neighbors = np.argwhere((is_north_subset == is_north1) & \
-                                        (mux_band_subset == mux_band1)).flatten()
-                freq_neighbors = np.argsort(np.abs(freq_subset[neighbors] - freq1)).flatten()
-                if not idet2 in neighbors[freq_neighbors[1:3]]:
-                    # freq_neighbors[0] is idet1
-                    # frequency neighbors on either side
-                    continue
-                x2, y2 = position_subset[idet2]
-                # Translate frequencies to chi
-                df = freq1 - freq2
-                avg_f = (freq1 + freq2) / 2
-                chi = alpha * np.power(avg_f, 4) * np.power(df, -2) * 1e12
-                # Check for anomalously high chi in absense of resonator collision
-                if chi > 1 and np.abs(df) > collision:
-                    msg = f"Anomalously high chi at"
-                    msg += f" {det1}@({x1}, {y1}), {det2}@({x2}, {y2})"
-                    msg += f" df: {df}"
-                    msg += f" : {chi}"
-                    raise RuntimeError(msg)
-                # Check for resonator collision, if so set flag to zero TOD
-                if np.abs(df) < collision:
-                    chi = np.nan
-                chis[(det1, det2)] = chi
-                chis[(det2, det1)] = chi
+
+        chis.update(
+            wafer_chis(
+                detector_subset,
+                position_subset,
+                freq_subset,
+                is_north_subset,
+                mux_band_subset,
+                bond_pad_subset,
+                alpha,
+                collision,
+            )
+        )
+
+    return chis
+
+
+def chi_real_obs(focalplane, dets, alpha, collision):
+    """Compute the crosstalk magnitude for a real focalplane.
+
+    This uses metadata found in real observations to compute the crosstalk.
+    One simplification is that real data is always organized with a single wafer
+    per observation.
+
+    Args:
+        focalplane (SOFocalplane):  Focalplane object
+        dets (iterable):  detector names to consider
+        alpha:  crosstalk prefactor (Hz^-2), from John Groh (via FastHenry),
+            valid for nearest physical neighbors
+        collision (float):  The threshold to consider a resonator collision.
+
+    Returns:
+        (dict):  The chi for every detector pair.
+
+    """
+    # Get the bandpass, polarization and position for every detector
+    pols = []
+    positions = []
+    wafers = []
+    freq = []
+    is_north = []
+    mux_band = []
+    bond_pad = []
+
+    for det in dets:
+        wafers.append(focalplane[det]["det_info:wafer_slot"])
+        pols.append(focalplane[det]["det_info:wafer:pol"])
+        positions.append(
+            (
+                focalplane[det]["det_info:wafer:x"],
+                focalplane[det]["det_info:wafer:y"],
+            )
+        )
+        freq.append(focalplane[det]["det_info:smurf:frequency"])
+        # Get other helpful variables
+        is_north.append(focalplane[det]["det_info:wafer:coax"])
+        mux_band.append(focalplane[det]["det_info:wafer:mux_band"])
+        bond_pad.append(focalplane[det]["det_info:wafer:bond_pad"])
+
+    freq = np.array(freq)
+    is_north = np.array(is_north)
+    mux_band = np.array(mux_band)
+    bond_pad = np.array(bond_pad)
+
+    return wafer_chis(
+        dets,
+        positions,
+        freq,
+        is_north,
+        mux_band,
+        bond_pad,
+        alpha,
+        collision,
+    )
+
+
+def pos_to_chi(focalplane, dets, alpha=9.64e-30, tol=1.0, collision=1.0):
+    """Calculate the crosstalk magnitude for all detector pairs.
+
+    This uses either real metadata or DetMap solutions to get the detector
+    positions and properties.
+
+    Args:
+        focalplane (SOFocalplane):  Focalplane object
+        dets (iterable):  detector names to consider
+        alpha:  crosstalk prefactor (Hz^-2), from John Groh (via FastHenry),
+            valid for nearest physical neighbors
+        tol (float):  Maximum allowed distance between provided and
+            matched detector positions (only in DetMap case).
+        collision (float):  The threshold to consider a resonator collision.
+
+    Returns:
+        (dict):  The chi for every detector pair.
+
+    """
+    # Make sure we have the necessary focalplane keys or the DetMap package
+    # available.
+    required_cols = [
+        "det_info:wafer_slot",
+        "det_info:wafer:mux_band",
+        "det_info:wafer:bond_pad",
+        "det_info:wafer:coax",
+        "det_info:wafer:pol",
+        "det_info:wafer:x",
+        "det_info:wafer:y",
+        "det_info:smurf:frequency",
+    ]
+    have_fp_cols = True
+    for colname in required_cols:
+        if colname not in focalplane.detector_data.colnames:
+            have_fp_cols = False
+            break
+    if not have_fp_cols and not detmap_available:
+        raise RuntimeError("Cannot evaluate chi: no DetMap or required focalplane info")
+
+    if have_fp_cols:
+        chis = chi_real_obs(focalplane, dets, alpha, collision)
+    else:
+        chis = chi_simulated_obs(focalplane, dets, alpha, tol, collision)
 
     return chis

--- a/sotodlib/toast/ops/sim_mumux_crosstalk.py
+++ b/sotodlib/toast/ops/sim_mumux_crosstalk.py
@@ -2,14 +2,17 @@
 # Full license can be found in the top level "LICENSE" file.
 
 import os
+import re
 import numpy as np
 import toast.rng
+import toast.qarray as qa
+import toast.ops
 from astropy import units as u
 from toast.data import Data
 from toast.observation import default_values as defaults
 from toast.ops.operator import Operator
 from toast.timing import function_timer, Timer
-from toast.traits import Bool, Int, Unicode, trait_docs
+from toast.traits import Bool, Instance, Int, Unicode, trait_docs
 from toast.utils import Environment, Logger, unit_conversion
 
 try:
@@ -17,6 +20,7 @@ try:
     # https://github.com/kmharrington/jbolo
     import jbolo.jbolo_funcs as jf
     from jbolo.utils import load_sim
+
     jbolo_available = True
 except:
     jbolo_available = False
@@ -25,27 +29,39 @@ from .mumux_crosstalk_util import detmap_available, pos_to_chi
 
 # JBolo sims to use
 JBOLO_MODELS = {
-    'SAT_LF' : os.path.expandvars("$JBOLO_MODELS_PATH/V3r7_JBolo/V3r7_Baseline/SAT/V3r7_Baseline_SAT_LF.yaml"),
-    'SAT_MF' : os.path.expandvars("$JBOLO_MODELS_PATH/V4r0/V4r0_Baseline/SAT/V4r0_Baseline_SAT_MF.yaml"),
-    'SAT_UHF' : os.path.expandvars("$JBOLO_MODELS_PATH/V4r0/V4r0_Baseline/SAT/V4r0_Baseline_SAT_UHF.yaml"),
-    'LAT_LF' : os.path.expandvars("$JBOLO_MODELS_PATH/V4r0/V4r0_Baseline/LAT/V4r0_Baseline_LAT_LF.yaml"),
-    'LAT_MF' : os.path.expandvars("$JBOLO_MODELS_PATH/V4r0/V4r0_Baseline/LAT/V4r0_Baseline_LAT_MF.yaml"),
-    'LAT_UHF' : os.path.expandvars("$JBOLO_MODELS_PATH/V4r0/V4r0_Baseline/LAT/V4r0_Baseline_LAT_UHF.yaml")
+    "SAT_LF": os.path.expandvars(
+        "$JBOLO_MODELS_PATH/V3r7_JBolo/V3r7_Baseline/SAT/V3r7_Baseline_SAT_LF.yaml"
+    ),
+    "SAT_MF": os.path.expandvars(
+        "$JBOLO_MODELS_PATH/V4r0/V4r0_Baseline/SAT/V4r0_Baseline_SAT_MF.yaml"
+    ),
+    "SAT_UHF": os.path.expandvars(
+        "$JBOLO_MODELS_PATH/V4r0/V4r0_Baseline/SAT/V4r0_Baseline_SAT_UHF.yaml"
+    ),
+    "LAT_LF": os.path.expandvars(
+        "$JBOLO_MODELS_PATH/V4r0/V4r0_Baseline/LAT/V4r0_Baseline_LAT_LF.yaml"
+    ),
+    "LAT_MF": os.path.expandvars(
+        "$JBOLO_MODELS_PATH/V4r0/V4r0_Baseline/LAT/V4r0_Baseline_LAT_MF.yaml"
+    ),
+    "LAT_UHF": os.path.expandvars(
+        "$JBOLO_MODELS_PATH/V4r0/V4r0_Baseline/LAT/V4r0_Baseline_LAT_UHF.yaml"
+    ),
 }
 
 JBOLO_CHANNELS = {
-    "SAT_f030" : "LF_1",
-    "SAT_f040" : "LF_2",
-    "SAT_f090" : "MF_1",
-    "SAT_f150" : "MF_2",
-    "SAT_f230" : "UHF_1",
-    "SAT_f290" : "UHF_2",
-    "LAT_f030" : "LF_1",
-    "LAT_f040" : "LF_2",
-    "LAT_f090" : "MF_1",
-    "LAT_f150" : "MF_2",
-    "LAT_f230" : "UHF_1",
-    "LAT_f290" : "UHF_2"
+    "SAT_f030": "LF_1",
+    "SAT_f040": "LF_2",
+    "SAT_f090": "MF_1",
+    "SAT_f150": "MF_2",
+    "SAT_f230": "UHF_1",
+    "SAT_f290": "UHF_2",
+    "LAT_f030": "LF_1",
+    "LAT_f040": "LF_2",
+    "LAT_f090": "MF_1",
+    "LAT_f150": "MF_2",
+    "LAT_f230": "UHF_1",
+    "LAT_f290": "UHF_2",
 }
 
 # Bolometer Resistance [Ohm]
@@ -78,6 +94,17 @@ class SimMuMUXCrosstalk(Operator):
         help="Observation detdata key for simulated signal",
     )
 
+    detector_pointing = Instance(
+        klass=Operator,
+        allow_none=True,
+        help="Operator for det Az/El pointing.  If None, boresight elevation is used.",
+    )
+
+    det_mask = Int(
+        defaults.det_mask_invalid,
+        help="Bit mask value for per-detector flagging",
+    )
+
     det_flags = Unicode(
         defaults.det_flags,
         allow_none=True,
@@ -107,27 +134,22 @@ class SimMuMUXCrosstalk(Operator):
         help="Draw new phase offsets for every observation and realization",
     )
 
+    # The name of the temporary, scaled, detector data field.
+    _temp_detdata_name = "temp_umux_crosstalk_input"
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-    def _temperature_to_squid_phase(
-            self, input_signal, Phi0, dPhi0dT
-    ):
-        """ Translate temperature-valued signal into SQUID phase
-        """
-        output_signal = input_signal.copy()
-        output_signal = Phi0 + input_signal * dPhi0dT
-        return output_signal
+    def _temperature_to_squid_phase(self, input_signal, Phi0, dPhi0dT):
+        """Translate temperature-valued signal into SQUID phase"""
+        return Phi0 + input_signal * dPhi0dT
 
     def _squid_phase_to_temperature(self, input_signal, dPhi0dT):
-        """ Translate SQUID phase-valued signal into temperature
-        """
-        output_signal = input_signal / dPhi0dT
-        return output_signal
+        """Translate SQUID phase-valued signal into temperature"""
+        return input_signal / dPhi0dT
 
     def _draw_Phi0(self, obs, focalplane, detectors, vmin=0.0, vmax=1.0):
-        """ Draw initial SQUID phases from a flat distribution
-        """
+        """Draw initial SQUID phases from a flat distribution"""
         Phi0 = {}
         for det in detectors:
             # randomize Phi0 in a reproducible manner
@@ -152,10 +174,14 @@ class SimMuMUXCrosstalk(Operator):
 
         return Phi0
 
-    def _evaluate_dPhi0dT(self, obs, signal, detectors, rows, Phi0, pwv, elevation):
-        """ Estimate how the SQUID phase in each detector changes
+    def _evaluate_dPhi0dT(self, data, detectors, Phi0, pwv, boresight_el):
+        """Estimate how the SQUID phase in each detector changes
         with the sky temperature
         """
+        log = Logger.get()
+        # The input data passed to this function only has one observation.
+        obs = data.obs[0]
+
         focalplane = obs.telescope.focalplane
         bandpass = focalplane.bandpass
 
@@ -166,64 +192,80 @@ class SimMuMUXCrosstalk(Operator):
         else:
             common_good = np.ones(obs.n_local_samples, dtype=bool)
 
-        # Create dicts for JBolo values
-        P_opts = {}
-        P_atm_refs = {}
-        efficiencies = {}
-        P_sats = {}
+        # Are we using the boresight or per-detector elevation?
+        if boresight_el is None:
+            # Per detector elevation
+            use_det_el = True
+        else:
+            use_det_el = False
+            # We only need to compute one set of properties per band.  Cache
+            # these and re-use them as needed.
+            P_opts = {}
+            P_sats = {}
 
         dPhi0dT = {}
-        for row, det in zip(rows, detectors):
-            band = focalplane[det]["band"]
-            cfreq = bandpass.center_frequency(det) * 1e-9  # GHz
-            det_flags = obs.detdata[self.det_flags][det]
-            good = np.logical_and(
-                common_good, (det_flags & self.det_flag_mask) == 0
-            )
-            #import pdb
-            #pdb.set_trace()
-            ## Calculate a global median 
-            local_good = signal[row][good]
-            if obs.comm.comm_group is not None:
-                all_good = obs.comm.comm_group.gather(local_good, root=0)
-                if obs.comm.group_rank == 0:
-                    median_signal = np.median(np.concatenate(all_good))
+        for det in detectors:
+            raw_band = focalplane[det]["band"]
+            if raw_band == "DARK" or raw_band[0] == "f":
+                # We are using real data with bands like "f090", "f150", etc
+                # Determine the telescope type from the name.
+                wafer_band = focalplane[det]["det_info:wafer:bandpass"]
+                if re.match(r"^sat.*", obs.telescope.name) is not None:
+                    band = f"SAT_{wafer_band}"
                 else:
-                    median_signal = None
-                median_signal = obs.comm.comm_group.bcast(median_signal, root=0)
+                    band = f"LAT_{wafer_band}"
             else:
-                median_signal = np.median(local_good)
-            ##
+                # Synthetic observation
+                band = raw_band
 
-            if band not in P_opts.keys():
-                # Compute detector properties using JBolo
-                jbolo_channel = JBOLO_CHANNELS[band]
-                jbolo_model   = JBOLO_MODELS[band[:4] + jbolo_channel.split('_')[0]]
+            det_flags = obs.detdata[self.det_flags][det]
+            good = np.logical_and(common_good, (det_flags & self.det_flag_mask) == 0)
+
+            jbolo_channel = JBOLO_CHANNELS[band]
+            jbolo_model = JBOLO_MODELS[band[:4] + jbolo_channel.split("_")[0]]
+
+            if use_det_el:
+                # We are computing properties for every detector
+                self.detector_pointing.apply(data, detectors=[det])
+                _, detel, _ = qa.to_lonlat_angles(
+                    obs.detdata[self.detector_pointing.quats][det]
+                )
+                elevation = np.degrees(np.median(detel[good]))
                 jsim = load_sim(jbolo_model)
-                jsim['sources']['atmosphere']['elevation'] = elevation # Degrees
-                jsim['sources']['atmosphere']['pwv'] = int(pwv) # Microns
+                jsim["sources"]["atmosphere"]["elevation"] = elevation  # Degrees
+                jsim["sources"]["atmosphere"]["pwv"] = int(pwv)  # Microns
                 jf.run_optics(jsim)
                 jf.run_bolos(jsim)
-                P_opts[band] = float(jsim['outputs'][jbolo_channel]['P_opt']) # W
-                P_atm_refs[band] = float(jsim['outputs'][jbolo_channel]['sources']['atmosphere']['P_opt']) # W
-                efficiencies[band] = float(jsim['outputs'][jbolo_channel]['sources']['atmosphere']['effic_cumul_avg'])
-                P_sats[band] = float(jsim['outputs'][jbolo_channel]['P_sat']) # W
+                P_opt = float(jsim["outputs"][jbolo_channel]["P_opt"])
+                P_sat = float(jsim["outputs"][jbolo_channel]["P_sat"])
+            else:
+                # We are using the boresight elevation
+                elevation = boresight_el
+                if band not in P_opts.keys():
+                    # Compute detector properties using JBolo
+                    jsim = load_sim(jbolo_model)
+                    jsim["sources"]["atmosphere"]["elevation"] = elevation  # Degrees
+                    jsim["sources"]["atmosphere"]["pwv"] = int(pwv)  # Microns
+                    jf.run_optics(jsim)
+                    jf.run_bolos(jsim)
+                    P_opts[band] = float(jsim["outputs"][jbolo_channel]["P_opt"])  # W
+                    P_sats[band] = float(jsim["outputs"][jbolo_channel]["P_sat"])  # W
 
-            # Pull from cached values
-            P_opt = P_opts[band]
-            P_atm_ref = P_atm_refs[band]
-            efficiency = efficiencies[band]
-            P_sat = P_sats[band]
-            
+                # Pull from cached values
+                P_opt = P_opts[band]
+                P_sat = P_sats[band]
+
             # Compute conversion
-            P_atm = efficiency * bandpass.optical_loading(det, median_signal)  # W
-            P_opt += P_atm - P_atm_ref
             dPdT = bandpass.kcmb2w(det)  # K_CMB -> W
             R_TES = R_FRAC * R_BOLO
 
-            # Check for saturated detectors, flag if so
+            # Check for saturated detectors, flag if so.  I_TES will also
+            # be NaN in that case.
             if P_sat < P_opt:
+                msg = f"{obs.name}, det {det} is saturated, cutting"
+                log.debug(msg)
                 obs.detdata[self.det_flags][det] |= self.det_flag_mask
+                obs.update_local_detector_flags({det: self.det_mask})
 
             I_TES = np.sqrt((P_sat - P_opt) / R_TES)
             dIdP = -1 / (I_TES * (R_TES - R_SHUNT))  # W -> A
@@ -248,13 +290,17 @@ class SimMuMUXCrosstalk(Operator):
                 "Cannot calculate detector parameters -- no JBolo installation"
             )
         # Check for JBOLO data path
-        if 'JBOLO_PATH' not in os.environ.keys() or 'JBOLO_MODELS_PATH' not in os.environ.keys():
+        if (
+            "JBOLO_PATH" not in os.environ.keys()
+            or "JBOLO_MODELS_PATH" not in os.environ.keys()
+        ):
             raise RuntimeError(
                 "Cannot calculate detector parameters -- no JBolo models available"
             )
 
         for obs in data.obs:
-            # Get the original number of process rows in the observation
+            # Get the original number of process rows in the observation.  We
+            # use this when redistributing back to the original distribution.
             proc_rows = obs.dist.process_rows
 
             if self.det_data not in obs.detdata:
@@ -262,81 +308,136 @@ class SimMuMUXCrosstalk(Operator):
                 msg += "does not exist in {obs.name}"
                 raise RuntimeError(msg)
 
-            # Redistribute the data. For crosstalk, each process requires
-            # all detectors
-            # Duplicate just the fields of the observation we will use
+            log.debug_rank(f"Crosstalk sim begin {obs.name}", comm=obs.comm.comm_group)
+
+            # Before redistributing the data, compute any global values that are
+            # constant over the whole observation.
+            if self.detector_pointing is None:
+                # We are using the boresight elevation
+                if self.shared_flags is not None:
+                    good = (
+                        obs.shared[self.shared_flags].data & self.shared_flag_mask
+                    ) == 0
+                else:
+                    good = np.ones(obs.n_local_samples, dtype=bool)
+                boresight_el = np.degrees(
+                    np.median(obs.shared[defaults.elevation].data[good])
+                )
+            else:
+                boresight_el = None
+
+            # Make a copy of this observation and redistribute it so that each
+            # process has all detectors for a slice of time.  Duplicate just the fields
+            # of the observation we will use.  Put this temporary obs in a Data object
+            # so we can use other operators on it.
+            shared_fields = [self.shared_flags]
+            if self.detector_pointing is not None:
+                shared_fields.append(self.detector_pointing.boresight)
             temp_obs = obs.duplicate(
                 times=self.times,
                 meta=[],
-                shared=[self.shared_flags],
+                shared=shared_fields,
                 detdata=[self.det_data, self.det_flags],
                 intervals=[],
             )
             temp_obs.redistribute(1, times=self.times, override_sample_sets=None)
+            temp_data = Data(comm=data.comm)
+            temp_data.obs.append(temp_obs)
 
-            # Crosstalk the detector data
-            det_data = temp_obs.detdata[self.det_data]
-            detectors = det_data.keys()
-            rows = det_data.indices(detectors)
-            # Determine the units and potential scaling factor
-            det_units = det_data.units
-            det_scale = unit_conversion(det_units, u.K)
+            # The valid detectors we will consider.
+            good_dets = temp_obs.select_local_detectors(
+                selection=detectors, flagmask=self.det_mask
+            )
+
+            # Focalplane for this observation
             focalplane = temp_obs.telescope.focalplane
 
-            chis = pos_to_chi(focalplane, detectors)
+            # Compute the cross talk amplitudes
+            chis = pos_to_chi(focalplane, good_dets)
 
-            # Make a copy of the detector data in K_CMB
-            input_data = det_data.data.copy() * det_scale
-            output_data = det_data.data  # just a reference
+            # Find the scaling from the original detector units to K_CMB
+            det_data = temp_obs.detdata[self.det_data]
+            det_units = det_data.units
+            det_scale = unit_conversion(det_units, u.K)
+
+            # Make a scaled copy of the original detector data, so that we can modify
+            # the output.
+            toast.ops.Copy(detdata=[(self.det_data, self._temp_detdata_name)]).apply(
+                temp_data
+            )
+            toast.ops.CalibrateDetectors(
+                det_data=self._temp_detdata_name, cal_value=det_scale, cal_units=u.K
+            ).apply(temp_data)
+            input_data = temp_obs.detdata[self._temp_detdata_name]
 
             # Get observation parameters for dPhi0dT calculation
             pwv = obs.telescope.site.weather.pwv.to_value(u.um)
-            el  = obs["scan_el"].to_value(u.degree)
 
-            Phi0 = self._draw_Phi0(temp_obs, focalplane, detectors)
+            Phi0 = self._draw_Phi0(temp_obs, focalplane, good_dets)
             dPhi0dT = self._evaluate_dPhi0dT(
-                temp_obs, input_data, detectors, rows, Phi0, pwv, el
+                temp_data, good_dets, Phi0, pwv, boresight_el
             )
 
             # For each detector-detector pair:
             #     Get crosstalk strength, chi
             #     Generate output data by mixing input data
-            for row_target, det_target in zip(rows, detectors):
-                # Skip crosstalk for saturated detectors
-                if np.isnan(dPhi0dT[det_target]):
-                    continue
-
-                crosstalk = np.zeros_like(input_data[row_target])
+            for det_target in good_dets:
+                crosstalk = np.zeros_like(input_data[det_target])
                 target_squid_phase = self._temperature_to_squid_phase(
-                    input_data[row_target],
+                    input_data[det_target],
                     Phi0[det_target],
                     dPhi0dT[det_target],
                 )
-                for row_source, det_source in zip(rows, detectors):
+                first_samp = temp_obs.local_index_offset
+                last_samp = first_samp + temp_obs.n_local_samples
+                det_msg = f"{det_target}[{first_samp}:{last_samp}] "
+                det_msg += f"(phi0={Phi0[det_target]:0.2e}, "
+                det_msg += f"dphi0dT={dPhi0dT[det_target]:0.2e})"
+                for det_source in good_dets:
                     if (det_target, det_source) in chis:
                         chi = chis[(det_target, det_source)]
                     else:
+                        # No contribution from this source detector
                         continue
                     source_squid_phase = self._temperature_to_squid_phase(
-                        input_data[row_source],
+                        input_data[det_source],
                         Phi0[det_source],
                         dPhi0dT[det_source],
                     )
-                    # Add crosstalk if not collided resonator or saturated detector
-                    if not (np.isnan(chi) or np.isnan(dPhi0dT[det_source])):
+
+                    # Add crosstalk if not collided resonator
+                    if not np.isnan(chi):
                         crosstalk += chi * np.sin(
                             source_squid_phase - target_squid_phase
                         )
+                        det_msg += f"\n  {det_source} (phi0={Phi0[det_target]:0.2e}, "
+                        det_msg += f"dphi0dT={dPhi0dT[det_target]:0.2e}) "
+                        det_msg += f"chi = {chi:0.2e}"
                     else:
-                        # Otherwise flag
-                        temp_obs.detdata[self.det_flags][det_source] |= self.det_flag_mask
-                        temp_obs.detdata[self.det_flags][det_target] |= self.det_flag_mask
+                        # If collided, flag both detectors
+                        msg = f"{obs.name}: collision, cutting {det_target} "
+                        msg += f"and {det_source}"
+                        log.debug(msg)
+                        temp_obs.update_local_detector_flags(
+                            {
+                                det_source: self.det_mask,
+                                det_target: self.det_mask,
+                            },
+                        )
+                        temp_obs.detdata[self.det_flags][det_target] |= (
+                            self.det_flag_mask
+                        )
+                        temp_obs.detdata[self.det_flags][det_source] |= (
+                            self.det_flag_mask
+                        )
+                log.debug(det_msg)
 
                 # Translate crosstalk into temperature units and scale to
                 # match input data
-                output_data[row_target] += self._squid_phase_to_temperature(
-                    crosstalk, dPhi0dT[det_target]
-                ) / det_scale
+                det_data[det_target] += (
+                    self._squid_phase_to_temperature(crosstalk, dPhi0dT[det_target])
+                    / det_scale
+                )
 
             # Redistribute back
             temp_obs.redistribute(
@@ -346,7 +447,7 @@ class SimMuMUXCrosstalk(Operator):
             )
 
             # Copy data to original observation
-            for det in obs.select_local_detectors():
+            for det in good_dets:
                 # Unit conversion does not preserve offset so we do it
                 # explicitly here
                 offset_old = np.median(obs.detdata[self.det_data][det])
@@ -355,12 +456,16 @@ class SimMuMUXCrosstalk(Operator):
                 obs.detdata[self.det_data][det] = (
                     temp_obs.detdata[self.det_data][det] - offset_new + offset_old
                 )
-                # Propagate flags
-                obs.detdata[self.det_flags][det] |= temp_obs.detdata[self.det_flags][det]
+                # Propagate flags.
+                obs.detdata[self.det_flags][det] |= temp_obs.detdata[self.det_flags][
+                    det
+                ]
+                obs.update_local_detector_flags(temp_obs.local_detector_flags)
 
             # Free data copy
             temp_obs.clear()
             del temp_obs
+            del temp_data
 
         return
 
@@ -368,9 +473,16 @@ class SimMuMUXCrosstalk(Operator):
         return
 
     def _requires(self):
-        req = self.stokes_weights.requires()
-        req["shared"].append(self.hwp_angle)
-        req["detdata"].append(self.weights)
+        req = {
+            "shared": [self.times],
+            "detdata": [self.det_data],
+        }
+        if self.shared_flags is not None:
+            req["shared"].append(self.shared_flags)
+        if self.det_flags is not None:
+            req["detdata"].append(self.det_flags)
+        if self.detector_pointing is not None:
+            req.update(self.detector_pointing.requires())
         return req
 
     def _provides(self):

--- a/sotodlib/toast/ops/sim_mumux_crosstalk.py
+++ b/sotodlib/toast/ops/sim_mumux_crosstalk.py
@@ -22,10 +22,11 @@ try:
     from jbolo.utils import load_sim
 
     jbolo_available = True
-except:
+except (ImportError, AttributeError):
     jbolo_available = False
 
-from .mumux_crosstalk_util import detmap_available, pos_to_chi
+from .mumux_crosstalk_util import pos_to_chi
+
 
 # JBolo sims to use
 JBOLO_MODELS = {
@@ -134,11 +135,14 @@ class SimMuMUXCrosstalk(Operator):
         help="Draw new phase offsets for every observation and realization",
     )
 
-    # The name of the temporary, scaled, detector data field.
-    _temp_detdata_name = "temp_umux_crosstalk_input"
-
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+
+        # Set of real data band types for non-optical detectors
+        self._alt_band_keys = {"DARK", "NC", "SQID"}
+
+        # The name of the temporary, scaled, detector data field.
+        self._temp_detdata_name = "temp_umux_crosstalk_input"
 
     def _temperature_to_squid_phase(self, input_signal, Phi0, dPhi0dT):
         """Translate temperature-valued signal into SQUID phase"""
@@ -206,7 +210,7 @@ class SimMuMUXCrosstalk(Operator):
         dPhi0dT = {}
         for det in detectors:
             raw_band = focalplane[det]["band"]
-            if raw_band == "DARK" or raw_band[0] == "f":
+            if raw_band in self._alt_band_keys or raw_band[0] == "f":
                 # We are using real data with bands like "f090", "f150", etc
                 # Determine the telescope type from the name.
                 wafer_band = focalplane[det]["det_info:wafer:bandpass"]
@@ -241,7 +245,7 @@ class SimMuMUXCrosstalk(Operator):
             else:
                 # We are using the boresight elevation
                 elevation = boresight_el
-                if band not in P_opts.keys():
+                if band not in P_opts:
                     # Compute detector properties using JBolo
                     jsim = load_sim(jbolo_model)
                     jsim["sources"]["atmosphere"]["elevation"] = elevation  # Degrees
@@ -291,8 +295,8 @@ class SimMuMUXCrosstalk(Operator):
             )
         # Check for JBOLO data path
         if (
-            "JBOLO_PATH" not in os.environ.keys()
-            or "JBOLO_MODELS_PATH" not in os.environ.keys()
+            "JBOLO_PATH" not in os.environ
+            or "JBOLO_MODELS_PATH" not in os.environ
         ):
             raise RuntimeError(
                 "Cannot calculate detector parameters -- no JBolo models available"
@@ -410,8 +414,8 @@ class SimMuMUXCrosstalk(Operator):
                         crosstalk += chi * np.sin(
                             source_squid_phase - target_squid_phase
                         )
-                        det_msg += f"\n  {det_source} (phi0={Phi0[det_target]:0.2e}, "
-                        det_msg += f"dphi0dT={dPhi0dT[det_target]:0.2e}) "
+                        det_msg += f"\n  {det_source} (phi0={Phi0[det_source]:0.2e}, "
+                        det_msg += f"dphi0dT={dPhi0dT[det_source]:0.2e}) "
                         det_msg += f"chi = {chi:0.2e}"
                     else:
                         # If collided, flag both detectors
@@ -467,8 +471,6 @@ class SimMuMUXCrosstalk(Operator):
             del temp_obs
             del temp_data
 
-        return
-
     def _finalize(self, data, **kwargs):
         return
 
@@ -487,8 +489,8 @@ class SimMuMUXCrosstalk(Operator):
 
     def _provides(self):
         prov = {
-            "meta": list(),
-            "shared": list(),
+            "meta": [],
+            "shared": [],
             "detdata": [
                 self.det_data,
             ],
@@ -496,4 +498,4 @@ class SimMuMUXCrosstalk(Operator):
         return prov
 
     def _accelerators(self):
-        return list()
+        return []

--- a/sotodlib/toast/ops/sim_sso.py
+++ b/sotodlib/toast/ops/sim_sso.py
@@ -69,6 +69,11 @@ class SimSSO(Operator):
         help="HDF5 file that stores the simulated beam",
     )
 
+    det_mask = Int(
+        defaults.det_mask_invalid,
+        help="Bit mask value for per-detector flagging",
+    )
+
     det_data = Unicode(
         defaults.det_data,
         help="Observation detdata key for simulated signal",
@@ -227,7 +232,7 @@ class SimSSO(Operator):
                 # Make sure detector data output exists.  If not, create it
                 # with units of Kelvin.
 
-                dets = obs.select_local_detectors(detectors)
+                dets = obs.select_local_detectors(detectors, flagmask=self.det_mask)
 
                 exists = obs.detdata.ensure(
                     self.det_data, detectors=dets, create_units=u.K

--- a/tests/test_sim_mumux_crosstalk.py
+++ b/tests/test_sim_mumux_crosstalk.py
@@ -5,6 +5,7 @@
 
 """
 
+import os
 import unittest
 
 import astropy.units as u
@@ -18,14 +19,13 @@ try:
 
     import sotodlib.toast as sotoast
     import sotodlib.toast.ops as so_ops
+    from sotodlib.toast.ops import detmap_available, pos_to_chi, jbolo_available
     toast_available = True
 except ImportError as e:
     toast_available = False
 
 from ._helpers import (calibration_schedule, close_data_and_comm,
                       simulation_test_data)
-
-from sotodlib.toast.ops import detmap_available, pos_to_chi
 
 
 class SimMuMUXCrosstalkTest(unittest.TestCase):
@@ -34,9 +34,16 @@ class SimMuMUXCrosstalkTest(unittest.TestCase):
             print("toast cannot be imported- skipping unit tests", flush=True)
             return
 
-        if not detmap_available:
+        if not detmap_available or not jbolo_available:
             print(
-                "DetMap cannot be imported- skipping muMUX unit tests",
+                "DetMap / jbolo cannot be imported- skipping muMUX unit tests",
+                flush=True,
+            )
+            return
+
+        if "JBOLO_PATH" not in os.environ or "JBOLO_MODELS_PATH" not in os.environ:
+            print(
+                "JBOLO environment variables not set- skipping muMUX unit tests",
                 flush=True,
             )
             return

--- a/tests/test_sim_mumux_crosstalk.py
+++ b/tests/test_sim_mumux_crosstalk.py
@@ -1,9 +1,7 @@
 # Copyright (c) 2023 Simons Observatory.
 # Full license can be found in the top level "LICENSE" file.
 
-"""Check functionality of the muMUX crosstalk simulation
-
-"""
+"""Check functionality of the muMUX crosstalk simulation"""
 
 import os
 import unittest
@@ -20,12 +18,12 @@ try:
     import sotodlib.toast as sotoast
     import sotodlib.toast.ops as so_ops
     from sotodlib.toast.ops import detmap_available, pos_to_chi, jbolo_available
+
     toast_available = True
 except ImportError as e:
     toast_available = False
 
-from ._helpers import (calibration_schedule, close_data_and_comm,
-                      simulation_test_data)
+from ._helpers import calibration_schedule, close_data_and_comm, simulation_test_data
 
 
 class SimMuMUXCrosstalkTest(unittest.TestCase):
@@ -85,42 +83,55 @@ class SimMuMUXCrosstalkTest(unittest.TestCase):
 
         # Make a copy of the data for reference
 
-        signal0 = data.obs[0].detdata["signal"].data.copy()
+        toast.ops.Copy(detdata=[("signal", "input")]).apply(data)
 
         # Simple test just confirms that the operator functions
 
         so_ops.SimMuMUXCrosstalk(
-            name="sim_mumux_crosstalk",
+            detector_pointing=pointing,
         ).apply(data)
 
         # Compare signal before and after to make sure the magnitude
         # of the effect is not crazy
 
-        signal1 = data.obs[0].detdata["signal"].data.copy()
-
-        rms0 = np.std(signal0)
-        rmsdiff = np.std(signal0 - signal1)
-
-        assert rms0 != 0
-        assert rmsdiff / rms0 < 1e-3
+        for ob in data.obs:
+            for det in ob.select_local_detectors(flagmask=defaults.det_mask_invalid):
+                # We have simulated data in the turnarounds above, and have not
+                # done anything else to flag samples.  So we ignore sample flags
+                # in this test.
+                sig_in = ob.detdata["input"][det]
+                sig_out = ob.detdata["signal"][det]
+                rms_in = np.std(sig_in)
+                rmsdiff = np.std(sig_out - sig_in)
+                if rms_in == 0:
+                    print(f"{ob.name}:{det} rms_in should not be zero!", flush=True)
+                    self.assertTrue(False)
+                if rmsdiff / rms_in > 1.0e-2:
+                    print(
+                        f"{ob.name}:{det} rmsdiff / rms_in = {rmsdiff / rms_in}",
+                        flush=True,
+                    )
+                    self.assertTrue(False)
 
         # Check that the crosstalk strength is as expected
 
-        obs = data.obs[0]
-        fp = obs.telescope.focalplane
-        dets = obs.detdata["signal"].keys()
-        chis = pos_to_chi(fp, dets)
-        ndet = len(dets)
-        nnz = len(chis)
-        med = np.median(np.log10(list(chis.values())))
-
-        print(f"ndet = {ndet}",flush=True)
-        print(f"nnz = {nnz} = {nnz / ndet} ndet",flush=True)
-        print(f"median(log10(chi)) = {med}",flush=True)
-        assert nnz > ndet and nnz < 2 * ndet
-        assert med > -3 and med < -2
+        for ob in data.obs:
+            dets = ob.select_local_detectors(flagmask=defaults.det_mask_invalid)
+            fp = ob.telescope.focalplane
+            chis = pos_to_chi(fp, dets)
+            ndet = len(dets)
+            nnz = len(chis)
+            med = np.median(np.log10(list(chis.values())))
+            if nnz <= ndet or nnz >= 2 * ndet:
+                print(f"{ob.name} ndet = {ndet}", flush=True)
+                print(f"{ob.name} nnz = {nnz} = {nnz / ndet} ndet", flush=True)
+                self.assertTrue(False)
+            if med < -3 or med > -2:
+                print(f"{ob.name} median(log10(chi)) = {med}", flush=True)
+                self.assertTrue(False)
 
         close_data_and_comm(data)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
- Support real metadata names as seen in a typical observation.
- If using real observations, do not require DetMap.
- Refactor crosstalk utils to extract code that is common between the simulated and real observing cases.
- In SimSSO operator, apply detector cuts if they exist.
- When using real data, translate band names to expected format
- Add det_mask trait and handle detectors which are flagged as invalid.
- Update detector flags if saturated
- Add support for per-detector elevation.  Remove calculation of loading based on the TOD.