### PR TITLE
Update preproc documentation.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,6 +7,7 @@ build:
 
 sphinx:
     configuration: docs/conf.py
+    fail_on_warning: true
 
 python:
     install:

--- a/docs/hkdb.rst
+++ b/docs/hkdb.rst
@@ -1,4 +1,5 @@
 .. py:module:: sotodlib.io.hkdb
+   :no-index:
 
 ============================
 Loading L3 Housekeeping Data

--- a/docs/preprocess.rst
+++ b/docs/preprocess.rst
@@ -33,7 +33,8 @@ records which init layer it was built from, so if you try to run a proc
 config against a different init archive than the one it was created with, it
 will fail rather than silently mixing incompatible layers. Layers are
 chainable, so a proc layer's output can itself become the init input for a
-further layer.
+further layer, though doing so currently means running that further layer
+interactively because there is no ``three_layer_preprocess_tod`` script.
 
 This split was introduced to separate the pre-demodulation and
 post-demodulation steps for the SATs: the first (init) layer runs pointing,
@@ -52,7 +53,8 @@ synthetic examples on this page), see the platform config directories in the
 `site-pipeline-configs <https://github.com/simonsobs/site-pipeline-configs>`_
 repository, e.g. ``satp1/preprocess_config_init.yaml`` +
 ``satp1/preprocess_config_proc.yaml`` (two-layer) and
-``lat/preprocess_config_cmb.yaml`` (single-layer).
+``lat/preprocess_config_cmb_mf.yaml`` / ``lat/preprocess_config_cmb_uhf.yaml``
+(single-layer).
 
 `[TOD Processing] Infrastructure Introduction <https://simonsobs.atlassian.net/wiki/spaces/DM/pages/305627401/TOD+Processing+Infrastructure+Introduction>`_ has a fuller walkthrough (jobdb usage, extensive interactive/Python examples for loading, running, and saving preprocessing archives) that complements this reference page.
 
@@ -66,7 +68,8 @@ Passing ``--run-from-jobdb`` to ``preprocess_tod``/``multilayer_preprocess_tod``
 resumes a batch run from an existing jobdb's run list instead of rebuilding
 one — useful for continuing a large run that was interrupted (e.g. a Slurm
 job hitting its walltime) without redoing already-completed or
-already-known-to-fail work. Jobs can be inspected programmatically via
+already-known-to-fail work. It also starts immediately, since the wafer/band
+groups don't need to be recomputed. Jobs can be inspected programmatically via
 ``sotodlib.site_pipeline.jobdb.JobManager``.
 
 Preprocessing Pipelines
@@ -167,8 +170,8 @@ processing pipeline would look like::
 
     # How to subdivide observations
     subobs:
-        use: detset
-        label: detset
+        use: ["wafer_slot", "wafer.bandpass"]
+        label: "wafer_slot"
 
     # Metadata index & archive filenaming
     archive:
@@ -176,6 +179,7 @@ processing pipeline would look like::
         policy:
             type: 'simple'
             filename: 'preprocess_archive.h5'
+        batch_size: 50
 
     process_pipe:
         - name : "fft_trim"
@@ -209,10 +213,9 @@ processing pipeline would look like::
         
         - name: "calibrate"
           process:
-            kind: "single_value"
-            ## phase_to_pA: 9e6/(2*np.pi)
-            val: 1432394.4878270582
-        
+            kind: "array"
+            cal_array: "det_cal.phase_to_pW"
+
         - name: "psd"
           process:
             detrend: False
@@ -546,13 +549,13 @@ Scan / Turnaround Flags
 Flag Combination (Mapmaking / Splits)
 -------------------------------------
 
-================= ================ =================================================
+================= ================ =====================================================================================
 ``name:``         Class            What it does
-================= ================ =================================================
-``union_flags``   ``UnionFlags``   Do the union of relevant flags for mapping.
-``combine_flags`` ``CombineFlags`` Do the combination of relevant flags for mapping.
+================= ================ =====================================================================================
+``union_flags``   ``UnionFlags``   Deprecated -- use ``combine_flags`` instead. Kept only to load old process archives.
+``combine_flags`` ``CombineFlags`` Do the combination of relevant flags for mapping (generalizes ``union_flags``).
 ``split_flags``   ``SplitFlags``   Get flags used for map splitting/bundling.
-================= ================ =================================================
+================= ================ =====================================================================================
 
 .. autoclass:: sotodlib.preprocess.processes.UnionFlags
 .. autoclass:: sotodlib.preprocess.processes.CombineFlags

--- a/docs/preprocess.rst
+++ b/docs/preprocess.rst
@@ -21,7 +21,53 @@ entire observation is loaded, without signal. For example, pipeline steps such
 as ``DetBiasFlags`` requires tod-level data including signal, whereas
 ``SSOFootprint`` does not and uses observation-level data.
 
+Single-layer vs. two-layer ("multilayer") pipelines
+:::::::::::::::::::::::::::::::::::::::::::::::::::
 
+A single ``process_pipe`` config file, run through ``preprocess_tod``, is a
+**single-layer** pipeline. For some platforms (in particular the SATs) the
+full processing recipe is instead split into **two layers**, run through
+``multilayer_preprocess_tod`` with two config files: an **init** (first)
+layer and a **proc** (second) layer that depends on it. The proc layer
+records which init layer it was built from, so if you try to run a proc
+config against a different init archive than the one it was created with, it
+will fail rather than silently mixing incompatible layers. Layers are
+chainable, so a proc layer's output can itself become the init input for a
+further layer.
+
+This split was introduced to separate the pre-demodulation and
+post-demodulation steps for the SATs: the first (init) layer runs pointing,
+flagging, HWP-synchronous-signal removal, calibration, PCA relcal, and
+demodulation, producing calibrated demodulated Q/U timestreams; the second
+(proc) layer runs the filters that operate on that demodulated data (e.g.
+``azss``, ``estimate_t2p``/``subtract_t2p``, ``sub_polyf``). Splitting the
+pipeline this way means the second layer's filtering can be iterated on and
+re-run without repeating the expensive first-layer processing. LAT configs in
+production are currently single-layer only (no init/proc split), reflecting
+that LAT does not run the HWP-demodulation/ground-pickup/T-to-P-leakage
+processing chain the SATs do in this pipeline.
+
+For real, in-production examples of both designs (as opposed to the
+synthetic examples on this page), see the platform config directories in the
+`site-pipeline-configs <https://github.com/simonsobs/site-pipeline-configs>`_
+repository, e.g. ``satp1/preprocess_config_init.yaml`` +
+``satp1/preprocess_config_proc.yaml`` (two-layer) and
+``lat/preprocess_config_cmb.yaml`` (single-layer).
+
+`[TOD Processing] Infrastructure Introduction <https://simonsobs.atlassian.net/wiki/spaces/DM/pages/305627401/TOD+Processing+Infrastructure+Introduction>` has a fuller walkthrough (jobdb usage, extensive interactive/Python examples for loading, running, and saving preprocessing archives) that complements this reference page.
+
+Preprocessing job tracking (``jobdb``)
+::::::::::::::::::::::::::::::::::::::
+
+Preprocessing configs can optionally include a top-level ``jobdb`` key giving
+the path to a SQLite database that tracks the state (``open``/``done``/
+``failed``) of each preprocessing job (an obs_id + group combination).
+Passing ``--run-from-jobdb`` to ``preprocess_tod``/``multilayer_preprocess_tod``
+resumes a batch run from an existing jobdb's run list instead of rebuilding
+one — useful for continuing a large run that was interrupted (e.g. a Slurm
+job hitting its walltime) without redoing already-completed or
+already-known-to-fail work. Jobs can be inspected programmatically via
+``sotodlib.site_pipeline.jobdb.JobManager``.
 
 Preprocessing Pipelines
 ------------------------
@@ -272,43 +318,265 @@ A configuration file for the processing pipeline would look like::
                             'ws6': [8.5, -7]}
             focal_plane: 'focal_plane_positions.npz'
 
+Process Step Glossary
+---------------------
+
+Quick reference for every registered ``process_pipe`` step name (the
+``name:`` string you put in a config file), grouped by what it's for. The
+"What it does" column is the first line of each class's docstring (see
+`Processing Modules`_ below for the full docstring, including config
+options, for any given step). This table is generated from
+``sotodlib.preprocess.processes``; if you add a new registered process,
+add a row here too and a matching ``.. autoclass::`` entry under
+`Processing Modules`_ below —
+``tests/test_preprocess_docs.py`` will fail CI if the two fall out of
+sync.
+
+**General / utility**
+
+======================= ==================== =================================================================
+``name:``               Class                What it does
+======================= ==================== =================================================================
+``fft_trim``            ``FFTTrim``          Trim the AxisManager to optimize for faster FFTs later in the pipeline.
+``detrend``              ``Detrend``          Remove mean, median or linear trend from the data.
+``move``                 ``Move``             Rename or remove a data field (used to replace gamma angles with those from wiregrid for example).
+``trim_flag_edge``       ``TrimFlagEdge``     Trim edge until given flags of all detectors are False.
+======================= ==================== =================================================================
+
+**Detector Cuts and Flags**
+
+======================= ======================== =================================================================
+``name:``               Class                    What it does
+======================= ======================== =================================================================
+``det_bias_flags``      ``DetBiasFlags``         Derive poorly biased detectors from IV and Bias Step data.
+``trends``              ``Trends``               Check for large linear ramping in the data to look for unlocked detectors.
+``ptp_flags``           ``PTPFlags``             Find (and cut) detectors with anomalous peak-to-peak signal.
+``inv_var_flags``       ``InvVarFlags``          Find (and cut) detectors with too high inverse variance.
+``cut_bad_dist``        ``CutBadDistribution``   Detector cuts to keep a statistic (i.e white noise, peak-peak, fknee, etc.) within some bounds of a gaussian distribution.
+``detcal_nan_cuts``     ``DetcalNanCuts``        Remove detectors with NaN values in the specified det_cal metadata fields.
+``fp_flags``            ``FocalplaneNanFlags``   Cut detectors which have nans in their pointing information.
+``dark_dets``           ``DarkDets``             Cut dark detectors in the data.
+``acu_drop_flags``      ``AcuDropFlags``         Expands ACU drop (bad ACU/platform pointing data) flag fields in aman to all detectors.
+``smurfgaps_flags``     ``SmurfGapsFlags``       Expand smurfgaps (bad smurf data) flag of each stream_id to all detectors.
+``load_premade_flags``  ``LoadPremadeFlags``  Load premade flags from aman.
+``tod_stats``           ``GetStats``          Get basic statistics from a TOD or its power spectrum to use for flags and cuts.
+======================= ==================== =================================================================
+
+**Glitches & jumps**
+
+======================= ==================== =================================================================
+``name:``               Class                What it does
+======================= ==================== =================================================================
+``glitches``            ``GlitchDetection``  Run glitch detection algorithm to find glitches.
+``glitchfill``          ``GlitchFill``       Fill glitches.
+``jumps``               ``Jumps``            Run generic jump finding and fixing algorithm.
+``fix_jumps``           ``FixJumps``         Repairs the jump heights given a set of jump flags and heights.
+======================= ==================== =================================================================
+
+**Noise & PSD**
+
+======================= ==================== =================================================================
+``name:``               Class                What it does
+======================= ==================== =================================================================
+``psd``                 ``PSDCalc``          Calculate the PSD of the data and add it to the AxisManager.
+``noise_ratio``         ``NoiseRatio``       Compute ratios of "signal band" to white noise in PSDs (simple fit-independent way to check for excessive 1/f channels).
+``noise``               ``Noise``            Estimate the white noise levels in the data.
+======================= ==================== =================================================================
+
+**Calibration**
+
+======================= ======================== =================================================================
+``name:``               Class                    What it does
+======================= ======================== =================================================================
+``calibrate``           ``Calibrate``            Calibrate the timestreams based on some provided information (Abscal, relcal, bias step)--just a multiplication.
+``pca_relcal``          ``PCARelCal``            Estimate the relcal factor from the atmosphere using PCA.
+``correct_iir_params``  ``CorrectIIRParams``     Correct missing iir_params (readout downsampling filter) by default values.
+======================= ======================== =================================================================
+
+**HWP & demodulation**
+
+======================= ==================== =================================================================
+``name:``               Class                What it does
+======================= ==================== =================================================================
+``hwp_angle_model``     ``HWPAngleModel``    Apply hwp angle model (from metadata) to the TOD.
+``estimate_hwpss``      ``EstimateHWPSS``    Builds a HWPSS (HWP-synchronous-signal) template.
+``subtract_hwpss``      ``SubtractHWPSS``    Subtracts a HWPSS template from signal.
+``demodulate``          ``Demodulate``       Demodulate the TOD.
+``a2_stats``            ``A2Stats``          Calculate statistical metrics for A2, the 2f-demodulated Q and U signals.
+``get_tau_hwp``         ``GetTauHWP``        Analyze observation with hwp spinning up or spinning down to estimate time constant.
+======================= ==================== =================================================================
+
+**Ground pickup (AzSS)**
+
+============================ ============================ =================================================================
+``name:``                    Class                        What it does
+============================ ============================ =================================================================
+``azss``                     ``AzSS``                     Estimates Azimuth Synchronous Signal (AzSS) by binning signal by azimuth of boresight  and subtract.
+``subtract_azss_template``   ``SubtractAzSSTemplate``     Subtract Azimuth Synchronous Signal (AzSS) common template.
+============================ ============================ =================================================================
+
+**Filtering**
+
+======================= ==================== =================================================================
+``name:``               Class                What it does
+======================= ==================== =================================================================
+``fourier_filter``      ``FourierFilter``    Applies a chain of Fourier filters (defined in fft_ops) to the data.
+``sub_polyf``           ``SubPolyf``         Fit TOD in each subscan with polynomial of given order and subtract it.
+``apodize``             ``Apodize``          Apodize the edges of a signal.
+``scan_freq_cut``       ``ScanFreqCut``      Apply high-pass cut at the scan frequency.
+``pca_filter``          ``PCAFilter``        Applies a pca filter to the data.
+``get_common_mode``     ``GetCommonMode``    Calculate common mode (average over detectors not PCA filtered).
+======================= ==================== =================================================================
+
+**Pointing & focal-plane geometry**
+
+============================== ============================== =================================================================
+``name:``                      Class                          What it does
+============================== ============================== =================================================================
+``pointing_model``             ``PointingModel``               Apply pointing model to the TOD.
+``rotate_focal_plane``         ``RotateFocalPlane``            Interpret the boresight rotation effect as a focal plane rotation.
+``rotate_qu``                  ``RotateQU``                    Rotate Q and U components to/from telescope coordinates.
+``subtract_qu_common_mode``    ``SubtractQUCommonMode``        Subtract Q and U common mode.
+============================== ============================== =================================================================
+
+**Sources & planets**
+
+======================= ======================== =================================================================
+``name:``               Class                    What it does
+======================= ======================== =================================================================
+``source_flags``        ``SourceFlags``          Calculate the source flags in the data.
+``filter_for_sources``  ``FilterForSources``     Mask and gap-fill the signal at samples flagged by source_flags.
+``sso_footprint``       ``SSOFootprint``         Find nearby sources within a given distance and get SSO footprint and plot.
+======================= ======================== =================================================================
+
+**T-to-P (temperature-to-polarization) leakage**
+
+======================= ==================== =================================================================
+``name:``               Class                What it does
+======================= ==================== =================================================================
+``estimate_t2p``        ``EstimateT2P``      Estimate T to P leakage coefficients.
+``subtract_t2p``        ``SubtractT2P``      Subtract T to P leakage.
+======================= ==================== =================================================================
+
+**Scan / turnaround flags**
+
+======================= ======================== =================================================================
+``name:``               Class                    What it does
+======================= ======================== =================================================================
+``flag_turnarounds``    ``FlagTurnarounds``      From the Azimuth encoder data, flag turnarounds, left-going, and right-going.
+``noisy_subscan_flags`` ``BadSubscanFlags``      Identifies and flags bad subscans (statistics of the subscan non-gaussian, e.g., high kurtosis).
+======================= ======================== =================================================================
+
+**Flag combination (for mapmaking / splits)**
+
+======================= ==================== =================================================================
+``name:``               Class                What it does
+======================= ==================== =================================================================
+``union_flags``         ``UnionFlags``       Do the union of relevant flags for mapping.
+``combine_flags``       ``CombineFlags``     Do the combination of relevant flags for mapping.
+``split_flags``         ``SplitFlags``       Get flags used for map splitting/bundling.
+======================= ==================== =================================================================
+
+
 Processing Modules
 ------------------
 
+Full reference (docstrings, including ``calc``/``save``/``select``/``plot``
+config options and example config blocks) for all registered process
+classes, grouped as in the glossary above.
 
-TOD Operations
-::::::::::::::
+General / Utility
+::::::::::::::::::
 .. autoclass:: sotodlib.preprocess.processes.FFTTrim
 .. autoclass:: sotodlib.preprocess.processes.Detrend
-.. autoclass:: sotodlib.preprocess.processes.PSDCalc
-.. autoclass:: sotodlib.preprocess.processes.Apodize
-.. autoclass:: sotodlib.preprocess.processes.SubPolyf
+.. autoclass:: sotodlib.preprocess.processes.Move
+.. autoclass:: sotodlib.preprocess.processes.TrimFlagEdge
+
+Detector Quality Flags
+:::::::::::::::::::::::
+.. autoclass:: sotodlib.preprocess.processes.DetBiasFlags
+.. autoclass:: sotodlib.preprocess.processes.Trends
+.. autoclass:: sotodlib.preprocess.processes.PTPFlags
+.. autoclass:: sotodlib.preprocess.processes.InvVarFlags
+.. autoclass:: sotodlib.preprocess.processes.CutBadDistribution
+.. autoclass:: sotodlib.preprocess.processes.DetcalNanCuts
+.. autoclass:: sotodlib.preprocess.processes.FocalplaneNanFlags
+.. autoclass:: sotodlib.preprocess.processes.DarkDets
+.. autoclass:: sotodlib.preprocess.processes.AcuDropFlags
+.. autoclass:: sotodlib.preprocess.processes.SmurfGapsFlags
+
+Premade Flags & Stats
+:::::::::::::::::::::::
+.. autoclass:: sotodlib.preprocess.processes.LoadPremadeFlags
+.. autoclass:: sotodlib.preprocess.processes.GetStats
+
+Glitches & Jumps
+::::::::::::::::::
+.. autoclass:: sotodlib.preprocess.processes.GlitchDetection
+.. autoclass:: sotodlib.preprocess.processes.GlitchFill
 .. autoclass:: sotodlib.preprocess.processes.Jumps
 .. autoclass:: sotodlib.preprocess.processes.FixJumps
-.. autoclass:: sotodlib.preprocess.processes.FourierFilter
+
+Noise & PSD
+::::::::::::
+.. autoclass:: sotodlib.preprocess.processes.PSDCalc
+.. autoclass:: sotodlib.preprocess.processes.NoiseRatio
+.. autoclass:: sotodlib.preprocess.processes.Noise
 
 Calibration
 :::::::::::
 .. autoclass:: sotodlib.preprocess.processes.Calibrate
 .. autoclass:: sotodlib.preprocess.processes.PCARelCal
+.. autoclass:: sotodlib.preprocess.processes.CorrectIIRParams
 
-Flagging and Products
-:::::::::::::::::::::
-.. autoclass:: sotodlib.preprocess.processes.Trends
-.. autoclass:: sotodlib.preprocess.processes.GlitchDetection
-.. autoclass:: sotodlib.preprocess.processes.GlitchFill
-.. autoclass:: sotodlib.preprocess.processes.Noise
-.. autoclass:: sotodlib.preprocess.processes.FlagTurnarounds
-.. autoclass:: sotodlib.preprocess.processes.DarkDets
-.. autoclass:: sotodlib.preprocess.processes.SourceFlags
-.. autoclass:: sotodlib.preprocess.processes.GetStats
-
-HWP Related
-:::::::::::
+HWP & Demodulation
+:::::::::::::::::::
+.. autoclass:: sotodlib.preprocess.processes.HWPAngleModel
 .. autoclass:: sotodlib.preprocess.processes.EstimateHWPSS
 .. autoclass:: sotodlib.preprocess.processes.SubtractHWPSS
 .. autoclass:: sotodlib.preprocess.processes.Demodulate
+.. autoclass:: sotodlib.preprocess.processes.A2Stats
+.. autoclass:: sotodlib.preprocess.processes.GetTauHWP
 
-Obs Operations
-::::::::::::::
+Ground Pickup (AzSS)
+::::::::::::::::::::::
+.. autoclass:: sotodlib.preprocess.processes.AzSS
+.. autoclass:: sotodlib.preprocess.processes.SubtractAzSSTemplate
+
+Filtering
+:::::::::
+.. autoclass:: sotodlib.preprocess.processes.FourierFilter
+.. autoclass:: sotodlib.preprocess.processes.SubPolyf
+.. autoclass:: sotodlib.preprocess.processes.Apodize
+.. autoclass:: sotodlib.preprocess.processes.ScanFreqCut
+.. autoclass:: sotodlib.preprocess.processes.PCAFilter
+.. autoclass:: sotodlib.preprocess.processes.GetCommonMode
+
+Pointing & Focal-Plane Geometry
+:::::::::::::::::::::::::::::::::
+.. autoclass:: sotodlib.preprocess.processes.PointingModel
+.. autoclass:: sotodlib.preprocess.processes.RotateFocalPlane
+.. autoclass:: sotodlib.preprocess.processes.RotateQU
+.. autoclass:: sotodlib.preprocess.processes.SubtractQUCommonMode
+
+Sources & Planets
+::::::::::::::::::
+.. autoclass:: sotodlib.preprocess.processes.SourceFlags
+.. autoclass:: sotodlib.preprocess.processes.FilterForSources
 .. autoclass:: sotodlib.preprocess.processes.SSOFootprint
+
+T-to-P Leakage
+:::::::::::::::
+.. autoclass:: sotodlib.preprocess.processes.EstimateT2P
+.. autoclass:: sotodlib.preprocess.processes.SubtractT2P
+
+Scan / Turnaround Flags
+:::::::::::::::::::::::::
+.. autoclass:: sotodlib.preprocess.processes.FlagTurnarounds
+.. autoclass:: sotodlib.preprocess.processes.BadSubscanFlags
+
+Flag Combination (Mapmaking / Splits)
+:::::::::::::::::::::::::::::::::::::::
+.. autoclass:: sotodlib.preprocess.processes.UnionFlags
+.. autoclass:: sotodlib.preprocess.processes.CombineFlags
+.. autoclass:: sotodlib.preprocess.processes.SplitFlags

--- a/docs/preprocess.rst
+++ b/docs/preprocess.rst
@@ -54,7 +54,7 @@ repository, e.g. ``satp1/preprocess_config_init.yaml`` +
 ``satp1/preprocess_config_proc.yaml`` (two-layer) and
 ``lat/preprocess_config_cmb.yaml`` (single-layer).
 
-`[TOD Processing] Infrastructure Introduction <https://simonsobs.atlassian.net/wiki/spaces/DM/pages/305627401/TOD+Processing+Infrastructure+Introduction>` has a fuller walkthrough (jobdb usage, extensive interactive/Python examples for loading, running, and saving preprocessing archives) that complements this reference page.
+`[TOD Processing] Infrastructure Introduction <https://simonsobs.atlassian.net/wiki/spaces/DM/pages/305627401/TOD+Processing+Infrastructure+Introduction>`_ has a fuller walkthrough (jobdb usage, extensive interactive/Python examples for loading, running, and saving preprocessing archives) that complements this reference page.
 
 Preprocessing job tracking (``jobdb``)
 ::::::::::::::::::::::::::::::::::::::

--- a/docs/preprocess.rst
+++ b/docs/preprocess.rst
@@ -70,7 +70,7 @@ already-known-to-fail work. Jobs can be inspected programmatically via
 ``sotodlib.site_pipeline.jobdb.JobManager``.
 
 Preprocessing Pipelines
-------------------------
+:::::::::::::::::::::::
 
 A preprocessing pipeline is series of modules, each inheriting from
 ``_Preprocess``, that are defined through a configuration file and intended to be
@@ -90,7 +90,7 @@ modules that can be used to make a new pipeline.
 
 
 Processing Scripts
-------------------
+::::::::::::::::::
 These scripts are designed to be the ones that interact with specific
 configuration files and specific manifest databases.
 
@@ -113,7 +113,7 @@ configuration files and specific manifest databases.
 
 
 Processing Util Functions
----------------------------
+:::::::::::::::::::::::::
 These functions support and are used within the driver processing scripts
 above and are useful for saving, loading, and verifying preprocessing archives
 and databases.
@@ -153,7 +153,7 @@ and databases.
 
 
 Example TOD Pipeline Configuration File
----------------------------------------
+:::::::::::::::::::::::::::::::::::::::
 
 Suppose we want to run a simple pipeline that runs the glitch calculator and
 estimates the white noise levels of the data. A configuration file for the
@@ -234,7 +234,7 @@ the processing pipe. The ``process`` function is always run before the
 ``calc_and_save`` when ``plot: True`` for a module that supports it.
 
 Example Planet TOD Pipeline Configuration File
-----------------------------------------------
+::::::::::::::::::::::::::::::::::::::::::::::
 Similar to a regular TOD pipeline, if we want to run one for planet observations,
 we must first flag sources in the signal and gapfill them. An example configuration
 file should be equivalent to non-planet data processing after a few extra first
@@ -282,7 +282,7 @@ steps::
             modes: 3
 
 Example Obs Pipeline Configuration File
----------------------------------------
+:::::::::::::::::::::::::::::::::::::::
 
 Suppose we want to run an observation-level pipeline that creates a SSO footprint.
 A configuration file for the processing pipeline would look like::
@@ -319,181 +319,57 @@ A configuration file for the processing pipeline would look like::
             focal_plane: 'focal_plane_positions.npz'
 
 Process Step Glossary
----------------------
+:::::::::::::::::::::
 
 Quick reference for every registered ``process_pipe`` step name (the
-``name:`` string you put in a config file), grouped by what it's for. The
-"What it does" column is the first line of each class's docstring (see
-`Processing Modules`_ below for the full docstring, including config
-options, for any given step). This table is generated from
+``name:`` string you put in a config file), grouped by what it's for.
+The "What it does" column is the first line of each class's docstring
+-- see that class's full entry below (including ``calc``/``save``/
+``select``/``plot`` config options and an example config block) in the
+same subsection. This table is generated from
 ``sotodlib.preprocess.processes``; if you add a new registered process,
-add a row here too and a matching ``.. autoclass::`` entry under
-`Processing Modules`_ below —
-``tests/test_preprocess_docs.py`` will fail CI if the two fall out of
-sync.
-
-**General / utility**
-
-======================= ==================== =================================================================
-``name:``               Class                What it does
-======================= ==================== =================================================================
-``fft_trim``            ``FFTTrim``          Trim the AxisManager to optimize for faster FFTs later in the pipeline.
-``detrend``              ``Detrend``          Remove mean, median or linear trend from the data.
-``move``                 ``Move``             Rename or remove a data field (used to replace gamma angles with those from wiregrid for example).
-``trim_flag_edge``       ``TrimFlagEdge``     Trim edge until given flags of all detectors are False.
-======================= ==================== =================================================================
-
-**Detector Cuts and Flags**
-
-======================= ======================== =================================================================
-``name:``               Class                    What it does
-======================= ======================== =================================================================
-``det_bias_flags``      ``DetBiasFlags``         Derive poorly biased detectors from IV and Bias Step data.
-``trends``              ``Trends``               Check for large linear ramping in the data to look for unlocked detectors.
-``ptp_flags``           ``PTPFlags``             Find (and cut) detectors with anomalous peak-to-peak signal.
-``inv_var_flags``       ``InvVarFlags``          Find (and cut) detectors with too high inverse variance.
-``cut_bad_dist``        ``CutBadDistribution``   Detector cuts to keep a statistic (i.e white noise, peak-peak, fknee, etc.) within some bounds of a gaussian distribution.
-``detcal_nan_cuts``     ``DetcalNanCuts``        Remove detectors with NaN values in the specified det_cal metadata fields.
-``fp_flags``            ``FocalplaneNanFlags``   Cut detectors which have nans in their pointing information.
-``dark_dets``           ``DarkDets``             Cut dark detectors in the data.
-``acu_drop_flags``      ``AcuDropFlags``         Expands ACU drop (bad ACU/platform pointing data) flag fields in aman to all detectors.
-``smurfgaps_flags``     ``SmurfGapsFlags``       Expand smurfgaps (bad smurf data) flag of each stream_id to all detectors.
-``load_premade_flags``  ``LoadPremadeFlags``  Load premade flags from aman.
-``tod_stats``           ``GetStats``          Get basic statistics from a TOD or its power spectrum to use for flags and cuts.
-======================= ==================== =================================================================
-
-**Glitches & jumps**
-
-======================= ==================== =================================================================
-``name:``               Class                What it does
-======================= ==================== =================================================================
-``glitches``            ``GlitchDetection``  Run glitch detection algorithm to find glitches.
-``glitchfill``          ``GlitchFill``       Fill glitches.
-``jumps``               ``Jumps``            Run generic jump finding and fixing algorithm.
-``fix_jumps``           ``FixJumps``         Repairs the jump heights given a set of jump flags and heights.
-======================= ==================== =================================================================
-
-**Noise & PSD**
-
-======================= ==================== =================================================================
-``name:``               Class                What it does
-======================= ==================== =================================================================
-``psd``                 ``PSDCalc``          Calculate the PSD of the data and add it to the AxisManager.
-``noise_ratio``         ``NoiseRatio``       Compute ratios of "signal band" to white noise in PSDs (simple fit-independent way to check for excessive 1/f channels).
-``noise``               ``Noise``            Estimate the white noise levels in the data.
-======================= ==================== =================================================================
-
-**Calibration**
-
-======================= ======================== =================================================================
-``name:``               Class                    What it does
-======================= ======================== =================================================================
-``calibrate``           ``Calibrate``            Calibrate the timestreams based on some provided information (Abscal, relcal, bias step)--just a multiplication.
-``pca_relcal``          ``PCARelCal``            Estimate the relcal factor from the atmosphere using PCA.
-``correct_iir_params``  ``CorrectIIRParams``     Correct missing iir_params (readout downsampling filter) by default values.
-======================= ======================== =================================================================
-
-**HWP & demodulation**
-
-======================= ==================== =================================================================
-``name:``               Class                What it does
-======================= ==================== =================================================================
-``hwp_angle_model``     ``HWPAngleModel``    Apply hwp angle model (from metadata) to the TOD.
-``estimate_hwpss``      ``EstimateHWPSS``    Builds a HWPSS (HWP-synchronous-signal) template.
-``subtract_hwpss``      ``SubtractHWPSS``    Subtracts a HWPSS template from signal.
-``demodulate``          ``Demodulate``       Demodulate the TOD.
-``a2_stats``            ``A2Stats``          Calculate statistical metrics for A2, the 2f-demodulated Q and U signals.
-``get_tau_hwp``         ``GetTauHWP``        Analyze observation with hwp spinning up or spinning down to estimate time constant.
-======================= ==================== =================================================================
-
-**Ground pickup (AzSS)**
-
-============================ ============================ =================================================================
-``name:``                    Class                        What it does
-============================ ============================ =================================================================
-``azss``                     ``AzSS``                     Estimates Azimuth Synchronous Signal (AzSS) by binning signal by azimuth of boresight  and subtract.
-``subtract_azss_template``   ``SubtractAzSSTemplate``     Subtract Azimuth Synchronous Signal (AzSS) common template.
-============================ ============================ =================================================================
-
-**Filtering**
-
-======================= ==================== =================================================================
-``name:``               Class                What it does
-======================= ==================== =================================================================
-``fourier_filter``      ``FourierFilter``    Applies a chain of Fourier filters (defined in fft_ops) to the data.
-``sub_polyf``           ``SubPolyf``         Fit TOD in each subscan with polynomial of given order and subtract it.
-``apodize``             ``Apodize``          Apodize the edges of a signal.
-``scan_freq_cut``       ``ScanFreqCut``      Apply high-pass cut at the scan frequency.
-``pca_filter``          ``PCAFilter``        Applies a pca filter to the data.
-``get_common_mode``     ``GetCommonMode``    Calculate common mode (average over detectors not PCA filtered).
-======================= ==================== =================================================================
-
-**Pointing & focal-plane geometry**
-
-============================== ============================== =================================================================
-``name:``                      Class                          What it does
-============================== ============================== =================================================================
-``pointing_model``             ``PointingModel``               Apply pointing model to the TOD.
-``rotate_focal_plane``         ``RotateFocalPlane``            Interpret the boresight rotation effect as a focal plane rotation.
-``rotate_qu``                  ``RotateQU``                    Rotate Q and U components to/from telescope coordinates.
-``subtract_qu_common_mode``    ``SubtractQUCommonMode``        Subtract Q and U common mode.
-============================== ============================== =================================================================
-
-**Sources & planets**
-
-======================= ======================== =================================================================
-``name:``               Class                    What it does
-======================= ======================== =================================================================
-``source_flags``        ``SourceFlags``          Calculate the source flags in the data.
-``filter_for_sources``  ``FilterForSources``     Mask and gap-fill the signal at samples flagged by source_flags.
-``sso_footprint``       ``SSOFootprint``         Find nearby sources within a given distance and get SSO footprint and plot.
-======================= ======================== =================================================================
-
-**T-to-P (temperature-to-polarization) leakage**
-
-======================= ==================== =================================================================
-``name:``               Class                What it does
-======================= ==================== =================================================================
-``estimate_t2p``        ``EstimateT2P``      Estimate T to P leakage coefficients.
-``subtract_t2p``        ``SubtractT2P``      Subtract T to P leakage.
-======================= ==================== =================================================================
-
-**Scan / turnaround flags**
-
-======================= ======================== =================================================================
-``name:``               Class                    What it does
-======================= ======================== =================================================================
-``flag_turnarounds``    ``FlagTurnarounds``      From the Azimuth encoder data, flag turnarounds, left-going, and right-going.
-``noisy_subscan_flags`` ``BadSubscanFlags``      Identifies and flags bad subscans (statistics of the subscan non-gaussian, e.g., high kurtosis).
-======================= ======================== =================================================================
-
-**Flag combination (for mapmaking / splits)**
-
-======================= ==================== =================================================================
-``name:``               Class                What it does
-======================= ==================== =================================================================
-``union_flags``         ``UnionFlags``       Do the union of relevant flags for mapping.
-``combine_flags``       ``CombineFlags``     Do the combination of relevant flags for mapping.
-``split_flags``         ``SplitFlags``       Get flags used for map splitting/bundling.
-======================= ==================== =================================================================
-
-
-Processing Modules
-------------------
-
-Full reference (docstrings, including ``calc``/``save``/``select``/``plot``
-config options and example config blocks) for all registered process
-classes, grouped as in the glossary above.
+add a row to the relevant table below and a matching ``.. autoclass::``
+entry in the same subsection --
+``tests/test_preprocess_docs.py`` will fail CI if a class is registered
+but has no ``.. autoclass::`` entry anywhere on this page.
 
 General / Utility
-::::::::::::::::::
+-----------------
+
+================== ================ ==================================================================================================
+``name:``          Class            What it does
+================== ================ ==================================================================================================
+``fft_trim``       ``FFTTrim``      Trim the AxisManager to optimize for faster FFTs later in the pipeline.
+``detrend``        ``Detrend``      Remove mean, median or linear trend from the data.
+``move``           ``Move``         Rename or remove a data field (used to replace gamma angles with those from wiregrid for example).
+``trim_flag_edge`` ``TrimFlagEdge`` Trim edge until given flags of all detectors are False.
+================== ================ ==================================================================================================
+
 .. autoclass:: sotodlib.preprocess.processes.FFTTrim
 .. autoclass:: sotodlib.preprocess.processes.Detrend
 .. autoclass:: sotodlib.preprocess.processes.Move
 .. autoclass:: sotodlib.preprocess.processes.TrimFlagEdge
 
-Detector Quality Flags
-:::::::::::::::::::::::
+Detector Cuts and Flags
+-----------------------
+
+====================== ====================== ==========================================================================================================================
+``name:``              Class                  What it does
+====================== ====================== ==========================================================================================================================
+``det_bias_flags``     ``DetBiasFlags``       Derive poorly biased detectors from IV and Bias Step data.
+``trends``             ``Trends``             Check for large linear ramping in the data to look for unlocked detectors.
+``ptp_flags``          ``PTPFlags``           Find (and cut) detectors with anomalous peak-to-peak signal.
+``inv_var_flags``      ``InvVarFlags``        Find (and cut) detectors with too high inverse variance.
+``cut_bad_dist``       ``CutBadDistribution`` Detector cuts to keep a statistic (i.e white noise, peak-peak, fknee, etc.) within some bounds of a gaussian distribution.
+``detcal_nan_cuts``    ``DetcalNanCuts``      Remove detectors with NaN values in the specified det_cal metadata fields.
+``fp_flags``           ``FocalplaneNanFlags`` Cut detectors which have nans in their pointing information.
+``dark_dets``          ``DarkDets``           Cut dark detectors in the data.
+``acu_drop_flags``     ``AcuDropFlags``       Expands ACU drop (bad ACU/platform pointing data) flag fields in aman to all detectors.
+``smurfgaps_flags``    ``SmurfGapsFlags``     Expand smurfgaps (bad smurf data) flag of each stream_id to all detectors.
+``load_premade_flags`` ``LoadPremadeFlags``   Load premade flags from aman.
+``tod_stats``          ``GetStats``           Get basic statistics from a TOD or its power spectrum to use for flags and cuts.
+====================== ====================== ==========================================================================================================================
+
 .. autoclass:: sotodlib.preprocess.processes.DetBiasFlags
 .. autoclass:: sotodlib.preprocess.processes.Trends
 .. autoclass:: sotodlib.preprocess.processes.PTPFlags
@@ -504,33 +380,70 @@ Detector Quality Flags
 .. autoclass:: sotodlib.preprocess.processes.DarkDets
 .. autoclass:: sotodlib.preprocess.processes.AcuDropFlags
 .. autoclass:: sotodlib.preprocess.processes.SmurfGapsFlags
-
-Premade Flags & Stats
-:::::::::::::::::::::::
 .. autoclass:: sotodlib.preprocess.processes.LoadPremadeFlags
 .. autoclass:: sotodlib.preprocess.processes.GetStats
 
 Glitches & Jumps
-::::::::::::::::::
+----------------
+
+============== =================== ===============================================================
+``name:``      Class               What it does
+============== =================== ===============================================================
+``glitches``   ``GlitchDetection`` Run glitch detection algorithm to find glitches.
+``glitchfill`` ``GlitchFill``      Fill glitches.
+``jumps``      ``Jumps``           Run generic jump finding and fixing algorithm.
+``fix_jumps``  ``FixJumps``        Repairs the jump heights given a set of jump flags and heights.
+============== =================== ===============================================================
+
 .. autoclass:: sotodlib.preprocess.processes.GlitchDetection
 .. autoclass:: sotodlib.preprocess.processes.GlitchFill
 .. autoclass:: sotodlib.preprocess.processes.Jumps
 .. autoclass:: sotodlib.preprocess.processes.FixJumps
 
 Noise & PSD
-::::::::::::
+-----------
+
+=============== ============== ========================================================================================================================
+``name:``       Class          What it does
+=============== ============== ========================================================================================================================
+``psd``         ``PSDCalc``    Calculate the PSD of the data and add it to the AxisManager.
+``noise_ratio`` ``NoiseRatio`` Compute ratios of "signal band" to white noise in PSDs (simple fit-independent way to check for excessive 1/f channels).
+``noise``       ``Noise``      Estimate the white noise levels in the data.
+=============== ============== ========================================================================================================================
+
 .. autoclass:: sotodlib.preprocess.processes.PSDCalc
 .. autoclass:: sotodlib.preprocess.processes.NoiseRatio
 .. autoclass:: sotodlib.preprocess.processes.Noise
 
 Calibration
-:::::::::::
+-----------
+
+====================== ==================== ================================================================================================================
+``name:``              Class                What it does
+====================== ==================== ================================================================================================================
+``calibrate``          ``Calibrate``        Calibrate the timestreams based on some provided information (Abscal, relcal, bias step)--just a multiplication.
+``pca_relcal``         ``PCARelCal``        Estimate the relcal factor from the atmosphere using PCA.
+``correct_iir_params`` ``CorrectIIRParams`` Correct missing iir_params (readout downsampling filter) by default values.
+====================== ==================== ================================================================================================================
+
 .. autoclass:: sotodlib.preprocess.processes.Calibrate
 .. autoclass:: sotodlib.preprocess.processes.PCARelCal
 .. autoclass:: sotodlib.preprocess.processes.CorrectIIRParams
 
 HWP & Demodulation
-:::::::::::::::::::
+------------------
+
+=================== ================= ====================================================================================
+``name:``           Class             What it does
+=================== ================= ====================================================================================
+``hwp_angle_model`` ``HWPAngleModel`` Apply hwp angle model (from metadata) to the TOD.
+``estimate_hwpss``  ``EstimateHWPSS`` Builds a HWPSS (HWP-synchronous-signal) template.
+``subtract_hwpss``  ``SubtractHWPSS`` Subtracts a HWPSS template from signal.
+``demodulate``      ``Demodulate``    Demodulate the TOD.
+``a2_stats``        ``A2Stats``       Calculate statistical metrics for A2, the 2f-demodulated Q and U signals.
+``get_tau_hwp``     ``GetTauHWP``     Analyze observation with hwp spinning up or spinning down to estimate time constant.
+=================== ================= ====================================================================================
+
 .. autoclass:: sotodlib.preprocess.processes.HWPAngleModel
 .. autoclass:: sotodlib.preprocess.processes.EstimateHWPSS
 .. autoclass:: sotodlib.preprocess.processes.SubtractHWPSS
@@ -539,12 +452,32 @@ HWP & Demodulation
 .. autoclass:: sotodlib.preprocess.processes.GetTauHWP
 
 Ground Pickup (AzSS)
-::::::::::::::::::::::
+--------------------
+
+========================== ======================== ====================================================================================================
+``name:``                  Class                    What it does
+========================== ======================== ====================================================================================================
+``azss``                   ``AzSS``                 Estimates Azimuth Synchronous Signal (AzSS) by binning signal by azimuth of boresight  and subtract.
+``subtract_azss_template`` ``SubtractAzSSTemplate`` Subtract Azimuth Synchronous Signal (AzSS) common template.
+========================== ======================== ====================================================================================================
+
 .. autoclass:: sotodlib.preprocess.processes.AzSS
 .. autoclass:: sotodlib.preprocess.processes.SubtractAzSSTemplate
 
 Filtering
-:::::::::
+---------
+
+=================== ================= =======================================================================
+``name:``           Class             What it does
+=================== ================= =======================================================================
+``fourier_filter``  ``FourierFilter`` Applies a chain of Fourier filters (defined in fft_ops) to the data.
+``sub_polyf``       ``SubPolyf``      Fit TOD in each subscan with polynomial of given order and subtract it.
+``apodize``         ``Apodize``       Apodize the edges of a signal.
+``scan_freq_cut``   ``ScanFreqCut``   Apply high-pass cut at the scan frequency.
+``pca_filter``      ``PCAFilter``     Applies a pca filter to the data.
+``get_common_mode`` ``GetCommonMode`` Calculate common mode (average over detectors not PCA filtered).
+=================== ================= =======================================================================
+
 .. autoclass:: sotodlib.preprocess.processes.FourierFilter
 .. autoclass:: sotodlib.preprocess.processes.SubPolyf
 .. autoclass:: sotodlib.preprocess.processes.Apodize
@@ -553,30 +486,74 @@ Filtering
 .. autoclass:: sotodlib.preprocess.processes.GetCommonMode
 
 Pointing & Focal-Plane Geometry
-:::::::::::::::::::::::::::::::::
+-------------------------------
+
+=========================== ======================== ==================================================================
+``name:``                   Class                    What it does
+=========================== ======================== ==================================================================
+``pointing_model``          ``PointingModel``        Apply pointing model to the TOD.
+``rotate_focal_plane``      ``RotateFocalPlane``     Interpret the boresight rotation effect as a focal plane rotation.
+``rotate_qu``               ``RotateQU``             Rotate Q and U components to/from telescope coordinates.
+``subtract_qu_common_mode`` ``SubtractQUCommonMode`` Subtract Q and U common mode.
+=========================== ======================== ==================================================================
+
 .. autoclass:: sotodlib.preprocess.processes.PointingModel
 .. autoclass:: sotodlib.preprocess.processes.RotateFocalPlane
 .. autoclass:: sotodlib.preprocess.processes.RotateQU
 .. autoclass:: sotodlib.preprocess.processes.SubtractQUCommonMode
 
 Sources & Planets
-::::::::::::::::::
+-----------------
+
+====================== ==================== ===========================================================================
+``name:``              Class                What it does
+====================== ==================== ===========================================================================
+``source_flags``       ``SourceFlags``      Calculate the source flags in the data.
+``filter_for_sources`` ``FilterForSources`` Mask and gap-fill the signal at samples flagged by source_flags.
+``sso_footprint``      ``SSOFootprint``     Find nearby sources within a given distance and get SSO footprint and plot.
+====================== ==================== ===========================================================================
+
 .. autoclass:: sotodlib.preprocess.processes.SourceFlags
 .. autoclass:: sotodlib.preprocess.processes.FilterForSources
 .. autoclass:: sotodlib.preprocess.processes.SSOFootprint
 
 T-to-P Leakage
-:::::::::::::::
+--------------
+
+================ =============== =====================================
+``name:``        Class           What it does
+================ =============== =====================================
+``estimate_t2p`` ``EstimateT2P`` Estimate T to P leakage coefficients.
+``subtract_t2p`` ``SubtractT2P`` Subtract T to P leakage.
+================ =============== =====================================
+
 .. autoclass:: sotodlib.preprocess.processes.EstimateT2P
 .. autoclass:: sotodlib.preprocess.processes.SubtractT2P
 
 Scan / Turnaround Flags
-:::::::::::::::::::::::::
+-----------------------
+
+======================= =================== ================================================================================================
+``name:``               Class               What it does
+======================= =================== ================================================================================================
+``flag_turnarounds``    ``FlagTurnarounds`` From the Azimuth encoder data, flag turnarounds, left-going, and right-going.
+``noisy_subscan_flags`` ``BadSubscanFlags`` Identifies and flags bad subscans (statistics of the subscan non-gaussian, e.g., high kurtosis).
+======================= =================== ================================================================================================
+
 .. autoclass:: sotodlib.preprocess.processes.FlagTurnarounds
 .. autoclass:: sotodlib.preprocess.processes.BadSubscanFlags
 
 Flag Combination (Mapmaking / Splits)
-:::::::::::::::::::::::::::::::::::::::
+-------------------------------------
+
+================= ================ =================================================
+``name:``         Class            What it does
+================= ================ =================================================
+``union_flags``   ``UnionFlags``   Do the union of relevant flags for mapping.
+``combine_flags`` ``CombineFlags`` Do the combination of relevant flags for mapping.
+``split_flags``   ``SplitFlags``   Get flags used for map splitting/bundling.
+================= ================ =================================================
+
 .. autoclass:: sotodlib.preprocess.processes.UnionFlags
 .. autoclass:: sotodlib.preprocess.processes.CombineFlags
 .. autoclass:: sotodlib.preprocess.processes.SplitFlags

--- a/docs/preprocess.rst
+++ b/docs/preprocess.rst
@@ -56,7 +56,35 @@ repository, e.g. ``satp1/preprocess_config_init.yaml`` +
 ``lat/preprocess_config_cmb_mf.yaml`` / ``lat/preprocess_config_cmb_uhf.yaml``
 (single-layer).
 
-`[TOD Processing] Infrastructure Introduction <https://simonsobs.atlassian.net/wiki/spaces/DM/pages/305627401/TOD+Processing+Infrastructure+Introduction>`_ has a fuller walkthrough (jobdb usage, extensive interactive/Python examples for loading, running, and saving preprocessing archives) that complements this reference page.
+`[TOD Processing] Infrastructure Introduction <https://simonsobs.atlassian.net/wiki/spaces/DM/pages/305627401/TOD+Processing+Infrastructure+Introduction>`_ has a fuller walkthrough (jobdb usage, extensive interactive/Python examples for loading, running, and saving preprocessing archives) that complements this reference page -- including a deeper look at first-run-vs-rerun behavior than the summary below.
+
+Running for the first time vs. re-running against an existing archive
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+The ``archive`` config key names two things together: ``archive.index``, a
+ManifestDb sqlite file keyed on ``obs_id`` plus the ``subobs.use`` grouping
+fields (e.g. detset, or ``["wafer_slot", "wafer.bandpass"]``), and
+``archive.policy.filename``, the HDF5 file the actual ``proc_aman`` results
+are written into. Together these are "the archive" for a given config.
+
+- **First run**: ``archive.index`` doesn't exist yet, so
+  :func:`sotodlib.preprocess.preprocess_util.get_preprocess_db` creates a new,
+  empty ManifestDb there. Every obs_id/group the query returns is processed
+  from scratch -- each pipeline step's ``calc_and_save`` runs, and the results
+  are written into the archive as they complete.
+- **Re-running**: if ``archive.index`` already exists, ``preprocess_tod``
+  inspects it first and drops any obs_id/group already present in the archive
+  from the run list, so a second invocation over the same (or an overlapping)
+  observation list only processes what's new -- already-archived
+  observations are left alone rather than recomputed. Pass ``--overwrite`` to
+  force everything in the query to be reprocessed and the existing entries
+  replaced instead.
+- This is also what makes the archive reusable for **simulations**: when
+  :meth:`sotodlib.preprocess.pcore.Pipeline.run` is called with an existing
+  ``proc_aman`` (as loaded from the archive), every step's ``calc_and_save``
+  is skipped and only ``process()`` re-runs on top of the already-computed
+  products -- e.g. reapplying a filter fit on real data to a signal-only sim
+  without redoing the fit.
 
 Preprocessing job tracking (``jobdb``)
 ::::::::::::::::::::::::::::::::::::::

--- a/docs/site_pipeline.rst
+++ b/docs/site_pipeline.rst
@@ -410,8 +410,9 @@ multiple wafers at once.
 Otherwise, specify a wafer slot or restrict detectors in command line args to debug.
 
 Command Line arguments:
+
 .. argparse::
-   :module: sotodlib.site_pipeline.get_brightsrc_pointing_part1
+   :module: sotodlib.site_pipeline.get_brightsrc_pointing_step1
    :func: get_parser
 
 
@@ -588,17 +589,18 @@ Example NERSC slurm job submission config file
 ``````````````````````````````````````````````
 
 .. code-block:: yaml
+
   #!/bin/bash -l
 
   #SBATCH --qos=shared
   #SBATCH --constraint=cpu
   #SBATCH --nodes=1
   #SBATCH --ntasks=1
-  
+
   #SBATCH --cpus-per-task=14
   #SBATCH --time=00:30:00
-  #SBATCH --mem=220G`` #(may need regular queue & up to 400 Gb for long obs)
-  
+  #SBATCH --mem=220G #(may need regular queue & up to 400 Gb for long obs)
+
   export OMP_NUM_THREADS=1
   set -e
 
@@ -613,13 +615,13 @@ Example NERSC slurm job submission config file
 
   if (($map)); then
     echo submitted map job;
-    srun -n 1 -N 1 -c 14 python3 
+    srun -n 1 -N 1 -c 14 python3
        /path/to/sotodlib/site_pipeline/get_brightsrc_pointing_step1.py $yfile
        --obs_id=${2} --sso_name="moon";
   else
     echo submitted tod job;
-    srun -n 1 -N 1 -c 14 python3 
-        /path/to/sotodlib/site_pipeline/get_brightsrc_pointing_step2.py $yfile 
+    srun -n 1 -N 1 -c 14 python3
+        /path/to/sotodlib/site_pipeline/get_brightsrc_pointing_step2.py $yfile
         --obs_id=${2} --sso_name="moon";
   fi
 
@@ -640,7 +642,7 @@ get_brightsrc_pointing_part2
 See Part 1 for description
 
 .. argparse::
-   :module: sotodlib.site_pipeline.get_brightsrc_pointing_part2
+   :module: sotodlib.site_pipeline.get_brightsrc_pointing_step2
    :func: get_parser
 
 
@@ -729,7 +731,7 @@ To run, this script requires a config file described below. If run without the
 
 .. argparse::
    :module: sotodlib.site_pipeline.update_det_match
-   :func: make_parser
+   :func: get_parser
 
 Generated results
 ```````````````````
@@ -1763,31 +1765,10 @@ config
    :undoc-members:
 
 
-constants
-`````````
-
-.. automodule:: sotodlib.site_pipeline.utils.constants
-   :members:
-   :undoc-members:
-
 depth1_utils
 ````````````
 
 .. automodule:: sotodlib.site_pipeline.utils.depth1_utils
-   :members:
-   :undoc-members:
-
-exceptions
-``````````
-
-.. automodule:: sotodlib.site_pipeline.utils.exceptions
-   :members:
-   :undoc-members:
-
-io
-``
-
-.. automodule:: sotodlib.site_pipeline.utils.io
    :members:
    :undoc-members:
 

--- a/sotodlib/coords/det_match.py
+++ b/sotodlib/coords/det_match.py
@@ -624,7 +624,7 @@ class MatchParams:
             matching.
         freq_width (float):
             width of exponential to use in the frequency cost function (MHz).
-        dist_width (float)
+        dist_width (float):
             width of exponential to use in the pointing cost function (rad)
         unmatched_good_res_pen (float):
             penalty to apply to leaving a resonator with a good qi unassigned
@@ -633,6 +633,7 @@ class MatchParams:
         enforce_pointing_reqs (bool):
             If this is enabled, it will enforce the following requirements when
             matching:
+
              - Resonators with OPTC det_type must have pointing data.
              - Resonators with UNRT, SQID, or BARE det_types must _not_ have pointing data.
              - Resonators with DARK or SLOT det_types may or may not have pointing data.

--- a/sotodlib/coords/det_match_solutions.py
+++ b/sotodlib/coords/det_match_solutions.py
@@ -18,72 +18,72 @@ import sys
 @dataclass
 class SolutionsCfg:
     """
-    Args
-    ------
-    ctx_path: str
+    Parameters
+    ----------
+    ctx_path : str
         Path to context file to use to pull tod metadata.
-    pointing_results_dir: str
-        Results to directory that contains pointing results.  Files in
-        directory should look like:
-        ```
-        focal_plane_<obs_id>_<wafer_slot>.hdf
-        ```
-    results_dir: str
+    pointing_results_dir : str
+        Results to directory that contains pointing results. Files in
+        directory should look like::
+
+            focal_plane_<obs_id>_<wafer_slot>.hdf
+
+    results_dir : str
         Directory where results should be stored.
-    wafer_info_path: str
+    wafer_info_path : str
         Path to the wafer_info h5 file.
-    tel_type: str
+    tel_type : str
         Tel type for the optics model. Either "SAT" or "LAT"
-    base_obs_id: str
+    base_obs_id : str
         Obs_id to use as a base for matching when merging multiple pointing
         obs_ids for a wafer.  Will default to the pointing obs_id with the
         greatest number of detectors above the min_R2 threshold.
-    zemax_path: str
+    zemax_path : str
         If running for a "LAT" tel_type, the path to the zemax file must be specified.
-    apply_roll: bool
+    apply_roll : bool
         Whether or not to apply the obs_id roll angle.  Some pointing sets
         may already be corrected for roll angle.
-    pointing_field: str
+    pointing_field : str
         Name of sub axis manager in pointing tune axis maanger containng the
         pointing information.
-    site_pipeline_cfg_dir: str
+    site_pipeline_cfg_dir : str
         Path to site-pipeline-config dir. Defaults to the env var
         ``$SITE_PIPELINE_CONFIG_DIR``.
-    finite_xi_thresh: int
+    finite_xi_thresh : int
         Minimum number of dets a pointing result must have to add it to the
         analysis.
-    min_r2: float
+    min_r2 : float
         Minimum R-squared for det pointing to be considered.
-    sel_rad: float
+    sel_rad : float
         Selection radius for grid-based interpolation pointing offset subtraction.
-    unassigned_slots: int:
+    unassigned_slots : int
         Number of additional "unassigned" node to use per-side
-    wafer_map_path: str
+    wafer_map_path : str
         Path to the wafer map file. Defaults to ``<site-pipeline-config>/shared/detmatpping/wafer_map.yaml``.
-    match_pars: dict
+    match_pars : dict
         Dictionary of match parameters to use for pointing obs_id merging and
         each match iteration.  Should have the form::
 
-        match_pars:
-            pointing:
-                freq_width: 0.4
-                dist_width: 2.0
-            match0:
-                freq_width: 200
-                dist_width: 0.4
-            match1:
-                freq_width: 50
-                dist_width: 0.8
-            match2:
-                freq_width: 5
-                dist_width: 0.1
+            match_pars:
+                pointing:
+                    freq_width: 0.4
+                    dist_width: 2.0
+                match0:
+                    freq_width: 200
+                    dist_width: 0.4
+                match1:
+                    freq_width: 50
+                    dist_width: 0.8
+                match2:
+                    freq_width: 5
+                    dist_width: 0.1
 
-    Initial pointing offset: Tuple[float, float]
+    initial_pointing_offset : Tuple[float, float]
         Estimated pointing offset for the boresight. This should be
         (xi_offset, eta_offset) where both are in radians.
-    ufm_to_fp_path: str
+    ufm_to_fp_path : str
         Path to file that maps wafer_slot to position on focal plane.
-    freq_correct_by_muxband: bool
+    freq_correct_by_muxband : bool
         If true, apply the same freq offset correction to all resonators in a mux-band.
     """
 

--- a/sotodlib/core/axisman.py
+++ b/sotodlib/core/axisman.py
@@ -830,21 +830,21 @@ class AxisManager:
         data array that is found assigned to an axis
         matching the specified axis.
 
-        Args:
-            axis (str): The name of the axis in the aman to reindex.
-            indexes (int array): an array of ints with length
-                equal to the length of the new array
-                and values equal to the idxs of the
-                values in the data to be reindexed.
-                Indexes that should be left as nan in
-                the new array should be set to -1 or nan.
+        For example, with data = [1,3,5] and indexes = [0, -1, 2, 1],
+        the result is new_data = [1, nan, 5, 3].
 
-            For example:
-                data = [1,3,5], indexes = [0, -1, 2, 1]
-                would result in new_data = [1, nan, 5, 3]
-            
-            in_place (bool): If in_place == True, the intersection is
-            applied to self.  Otherwise, a new object is returned,
+        Args:
+
+          axis (str): The name of the axis in the aman to reindex.
+
+          indexes (int array): an array of ints with length equal to
+            the length of the new array and values equal to the idxs
+            of the values in the data to be reindexed. Indexes that
+            should be left as nan in the new array should be set to
+            -1 or nan.
+
+          in_place (bool): If in_place == True, the intersection is
+            applied to self. Otherwise, a new object is returned,
             with data copied out.
         """
         # Check if axis even exists first

--- a/sotodlib/core/metadata/obsdb.py
+++ b/sotodlib/core/metadata/obsdb.py
@@ -416,7 +416,7 @@ class ObsDb(object):
           results must satisfy all the criteria (i.e. the individual
           constraints are AND-ed). If your tag name contains special 
           characters (e.g. '-'), you will need to enclose it in 
-          backticks when using it in a query string, e.g.:
+          backticks when using it in a query string, e.g.::
  
             obsdb.query('`bad-tag`=1', tags=['bad-tag'])
 

--- a/sotodlib/io/load_smurf.py
+++ b/sotodlib/io/load_smurf.py
@@ -194,12 +194,12 @@ class G3tSmurf:
 
         Args
         -----
-            archive_path: path
+            archive_path: str
                 Path to the data directory
-            db_path: path, optional
+            db_path: str, optional
                 Path to the sqlite file. Defaults to
                 ``<archive_path>/frames.db``
-            meta_path: path, optional
+            meta_path: str, optional
                 Path of directory containing smurf related metadata (ie. channel
                 assignments). Required for full functionality.
             echo: bool, optional
@@ -375,7 +375,7 @@ class G3tSmurf:
 
         Args
         ----
-            path: path
+            path: str
                 Path of the file to index
             session : SQLAlchemy session
                 Current, active sqlalchemy session
@@ -672,7 +672,7 @@ class G3tSmurf:
             assignemnt
         cha : string
             The file name of the channel assignment
-        cha_path : path
+        cha_path : str
             The absolute path to the channel assignment
         session : SQLAlchemy Session
             The active session
@@ -749,7 +749,7 @@ class G3tSmurf:
 
         Args
         -------
-        tune_path : path
+        tune_path : str
             The absolute path to the tune file
         ctime : int
             ctime of SMuRF Action
@@ -809,7 +809,7 @@ class G3tSmurf:
             The stream id for the particular SMuRF slot
         ctime : int
             The ctime of the SMuRF action called to create the tuning file.
-        tune_path : path
+        tune_path : str
             The absolute path to the tune file
         session : SQLAlchemy Session
             The active session
@@ -2988,7 +2988,8 @@ def load_file(
       obsfiledb : a ObsFileDb instance (optional, used when loading from context)
       status : a SmurfStatus Instance if we don't want to use the one from the
           first file
-      det_axis : name of the axis used for channels / detectors
+      det_axis : str
+          Name of the axis used for channels / detectors
       linearize_timestamps : bool
           sent to _get_timestamps. if true and using unix timing, linearize the timing
           based on the frame counter

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -521,20 +521,20 @@ class NoiseRatio(_Preprocess):
 
     Example config block::
 
-    - name: "noise_ratio"
-      psd: "psdQ"
-      wrap: "noise_ratio_Q"
-      subscan: False
-      calc:
-        f_sel: [0.04, 0.14]
-        f_wn: [0.6, 1.0]
-      save: True
-      select:
-        r_max: 1.19
-        select_per_detector: True
+      - name: "noise_ratio"
+        psd: "psdQ"
+        wrap: "noise_ratio_Q"
+        subscan: False
+        calc:
+          f_sel: [0.04, 0.14]
+          f_wn: [0.6, 1.0]
+        save: True
+        select:
+          r_max: 1.19
+          select_per_detector: True
 
     .. autofunction:: sotodlib.tod_ops.fft_ops.noise_ratio
-"""
+    """
     name = "noise_ratio"
 
     def __init__(self, step_cfgs):
@@ -1344,7 +1344,7 @@ class AzSS(_Preprocess):
           subtract: True
 
     If we estimate and subtract azss in left going scans only,
-    make union of glitch_flags and scan_flags first
+    make union of glitch_flags and scan_flags first::
 
       - name : "union_flags"
         process:
@@ -2748,6 +2748,11 @@ class UnionFlags(_Preprocess):
     """Do the union of relevant flags for mapping
     Typically you would include turnarounds, glitches, etc.
 
+    .. deprecated::
+        Use the more general ``CombineFlags`` instead. ``UnionFlags`` is kept
+        only so archives built with older process configs can still be
+        loaded; ``process()`` raises a deprecation warning when run.
+
     Saves results for aman under the "flags.[total_flags_label]" field.
 
      Example config block::
@@ -2878,6 +2883,12 @@ class RotateFocalPlane(_Preprocess):
 class RotateQU(_Preprocess):
     """Rotate Q and U components to/from telescope coordinates.
 
+    ``sign: 1`` (the default) rotates each detector's demodQ/demodU out of
+    its own polarization-angle frame and into the shared telescope frame,
+    zeroing ``focal_plane.gamma`` when ``update_focal_plane: True``.
+    ``sign: -1`` undoes that, rotating back from the shared telescope frame
+    into each detector's own polarization-angle frame.
+
     Example config block::
 
         - name : "rotate_qu"
@@ -2945,8 +2956,7 @@ class SubtractQUCommonMode(_Preprocess):
     def save(self, proc_aman, coeff_aman):
         if not self.save_cfgs:
             return
-        if self.save_cfgs:
-            proc_aman.wrap(self.save_name, coeff_aman)
+        proc_aman.wrap(self.save_name, coeff_aman)
 
     def process(self, aman, proc_aman, sim=False, data_aman=None):
         if data_aman is not None:

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -29,6 +29,13 @@ class FFTTrim(_Preprocess):
     """Trim the AxisManager to optimize for faster FFTs later in the pipeline.
     All processing configs go to `fft_trim`
 
+    Example config block::
+
+      - name: "fft_trim"
+        process:
+          axis: "samps"
+          prefer: "right"
+
     .. autofunction:: sotodlib.tod_ops.fft_trim
     """
     name = "fft_trim"
@@ -48,6 +55,13 @@ class FFTTrim(_Preprocess):
 
 class Detrend(_Preprocess):
     """Detrend the signal. All processing configs go to `detrend_tod`
+
+    Example config block::
+
+      - name: "detrend"
+        signal: "signal" # optional
+        process:
+          method: "linear"
 
     .. autofunction:: sotodlib.tod_ops.detrend_tod
     """
@@ -69,7 +83,20 @@ class Detrend(_Preprocess):
 class DetBiasFlags(_FracFlaggedMixIn, _Preprocess):
     """
     Derive poorly biased detectors from IV and Bias Step data. Save results
-    in proc_aman under the "det_bias_cuts" field. 
+    in proc_aman under the "det_bias_flags" field.
+
+    Data selection cuts detectors flagged by any of the bias-range checks
+    (see ``get_det_bias_flags`` below for what each checks).
+
+    Example config block::
+
+      - name: "det_bias_flags"
+        calc:
+          rfrac_range: [0.2, 0.8]
+          # psat_range: [0.1, 10]  # optional, required if plot: True
+        save: True
+        select: True
+        plot: True
 
     .. autofunction:: sotodlib.tod_ops.flags.get_det_bias_flags
     """
@@ -1493,7 +1520,19 @@ class FlagTurnarounds(_Preprocess):
         All process configs go to ``get_turnaround_flags``. If the ``method`` key
         is not included in the preprocess config file calc configs then it will
         default to 'scanspeed'.
-    
+
+    Saves results in proc_aman under the "turnaround_flags" field, with
+    sub-fields ``turnarounds``, ``left_scan``, and ``right_scan``.
+
+    Example config block::
+
+      - name: "flag_turnarounds"
+        process:
+          method: "scanspeed"
+        calc:
+          method: "scanspeed"
+        save: True
+
     .. autofunction:: sotodlib.tod_ops.flags.get_turnaround_flags
     """
     name = 'flag_turnarounds'
@@ -1536,7 +1575,15 @@ class FlagTurnarounds(_Preprocess):
 class SubPolyf(_Preprocess):
     """Fit TOD in each subscan with polynominal of given order and subtract it.
         All process configs go to `sotodlib.tod_ops.sub_polyf`.
-    
+
+    Example config block::
+
+      - name: "sub_polyf"
+        process:
+          degree: 0
+          method: "polyfit"
+          in_place: True
+
     .. autofunction:: sotodlib.tod_ops.subscan_polyfilter
     """
     name = 'sub_polyf'
@@ -2676,7 +2723,7 @@ class SplitFlags(_Preprocess):
             central_pixels: 0.071
           save: True
 
-    .. autofunction:: sotodlib.obs_ops.flags.get_split_flags
+    .. autofunction:: sotodlib.obs_ops.splits.get_split_flags
     """
     name = "split_flags"
 
@@ -2858,6 +2905,15 @@ class RotateQU(_Preprocess):
 class SubtractQUCommonMode(_Preprocess):
     """Subtract Q and U common mode.
 
+    If ``calc`` is set, computes the median Q/U template and each detector's
+    coupling coefficient to it (via
+    :func:`sotodlib.tod_ops.deproject.get_qu_common_mode_coeffs`) and saves
+    them under the ``qu_common_mode_coeffs`` field of ``proc_aman``.
+    ``process`` then subtracts that scaled template from each detector's Q/U
+    signal. If ``calc`` was not run (or its result wasn't saved), ``process``
+    falls back to computing the template/coefficients on the fly from the
+    current ``aman`` instead of using a saved ``proc_aman`` archive.
+
     Example config block::
 
         - name : 'subtract_qu_common_mode'
@@ -2867,28 +2923,30 @@ class SubtractQUCommonMode(_Preprocess):
           calc: True
           save: True
 
+    .. autofunction:: sotodlib.tod_ops.deproject.get_qu_common_mode_coeffs
     .. autofunction:: sotodlib.tod_ops.deproject.subtract_qu_common_mode
     """
     name = "subtract_qu_common_mode"
 
     def __init__(self, step_cfgs):
-        self.signal_name_Q = step_cfgs.get('signal_Q', 'demodQ')
-        self.signal_name_U = step_cfgs.get('signal_U', 'demodU')
+        self.signal_name_Q = step_cfgs.get('signal_name_Q', 'demodQ')
+        self.signal_name_U = step_cfgs.get('signal_name_U', 'demodU')
         self.save_name = "qu_common_mode_coeffs"
 
         super().__init__(step_cfgs)
 
     def calc_and_save(self, aman, proc_aman):
-        coeff_aman = get_qu_common_mode_coeffs(aman, Q_signal, U_signal, merge)
-        self.save(proc_aman, aman)
+        coeff_aman = tod_ops.deproject.get_qu_common_mode_coeffs(
+            aman, self.signal_name_Q, self.signal_name_U, merge=False)
+        self.save(proc_aman, coeff_aman)
 
         return aman, proc_aman
 
-    def save(self, proc_aman, aman):
+    def save(self, proc_aman, coeff_aman):
         if not self.save_cfgs:
             return
         if self.save_cfgs:
-            proc_aman.wrap(self.save_name, aman['qu_common_mode_coeffs'])
+            proc_aman.wrap(self.save_name, coeff_aman)
 
     def process(self, aman, proc_aman, sim=False, data_aman=None):
         if data_aman is not None:
@@ -3016,17 +3074,57 @@ class PointingModel(_Preprocess):
 class BadSubscanFlags(_Preprocess):
     """Identifies and flags bad subscans.
 
-      Example config block::
+    Saves results in proc_aman under the "noisy_subscan_flags" (valid
+    subscans, dets x samps) and "noisy_dets_flags" (valid detectors, dets)
+    fields. ``calc.subscan_stats`` must list signal names whose *last
+    character* (``T``/``Q``/``U``) selects a prior ``tod_stats`` result:
+    for each entry ``sig`` this looks up
+    ``proc_aman[stats_name + "_" + sig[-1]]``, so e.g. ``"demodQ"`` selects
+    ``proc_aman.tod_stats_Q``. This requires ``tod_stats`` (``GetStats``,
+    see above) to have already been run once per signal with a matching
+    ``wrap`` name (``tod_stats_T``/``tod_stats_Q``/``tod_stats_U`` for the
+    default ``stats_name: tod_stats``).
+
+    Example config block::
+
+        - name : "tod_stats"
+          signal: "dsT"
+          wrap: "tod_stats_T"
+          calc:
+            stat_names: ["std", "ptp"]
+            split_subscans: True
+          save: True
+
+        - name : "tod_stats"
+          signal: "demodQ"
+          wrap: "tod_stats_Q"
+          calc:
+            stat_names: ["median", "std", "skew", "kurtosis", "ptp"]
+            split_subscans: True
+          save: True
+
+        - name : "tod_stats"
+          signal: "demodU"
+          wrap: "tod_stats_U"
+          calc:
+            stat_names: ["median", "std", "skew", "kurtosis", "ptp"]
+            split_subscans: True
+          save: True
 
         - name : "noisy_subscan_flags"
-            stats_name: tod_stats # optional
-            calc: 
-                nstd_lim: 5.0 
-                merge: False
-            save: True
-            select: True
-    
-    .. autofunction:: sotodlib.tod_ops.flags.get_badsubscan_flags
+          stats_name: tod_stats # optional
+          calc:
+            subscan_stats: ["demodQ", "demodU", "dsT"]
+            nstd_lim: 3.0
+            ptp_lim: 0.8
+            kurt_lim: 0.5
+            skew_lim: 0.5
+            noisy_detector_lim: 0.5
+            merge: False
+          save: True
+          select: True
+
+    .. autofunction:: sotodlib.tod_ops.flags.get_noisy_subscan_flags
     """
     name = "noisy_subscan_flags"
 

--- a/sotodlib/preprocess/processes.py
+++ b/sotodlib/preprocess/processes.py
@@ -1171,6 +1171,7 @@ class A2Stats(_Preprocess):
     Calculate statistical metrics for A2, the 2f-demodulated Q and U signals.
 
     Takes the following ``calc`` config options:
+
     :stat_names: (*list*) List of strings identifying which statistics to calculate.
         Refer to ``sotodlib.tod_ops.flags.get_stats`` (below) for available stats.
         Default is ``["mean", "median", "var", "ptp"]``.

--- a/sotodlib/toast/ops/load_context.py
+++ b/sotodlib/toast/ops/load_context.py
@@ -68,6 +68,8 @@ class LoadContext(Operator):
     key.  For example, the shared smurfgap flags are named after the UFM (array
     name).  So you can import the correct field name for all observations with:
 
+    .. code-block:: python
+
         ax_flags=[
             (
                 "smurfgaps_ufm_{det_info:wafer:array}",

--- a/sotodlib/tod_ops/apodize.py
+++ b/sotodlib/tod_ops/apodize.py
@@ -9,6 +9,7 @@ def get_apodize_window_for_ends(aman, apodize_samps=1600, apo_type='C1'):
         aman: An axismanager
         apodize_samps (int): Number of samples to apply the cosine taper to at each end.
         apo_type (str): Type of apodization window applied to the edges. Options are:
+
             - ``'C1'``: Standard cosine (Hann) taper, i.e. a half-cosine that
               goes smoothly from 1 to 0 as ``0.5 * (1 + cos(x))`` over the
               apodization region. This is the default.
@@ -40,6 +41,7 @@ def get_apodize_window_from_flags(aman, flags, apodize_samps=200, apo_type='C1')
             a string, 'aman.flags[flags]' is used for the flags.
         apodize_samps (int): Number of samples to apply the cosine taper.
         apo_type (str): Type of apodization window applied to the edges. Options are:
+
             - ``'C1'``: Standard cosine (Hann) taper, i.e. a half-cosine that
               goes smoothly from 1 to 0 as ``0.5 * (1 + cos(x))`` over the
               apodization region. This is the default.
@@ -126,6 +128,7 @@ def apodize_cosine(aman, signal_name='signal', apodize_samps=1600, in_place=True
         window (numpy.ndarray): Precomputed apodization window.
         flags (str or RangesMatrix or Ranges): flag value to compute apodization window.
         apo_type (str): Type of apodization window applied to the edges. Options are:
+
             - ``'C1'``: Standard cosine (Hann) taper, i.e. a half-cosine that
               goes smoothly from 1 to 0 as ``0.5 * (1 + cos(x))`` over the
               apodization region. This is the default.

--- a/sotodlib/tod_ops/fft_ops.py
+++ b/sotodlib/tod_ops/fft_ops.py
@@ -991,7 +991,7 @@ def fit_noise_model(
                             lambda params: neglnlike(params, f, p, bin_size=bin_size, **_fixed),
                             full_output=True,
                         )
-                        hessian_ndt, _ = Hfun(res["x"])
+                        hessian_ndt = Hfun(res["x"])[0]
                         covout_i = np.linalg.inv(hessian_ndt)
                     except np.linalg.LinAlgError:
                         errout[i] = 'LinalgError'

--- a/sotodlib/tod_ops/flags.py
+++ b/sotodlib/tod_ops/flags.py
@@ -1189,7 +1189,10 @@ def get_noisy_subscan_flags(aman, subscan_stats, nstd_lim=None,
                          name="noisy_subscan"):
     """
     Identify and flag bad subscans based on various statistical thresholds.
-    aman : AxisManager 
+
+    Parameters
+    ----------
+    aman : AxisManager
         The tod.
     subscan_stats : dict
         Dictionary containing statistical metrics for subscans. Keys should 

--- a/sotodlib/tod_ops/flags.py
+++ b/sotodlib/tod_ops/flags.py
@@ -1144,7 +1144,8 @@ def noise_fit_flags(aman, low_wn, high_wn, high_fk):
     """
     Evaluate white noise and fknee cuts based on provided boundaries.
 
-    Parameters:
+    Parameters
+    ----------
     aman : object
         An object containing noise fit statistics and noise model coefficients.
     low_wn : float or None
@@ -1154,7 +1155,8 @@ def noise_fit_flags(aman, low_wn, high_wn, high_fk):
     high_fk : float or None
         The upper boundary for fknee. If None, fknee flagging is skipped.
 
-    Returns:
+    Returns
+    -------
     tuple or None
         A tuple containing flags for valid white noise and fknee if both boundaries are provided.
         If only one boundary is provided, returns the corresponding flag.

--- a/tests/test_preprocess_docs.py
+++ b/tests/test_preprocess_docs.py
@@ -8,10 +8,15 @@ This guards against the failure mode where a new process is added to
 sotodlib.preprocess.processes and registered on the pipeline, but never
 added to the "Processing Modules" section of docs/preprocess.rst -- so
 it's usable from a config file but invisible to anyone reading
-https://sotodlib.readthedocs.io/en/latest/preprocess.html. An audit found
-32 of 54 registered classes missing from the docs this way before this
-test was added; see the "preproc_docs" repo's GAP_ANALYSIS.md for the
-full write-up.
+https://sotodlib.readthedocs.io/en/latest/preprocess.html.
+
+This only checks for missing/stale coverage of the registry against the
+docs page -- it does not check that any of the RST itself is
+well-formed. That's what the Sphinx build is for: it will fail on a broken
+``.. autoclass::``/``.. autofunction::`` target or malformed docstring,
+which is a class of bug this test can't see (e.g. it can't tell that a
+docstring's own RST is broken -- only that some string referencing the
+class exists somewhere on the page).
 """
 
 import re
@@ -30,10 +35,17 @@ AUTOCLASS_RE = re.compile(
     re.MULTILINE,
 )
 
+# Matches a double-backtick'd identifier, e.g. the ``FFTTrim`` cell of a
+# "Process Step Glossary" table row.
+DOUBLE_BACKTICK_RE = re.compile(r"``(\w+)``")
+
 
 class TestPreprocessDocsCoverage(unittest.TestCase):
-    """Cross-check the live Pipeline.PIPELINE registry against the
-    ``.. autoclass::`` entries in docs/preprocess.rst.
+    """Cross-check the live Pipeline.PIPELINE registry against
+    docs/preprocess.rst: every registered class needs both a
+    ``.. autoclass::`` entry (its full reference section) and a row in
+    one of the "Process Step Glossary" summary tables (its one-line
+    quick-reference entry).
     """
 
     def setUp(self):
@@ -51,26 +63,36 @@ class TestPreprocessDocsCoverage(unittest.TestCase):
         self.registered = {
             cls.__name__ for cls in Pipeline.PIPELINE.values()
         }
-        self.documented = set(AUTOCLASS_RE.findall(PREPROCESS_RST.read_text()))
+        rst_text = PREPROCESS_RST.read_text()
+        self.documented = set(AUTOCLASS_RE.findall(rst_text))
+        # Table rows aren't parsed structurally -- just check that each
+        # class name appears somewhere as a double-backtick'd identifier
+        # outside of its own ".. autoclass::" line, which is what a
+        # "Class" column entry in a glossary table looks like.
+        non_autoclass_text = "\n".join(
+            line for line in rst_text.splitlines()
+            if not line.lstrip().startswith(".. autoclass::")
+        )
+        self.in_tables = set(DOUBLE_BACKTICK_RE.findall(non_autoclass_text))
 
-    def test_100_all_registered_processes_are_documented(self):
+    def test_100_all_registered_processes_have_an_autoclass_entry(self):
         missing = sorted(self.registered - self.documented)
         self.assertEqual(
             missing, [],
             "The following process classes are registered on "
             "Pipeline.PIPELINE (sotodlib/preprocess/processes.py) but "
             "have no '.. autoclass::' entry in docs/preprocess.rst. Add "
-            "one under the 'Processing Modules' section (and a row in "
-            f"the 'Process Step Glossary' table) for: {missing}"
+            f"one under the 'Processing Modules' section for: {missing}"
         )
 
-    def test_101_no_stale_autoclass_entries(self):
-        stale = sorted(self.documented - self.registered)
+    def test_101_all_registered_processes_have_a_glossary_row(self):
+        missing = sorted(self.registered - self.in_tables)
         self.assertEqual(
-            stale, [],
-            "The following classes are referenced via '.. autoclass::' "
-            "in docs/preprocess.rst but are no longer registered on "
-            f"Pipeline.PIPELINE (renamed or removed?): {stale}"
+            missing, [],
+            "The following process classes have no row in a 'Process "
+            "Step Glossary' summary table in docs/preprocess.rst (no "
+            "``ClassName`` appears outside an '.. autoclass::' line). "
+            f"Add a table row for: {missing}"
         )
 
 

--- a/tests/test_preprocess_docs.py
+++ b/tests/test_preprocess_docs.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2026 Simons Observatory.
+# Full license can be found in the top level "LICENSE" file.
+
+"""Check that every process class registered with the preprocessing
+Pipeline has documentation coverage in docs/preprocess.rst.
+
+This guards against the failure mode where a new process is added to
+sotodlib.preprocess.processes and registered on the pipeline, but never
+added to the "Processing Modules" section of docs/preprocess.rst -- so
+it's usable from a config file but invisible to anyone reading
+https://sotodlib.readthedocs.io/en/latest/preprocess.html. An audit found
+32 of 54 registered classes missing from the docs this way before this
+test was added; see the "preproc_docs" repo's GAP_ANALYSIS.md for the
+full write-up.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+from sotodlib.preprocess import Pipeline
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PREPROCESS_RST = REPO_ROOT / "docs" / "preprocess.rst"
+
+# Matches lines like:
+#   .. autoclass:: sotodlib.preprocess.processes.GlitchDetection
+AUTOCLASS_RE = re.compile(
+    r"^\.\.\s+autoclass::\s+sotodlib\.preprocess\.processes\.(\w+)\s*$",
+    re.MULTILINE,
+)
+
+
+class TestPreprocessDocsCoverage(unittest.TestCase):
+    """Cross-check the live Pipeline.PIPELINE registry against the
+    ``.. autoclass::`` entries in docs/preprocess.rst.
+    """
+
+    def setUp(self):
+        if not PREPROCESS_RST.exists():
+            # docs/ isn't guaranteed to ship alongside every install of
+            # the sotodlib package (e.g. a pip install from an sdist
+            # without docs/), so skip rather than fail in that case --
+            # this check only makes sense when run from a full checkout,
+            # which is how it's run in CI.
+            self.skipTest(
+                f"{PREPROCESS_RST} not found -- skipping doc-coverage "
+                "check (this test needs a full repo checkout, not just "
+                "an installed sotodlib package)."
+            )
+        self.registered = {
+            cls.__name__ for cls in Pipeline.PIPELINE.values()
+        }
+        self.documented = set(AUTOCLASS_RE.findall(PREPROCESS_RST.read_text()))
+
+    def test_100_all_registered_processes_are_documented(self):
+        missing = sorted(self.registered - self.documented)
+        self.assertEqual(
+            missing, [],
+            "The following process classes are registered on "
+            "Pipeline.PIPELINE (sotodlib/preprocess/processes.py) but "
+            "have no '.. autoclass::' entry in docs/preprocess.rst. Add "
+            "one under the 'Processing Modules' section (and a row in "
+            f"the 'Process Step Glossary' table) for: {missing}"
+        )
+
+    def test_101_no_stale_autoclass_entries(self):
+        stale = sorted(self.documented - self.registered)
+        self.assertEqual(
+            stale, [],
+            "The following classes are referenced via '.. autoclass::' "
+            "in docs/preprocess.rst but are no longer registered on "
+            f"Pipeline.PIPELINE (renamed or removed?): {stale}"
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_preprocess_docs.py
+++ b/tests/test_preprocess_docs.py
@@ -12,11 +12,12 @@ https://sotodlib.readthedocs.io/en/latest/preprocess.html.
 
 This only checks for missing/stale coverage of the registry against the
 docs page -- it does not check that any of the RST itself is
-well-formed. That's what the Sphinx build is for: it will fail on a broken
-``.. autoclass::``/``.. autofunction::`` target or malformed docstring,
-which is a class of bug this test can't see (e.g. it can't tell that a
-docstring's own RST is broken -- only that some string referencing the
-class exists somewhere on the page).
+well-formed (e.g. it can't tell that a docstring's own RST is broken --
+only that some string referencing the class exists somewhere on the
+page). That's what the actual Sphinx build is for: .readthedocs.yaml
+sets sphinx.fail_on_warning: true, so the "docs/readthedocs.org:
+sotodlib" PR check fails on any RST/autodoc warning, repo-wide -- not
+just in docs/preprocess.rst.
 """
 
 import re


### PR DESCRIPTION
This is part of a larger effort to make sure that all of the preprocessing configs are referenced and the lower level processes are documented. This adds tests to make sure that the page describing each process is kept up to date (as new processes are added they must include a reference in the docs), adds examples for processes which were missing them, describes init/proc, jobdb, and links to wiki references. It also adds a table which describes each process option.