### PR TITLE
feat: ignore vector groups when determining output structure

### DIFF
--- a/sotodlib/preprocess/preprocess_util.py
+++ b/sotodlib/preprocess/preprocess_util.py
@@ -1001,7 +1001,8 @@ def find_db(obs_id, configs, dets, context=None, logger=None):
     if context is None:
         context = core.Context(configs["context_file"])
     group_by = np.atleast_1d(configs['subobs'].get('use', 'detset'))
-    cur_groups = [list(np.fromiter(dets.values(), dtype='<U32'))]
+    # cur_groups = [list(np.fromiter(dets.values(), dtype='<U32'))]
+    cur_groups = [str(val) for val in dets.values() if np.isscalar(val)]
     dbexist = True
     if os.path.exists(configs['archive']['index']):
         db = core.metadata.ManifestDb(configs['archive']['index'])
@@ -1097,7 +1098,8 @@ def get_preproc_group_out_dict(obs_id, configs, dets, context=None, subdir='temp
     if context is None:
         context = core.Context(configs["context_file"])
 
-    cur_groups = [list(np.fromiter(dets.values(), dtype='<U32'))]
+    # cur_groups = [list(np.fromiter(dets.values(), dtype='<U32'))]
+    cur_groups = [str(val) for val in dets.values() if np.isscalar(val)]
     group_by = np.atleast_1d(configs['subobs'].get('use', 'detset'))
     newpath = f'{subdir}/{obs_id}'
     for cg in cur_groups[0]:
@@ -1333,7 +1335,8 @@ def preproc_or_load_group(obs_id, configs_init, dets, configs_proc=None,
     if logger is None:
         logger = init_logger("preprocess")
 
-    group = [list(np.fromiter(dets.values(), dtype='<U32'))][0]
+    # group = [list(np.fromiter(dets.values(), dtype='<U32'))][0]
+    group = [str(val) for val in dets.values() if np.isscalar(val)]
 
     # Do a try except around config and meta reading to catch metadata failures
     try:


### PR DESCRIPTION
Mainly so I can include `dets['readout_id'] = [id0, id1, ...]` without things crashing when I want to debug stuff. 